### PR TITLE
パズル完成時に設定画面に戻る導線を追加

### DIFF
--- a/src/components/HomePageSections.tsx
+++ b/src/components/HomePageSections.tsx
@@ -213,27 +213,20 @@ export const GameSectionComponent: React.FC<GameSectionProps> = ({
           onEmptyPanelClick={handleEmptyPanelClick}
           onEndGame={handleEndGame}
         />
-        {completed ? (
-          <>
-            <div>パズルが完成しました！</div>
-            <StartButton onClick={handleEndGame} style={{ marginTop: '10px' }}>
-              設定に戻る
+        <>
+          {completed && <div>パズルが完成しました！</div>}
+          <StartButton onClick={handleEndGame} style={{ marginTop: completed ? '10px' : '0' }}>
+            {completed ? '設定に戻る' : 'ゲームを終了して設定に戻る'}
+          </StartButton>
+          {!completed && emptyPanelClicks >= 10 && (
+            <StartButton
+              onClick={() => completePuzzle(pieces, setPieces, setCompleted)}
+              style={{ marginTop: '10px', backgroundColor: '#ff9800' }}
+            >
+              テスト：パズルを完成させる
             </StartButton>
-          </>
-        ) : (
-          <>
-            <StartButton onClick={handleEndGame}>ゲームを終了して設定に戻る</StartButton>
-            {completed}
-            {emptyPanelClicks >= 10 && (
-              <StartButton
-                onClick={() => completePuzzle(pieces, setPieces, setCompleted)}
-                style={{ marginTop: '10px', backgroundColor: '#ff9800' }}
-              >
-                テスト：パズルを完成させる
-              </StartButton>
-            )}
-          </>
-        )}
+          )}
+        </>
       </>
     )}
   </GameSection>

--- a/src/components/HomePageSections.tsx
+++ b/src/components/HomePageSections.tsx
@@ -211,9 +211,15 @@ export const GameSectionComponent: React.FC<GameSectionProps> = ({
           onReset={handleResetGame}
           onToggleHint={toggleHintMode}
           onEmptyPanelClick={handleEmptyPanelClick}
+          onEndGame={handleEndGame}
         />
         {completed ? (
-          <div>パズルが完成しました！</div>
+          <>
+            <div>パズルが完成しました！</div>
+            <StartButton onClick={handleEndGame} style={{ marginTop: '10px' }}>
+              設定に戻る
+            </StartButton>
+          </>
         ) : (
           <>
             <StartButton onClick={handleEndGame}>ゲームを終了して設定に戻る</StartButton>

--- a/src/components/organisms/PuzzleBoard.tsx
+++ b/src/components/organisms/PuzzleBoard.tsx
@@ -40,6 +40,7 @@ import { useVideoPlayback } from '../../hooks/useVideoPlayback';
  * @param onReset - ゲームをリセットする関数
  * @param onToggleHint - ヒントモードを切り替える関数
  * @param onEmptyPanelClick - 空のパネルをクリックしたときの処理
+ * @param onEndGame - ゲームを終了して設定に戻る関数
  */
 export type PuzzleBoardProps = {
   imageUrl: string;
@@ -55,6 +56,7 @@ export type PuzzleBoardProps = {
   onReset: () => void;
   onToggleHint: () => void;
   onEmptyPanelClick?: () => void; // 空白パネルがクリックされたときのコールバック
+  onEndGame?: () => void; // ゲームを終了して設定に戻る関数
 };
 
 /**
@@ -74,6 +76,7 @@ const PuzzleBoard: React.FC<PuzzleBoardProps> = ({
   onReset,
   onToggleHint,
   onEmptyPanelClick,
+  onEndGame,
 }) => {
   // 完成オーバーレイの表示/非表示を管理
   const { overlayVisible, toggleOverlay } = useCompletionOverlay();
@@ -143,6 +146,14 @@ const PuzzleBoard: React.FC<PuzzleBoardProps> = ({
             <CompletionMessage>パズル完成！</CompletionMessage>
             <CompletionTime>所要時間: {formatElapsedTime(elapsedTime)}</CompletionTime>
             <RestartButton onClick={onReset}>もう一度挑戦</RestartButton>
+            {onEndGame && (
+              <RestartButton
+                onClick={onEndGame}
+                style={{ marginTop: '10px', backgroundColor: '#2196F3' }}
+              >
+                設定に戻る
+              </RestartButton>
+            )}
           </CompletionOverlay>
         )}
 


### PR DESCRIPTION
## 変更内容

パズル完成時にゲームを終了して設定に戻る導線が無かったため、以下の変更を行いました：

1. `HomePageSections.tsx`：パズル完成時に「設定に戻る」ボタンを表示するように修正
2. `PuzzleBoard.tsx`：完成オーバーレイに「設定に戻る」ボタンを追加

## 動作確認方法

1. パズルゲームを開始する
2. パズルを完成させる（またはテスト用の「パズルを完成させる」ボタンを使用）
3. 以下の2箇所から設定画面に戻れることを確認：
   - 完成オーバーレイ内の「設定に戻る」ボタン
   - パズルボードの下に表示される「設定に戻る」ボタン