### PR TITLE
feat: IPNEにレベルアップポイント制を導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 - Falldown Shooter（落下型シューティング）
 - Labyrinth of Shadows（迷宮ホラー）
 - Deep Sea Interceptor（縦スクロールシューティング）
+- Non-Brake Descent（ハイスピード下り坂アクション）
+- IPNE（シンプルな迷路脱出ゲーム）
+- Agile Quiz Sugoroku（アジャイル・スクラム学習クイズ）
 
 ## 主な機能
 
@@ -24,11 +27,13 @@
 ## 技術スタック
 
 - **言語**: TypeScript
-- **フレームワーク**: React
-- **スタイリング**: styled-components
-- **状態管理**: Jotai
-- **ルーティング**: React Router
-- **テスト**: Jest
+- **フレームワーク**: React 19.0.0
+- **ルーティング**: React Router 7.3.0
+- **スタイリング**: styled-components 6.1.16
+- **状態管理**: Jotai 2.12.2
+- **オーディオ**: Tone.js 15.1.22
+- **ビルドツール**: Webpack 5.98.0
+- **テスト**: Jest 30.2.0
 
 ## セットアップ
 
@@ -36,7 +41,7 @@
 # 依存パッケージをインストール
 npm install
 
-# 開発サーバーを起動
+# 開発サーバーを起動（http://localhost:3000）
 npm start
 
 # 本番ビルド
@@ -65,9 +70,12 @@ src/
   │   ├── atoms/
   │   ├── molecules/
   │   └── organisms/
+  ├── features/                  # ゲームごとのロジック実装
+  ├── hooks/                     # カスタムフック
   ├── pages/                     # 各ゲームページ
-  ├── styles/                    # GlobalStyle など共通スタイル
   ├── store/                     # Jotai アトム
+  ├── styles/                    # GlobalStyle など共通スタイル
+  ├── types/                     # TypeScript 型定義
   ├── utils/                     # ストレージ・共有などのユーティリティ
   ├── App.tsx                    # ルート
   └── index.tsx                  # エントリーポイント
@@ -77,8 +85,8 @@ src/
 
 ### スタイル注入（styled-components）に関する注意
 
-本番ビルドでは `styled-components` が CSSOM（`insertRule`）でスタイルを注入します。  
-このとき `createGlobalStyle` 内に `@import` があると注入に失敗し、`npm run preview` など本番相当でスタイルが空になることがあります。  
+本番ビルドでは `styled-components` が CSSOM（`insertRule`）でスタイルを注入します。
+このとき `createGlobalStyle` 内に `@import` があると注入に失敗し、`npm run preview` など本番相当でスタイルが空になることがあります。
 そのため、フォント読み込みは `public/index.html` の `<link rel="stylesheet">` で行い、`createGlobalStyle` には `@import` を書かない方針とします。
 
 ## ライセンス

--- a/src/pages/IpnePage.styles.ts
+++ b/src/pages/IpnePage.styles.ts
@@ -1281,29 +1281,47 @@ export const ClassImage = styled.img`
 
 // ===== レベルアップポイント制UI =====
 
-// 未割り振りポイントバッジ
+// 強調アニメーション（未割り振り時のアピール）
+const glowPulse = keyframes`
+  0%, 100% {
+    box-shadow: 0 0 8px rgba(251, 191, 36, 0.6), 0 0 16px rgba(251, 191, 36, 0.3);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 0 16px rgba(251, 191, 36, 0.8), 0 0 32px rgba(251, 191, 36, 0.5);
+    transform: scale(1.05);
+  }
+`;
+
+const bounce = keyframes`
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+`;
+
+// 未割り振りポイントバッジ（右上に配置、ヘルプボタンの左）
 export const PendingPointsBadge = styled.button<{ $hasPoints: boolean }>`
   position: absolute;
-  top: 8.5rem;
-  left: 1rem;
+  top: 1rem;
+  right: 11rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
   background: ${props => props.$hasPoints
-    ? 'linear-gradient(135deg, rgba(251, 191, 36, 0.3), rgba(245, 158, 11, 0.3))'
+    ? 'linear-gradient(135deg, rgba(251, 191, 36, 0.4), rgba(245, 158, 11, 0.4))'
     : 'rgba(0, 0, 0, 0.5)'};
   border: 2px solid ${props => props.$hasPoints ? '#fbbf24' : 'rgba(255, 255, 255, 0.2)'};
   border-radius: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: ${props => props.$hasPoints ? '0.625rem 1rem' : '0.5rem 0.75rem'};
   cursor: ${props => props.$hasPoints ? 'pointer' : 'default'};
   z-index: 20;
   transition: all 0.3s ease;
-  animation: ${props => props.$hasPoints ? css`${pulse} 2s ease-in-out infinite` : 'none'};
+  animation: ${props => props.$hasPoints ? css`${glowPulse} 1.5s ease-in-out infinite, ${bounce} 2s ease-in-out infinite` : 'none'};
 
   &:hover {
     ${props => props.$hasPoints && `
-      background: linear-gradient(135deg, rgba(251, 191, 36, 0.4), rgba(245, 158, 11, 0.4));
-      transform: scale(1.05);
+      background: linear-gradient(135deg, rgba(251, 191, 36, 0.5), rgba(245, 158, 11, 0.5));
+      transform: scale(1.08);
+      box-shadow: 0 0 20px rgba(251, 191, 36, 0.7);
     `}
   }
 
@@ -1314,31 +1332,34 @@ export const PendingPointsBadge = styled.button<{ $hasPoints: boolean }>`
   }
 
   @media (max-width: 480px) {
-    top: 7.5rem;
-    padding: 0.375rem 0.5rem;
+    top: 0.5rem;
+    right: 8.5rem;
+    padding: ${props => props.$hasPoints ? '0.5rem 0.75rem' : '0.375rem 0.5rem'};
     gap: 0.375rem;
   }
 `;
 
 // 未割り振りポイント数表示
 export const PendingPointsCount = styled.span<{ $hasPoints: boolean }>`
-  font-size: 0.875rem;
+  font-size: ${props => props.$hasPoints ? '1rem' : '0.875rem'};
   font-weight: bold;
   color: ${props => props.$hasPoints ? '#fbbf24' : '#6b7280'};
+  text-shadow: ${props => props.$hasPoints ? '0 0 8px rgba(251, 191, 36, 0.5)' : 'none'};
 
   @media (max-width: 480px) {
-    font-size: 0.75rem;
+    font-size: ${props => props.$hasPoints ? '0.875rem' : '0.75rem'};
   }
 `;
 
 // 強化ボタンテキスト
 export const EnhanceButtonText = styled.span<{ $hasPoints: boolean }>`
-  font-size: 0.75rem;
+  font-size: ${props => props.$hasPoints ? '0.875rem' : '0.75rem'};
   font-weight: bold;
   color: ${props => props.$hasPoints ? '#fbbf24' : '#6b7280'};
+  text-shadow: ${props => props.$hasPoints ? '0 0 8px rgba(251, 191, 36, 0.5)' : 'none'};
 
   @media (max-width: 480px) {
-    font-size: 0.65rem;
+    font-size: ${props => props.$hasPoints ? '0.75rem' : '0.65rem'};
   }
 `;
 

--- a/src/pages/IpnePage.styles.ts
+++ b/src/pages/IpnePage.styles.ts
@@ -1278,3 +1278,91 @@ export const ClassImage = styled.img`
     height: 60px;
   }
 `;
+
+// ===== レベルアップポイント制UI =====
+
+// 未割り振りポイントバッジ
+export const PendingPointsBadge = styled.button<{ $hasPoints: boolean }>`
+  position: absolute;
+  top: 8.5rem;
+  left: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: ${props => props.$hasPoints
+    ? 'linear-gradient(135deg, rgba(251, 191, 36, 0.3), rgba(245, 158, 11, 0.3))'
+    : 'rgba(0, 0, 0, 0.5)'};
+  border: 2px solid ${props => props.$hasPoints ? '#fbbf24' : 'rgba(255, 255, 255, 0.2)'};
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: ${props => props.$hasPoints ? 'pointer' : 'default'};
+  z-index: 20;
+  transition: all 0.3s ease;
+  animation: ${props => props.$hasPoints ? css`${pulse} 2s ease-in-out infinite` : 'none'};
+
+  &:hover {
+    ${props => props.$hasPoints && `
+      background: linear-gradient(135deg, rgba(251, 191, 36, 0.4), rgba(245, 158, 11, 0.4));
+      transform: scale(1.05);
+    `}
+  }
+
+  &:active {
+    ${props => props.$hasPoints && `
+      transform: scale(0.98);
+    `}
+  }
+
+  @media (max-width: 480px) {
+    top: 7.5rem;
+    padding: 0.375rem 0.5rem;
+    gap: 0.375rem;
+  }
+`;
+
+// 未割り振りポイント数表示
+export const PendingPointsCount = styled.span<{ $hasPoints: boolean }>`
+  font-size: 0.875rem;
+  font-weight: bold;
+  color: ${props => props.$hasPoints ? '#fbbf24' : '#6b7280'};
+
+  @media (max-width: 480px) {
+    font-size: 0.75rem;
+  }
+`;
+
+// 強化ボタンテキスト
+export const EnhanceButtonText = styled.span<{ $hasPoints: boolean }>`
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: ${props => props.$hasPoints ? '#fbbf24' : '#6b7280'};
+
+  @media (max-width: 480px) {
+    font-size: 0.65rem;
+  }
+`;
+
+// レベルアップオーバーレイの閉じるボタン
+export const LevelUpCloseButton = styled.button`
+  margin-top: 1rem;
+  padding: 0.75rem 2rem;
+  background: rgba(107, 114, 128, 0.3);
+  border: 1px solid rgba(107, 114, 128, 0.5);
+  border-radius: 0.5rem;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: rgba(107, 114, 128, 0.4);
+    color: white;
+  }
+`;
+
+// 残りポイント表示
+export const RemainingPointsText = styled.p`
+  color: #fbbf24;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+`;


### PR DESCRIPTION
## Summary
- レベルアップ時に即座に強化を選ぶのではなく、ポイントを貯めて好きなタイミングで強化を割り振れる仕組みを導入
- 未割り振りポイントがある場合はアニメーション付きバッジで視覚的にアピール
- 「後で選ぶ」ボタンでモーダルを閉じ、戦闘を継続可能に

## Changes
- `IpnePage.tsx`: レベルアップポイント制のロジック実装
  - `pendingLevelPoints` で未割り振りポイントを管理
  - レベル上限（MAX_LEVEL=10）に達した場合はポイント付与をスキップ
  - 実効レベル（現在レベル + 未使用ポイント）でレベルアップ判定
- `IpnePage.styles.ts`: UI追加
  - `PendingPointsBadge`: 未割り振りポイント表示バッジ（ゴールドのグローアニメーション）
  - `LevelUpCloseButton`: レベルアップ画面を閉じるボタン
  - `RemainingPointsText`: 残りポイント表示
- `README.md`: ゲームリストと技術スタック情報の更新

## Test plan
- [ ] 敵を倒してレベルアップポイントを取得できることを確認
- [ ] 未割り振りポイントがある場合、右上にアニメーション付きバッジが表示されることを確認
- [ ] バッジをクリックでレベルアップ画面が開くことを確認
- [ ] 「後で選ぶ」ボタンで画面を閉じ、戦闘を継続できることを確認
- [ ] ポイントを割り振ると残りポイントが減ることを確認
- [ ] レベル10に達した後はポイントが増えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)