### PR TITLE
READMEのインストール方法のGitリポジトリ名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ TypeScriptとReactで作成された、ブラウザで遊べる絵合わせパ�
 
 ```bash
 # リポジトリをクローン
-git clone https://github.com/yourusername/puzzle-game.git
-cd puzzle-game
+git clone https://github.com/tomohiroJin/cline-playground-for-frontend.git
+cd cline-playground-for-frontend
 
 # 依存パッケージをインストール
 npm install


### PR DESCRIPTION
# 修正内容

READMEのインストール方法セクションにあるGitリポジトリ名が誤っていたため修正しました。

## 変更点

- `https://github.com/yourusername/puzzle-game.git` → `https://github.com/tomohiroJin/cline-playground-for-frontend.git`
- `cd puzzle-game` → `cd cline-playground-for-frontend`

## 関連タスク

READMEの誤りを修正するタスク