### PR TITLE
test: ゲームプラットフォームにテストを追加

### DIFF
--- a/src/features/agile-quiz-sugoroku/__tests__/constants.test.ts
+++ b/src/features/agile-quiz-sugoroku/__tests__/constants.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Agile Quiz Sugoroku - 定数とユーティリティのテスト
+ */
+import {
+  CONFIG,
+  getDebtPoints,
+  getColorByThreshold,
+  getInverseColorByThreshold,
+  getGrade,
+  ENGINEER_TYPES,
+  getSummaryText,
+  getStrengthText,
+  getChallengeText,
+  COLORS,
+  EVENTS,
+  EMERGENCY_EVENT,
+  DEBT_EVENTS,
+  GRADES,
+  INITIAL_GAME_STATS,
+  CATEGORY_NAMES,
+} from '../constants';
+import { ClassifyStats } from '../types';
+
+describe('Agile Quiz Sugoroku - 定数とユーティリティ', () => {
+  // ── getDebtPoints ────────────────────────────────────
+
+  describe('getDebtPoints - イベント別の負債ポイント', () => {
+    it('impl系イベントは負債5ポイント', () => {
+      expect(getDebtPoints('impl1')).toBe(CONFIG.debt.impl);
+      expect(getDebtPoints('impl2')).toBe(CONFIG.debt.impl);
+    });
+
+    it('test系イベントは負債3ポイント', () => {
+      expect(getDebtPoints('test1')).toBe(CONFIG.debt.test);
+      expect(getDebtPoints('test2')).toBe(CONFIG.debt.test);
+    });
+
+    it('refinementは負債4ポイント', () => {
+      expect(getDebtPoints('refinement')).toBe(CONFIG.debt.refinement);
+    });
+
+    it('planningは負債0ポイント', () => {
+      expect(getDebtPoints('planning')).toBe(0);
+    });
+
+    it('reviewは負債0ポイント', () => {
+      expect(getDebtPoints('review')).toBe(0);
+    });
+
+    it('不明なイベントは負債0ポイント', () => {
+      expect(getDebtPoints('unknown')).toBe(0);
+    });
+  });
+
+  // ── getColorByThreshold ──────────────────────────────
+
+  describe('getColorByThreshold - 閾値に応じた色', () => {
+    it('上限以上で緑を返す', () => {
+      expect(getColorByThreshold(80, 70, 40)).toBe(COLORS.green);
+    });
+
+    it('上限と下限の間で黄色を返す', () => {
+      expect(getColorByThreshold(50, 70, 40)).toBe(COLORS.yellow);
+    });
+
+    it('下限未満で赤を返す', () => {
+      expect(getColorByThreshold(30, 70, 40)).toBe(COLORS.red);
+    });
+
+    it('境界値（上限ちょうど）で緑を返す', () => {
+      expect(getColorByThreshold(70, 70, 40)).toBe(COLORS.green);
+    });
+
+    it('境界値（下限ちょうど）で黄色を返す', () => {
+      expect(getColorByThreshold(40, 70, 40)).toBe(COLORS.yellow);
+    });
+  });
+
+  // ── getInverseColorByThreshold ───────────────────────
+
+  describe('getInverseColorByThreshold - 逆閾値の色（低いほど良い）', () => {
+    it('低値で緑を返す', () => {
+      expect(getInverseColorByThreshold(5, 10, 20)).toBe(COLORS.green);
+    });
+
+    it('中間値で黄色を返す', () => {
+      expect(getInverseColorByThreshold(15, 10, 20)).toBe(COLORS.yellow);
+    });
+
+    it('高値で赤を返す', () => {
+      expect(getInverseColorByThreshold(25, 10, 20)).toBe(COLORS.red);
+    });
+  });
+
+  // ── getGrade ─────────────────────────────────────────
+
+  describe('getGrade - グレード計算', () => {
+    it('高スコアでSグレードを返す', () => {
+      // score = 100*0.5 + 100*0.3 + max(0,min(100,100-0*8))*0.2 = 50+30+20 = 100
+      const grade = getGrade(100, 100, 0);
+      expect(grade.g).toBe('S');
+    });
+
+    it('正答率50%、安定度30%、速度20%の重みで計算される', () => {
+      // tp=60 → 30, stab=50 → 15, spd=5 → (100-40)*0.2 = 12 → total=57 → C
+      const grade = getGrade(60, 50, 5);
+      expect(grade.g).toBe('C');
+    });
+
+    it('低スコアでDグレードを返す', () => {
+      // tp=10 → 5, stab=10 → 3, spd=15 → max(0,-20)*0.2 = 0 → total=8 → D
+      const grade = getGrade(10, 10, 15);
+      expect(grade.g).toBe('D');
+    });
+
+    it('各グレードにはラベルが設定されている', () => {
+      const grade = getGrade(100, 100, 0);
+      expect(grade.label).toBe('Legendary');
+      expect(grade.c).toBeDefined();
+    });
+  });
+
+  // ── ENGINEER_TYPES ───────────────────────────────────
+
+  describe('ENGINEER_TYPES - エンジニアタイプ分類', () => {
+    it('安定運用型: 安定度65以上、負債20以下、正答率60以上', () => {
+      const stats: ClassifyStats = {
+        stab: 70, debt: 15, emSuc: 0, sc: [60, 70], tp: 65, spd: 7,
+      };
+      const type = ENGINEER_TYPES.find((t) => t.c(stats));
+      expect(type?.n).toBe('安定運用型エンジニア');
+    });
+
+    it('火消し職人: 緊急対応成功2回以上', () => {
+      const stats: ClassifyStats = {
+        stab: 30, debt: 40, emSuc: 2, sc: [40, 50], tp: 45, spd: 8,
+      };
+      const type = ENGINEER_TYPES.find((t) => t.c(stats));
+      expect(type?.n).toBe('火消し職人エンジニア');
+    });
+
+    it('成長曲線型: 初回50%未満かつ最終65%以上', () => {
+      const stats: ClassifyStats = {
+        stab: 50, debt: 25, emSuc: 0, sc: [40, 55, 70], tp: 55, spd: 8,
+      };
+      const type = ENGINEER_TYPES.find((t) => t.c(stats));
+      expect(type?.n).toBe('成長曲線型エンジニア');
+    });
+
+    it('高速レスポンス型: 速度5.5以下かつ正答率50%以上', () => {
+      const stats: ClassifyStats = {
+        stab: 50, debt: 25, emSuc: 0, sc: [60, 60], tp: 60, spd: 4.0,
+      };
+      const type = ENGINEER_TYPES.find((t) => t.c(stats));
+      expect(type?.n).toBe('高速レスポンスエンジニア');
+    });
+
+    it('技術的負債と共に生きる人: 負債35以上', () => {
+      const stats: ClassifyStats = {
+        stab: 10, debt: 40, emSuc: 0, sc: [30, 30], tp: 30, spd: 10,
+      };
+      const type = ENGINEER_TYPES.find((t) => t.c(stats));
+      expect(type?.n).toBe('技術的負債と共に生きる人');
+    });
+
+    it('どの条件にも当てはまらない場合は無難に回すエンジニア', () => {
+      const stats: ClassifyStats = {
+        stab: 50, debt: 25, emSuc: 0, sc: [55, 55], tp: 55, spd: 7,
+      };
+      const type = ENGINEER_TYPES.find((t) => t.c(stats));
+      expect(type?.n).toBe('無難に回すエンジニア');
+    });
+  });
+
+  // ── getSummaryText ───────────────────────────────────
+
+  describe('getSummaryText - サマリーテキスト生成', () => {
+    it('正答率70%以上で高評価テキストを返す', () => {
+      const text = getSummaryText(75, 5, 10, 0);
+      expect(text).toContain('高い正答率');
+    });
+
+    it('正答率70%以上かつ速度6以下で速度の言及がある', () => {
+      const text = getSummaryText(75, 5, 10, 0);
+      expect(text).toContain('回答速度も優秀');
+    });
+
+    it('正答率70%以上かつ速度7で速度の言及がない', () => {
+      const text = getSummaryText(75, 7, 10, 0);
+      expect(text).not.toContain('回答速度も優秀');
+    });
+
+    it('正答率50-69%で基礎力テキストを返す', () => {
+      const text = getSummaryText(55, 7, 10, 0);
+      expect(text).toContain('基礎力');
+    });
+
+    it('正答率50-69%かつ負債21以上で負債警告を含む', () => {
+      const text = getSummaryText(55, 7, 25, 0);
+      expect(text).toContain('技術的負債');
+    });
+
+    it('正答率50%未満で走破テキストを返す', () => {
+      const text = getSummaryText(40, 8, 5, 0);
+      expect(text).toContain('走破');
+    });
+
+    it('正答率50%未満かつ緊急対応成功ありでその言及がある', () => {
+      const text = getSummaryText(40, 8, 5, 1);
+      expect(text).toContain('緊急対応');
+    });
+  });
+
+  // ── getStrengthText ──────────────────────────────────
+
+  describe('getStrengthText - 強み評価テキスト', () => {
+    it('80%以上で非常に高い精度のテキスト', () => {
+      expect(getStrengthText(85)).toContain('非常に高い精度');
+    });
+
+    it('60%以上で安定したテキスト', () => {
+      expect(getStrengthText(65)).toContain('安定');
+    });
+
+    it('40%以上で基礎知識のテキスト', () => {
+      expect(getStrengthText(45)).toContain('基礎知識');
+    });
+
+    it('40%未満で伸びる余地のテキスト', () => {
+      expect(getStrengthText(20)).toContain('伸びる余地');
+    });
+  });
+
+  // ── getChallengeText ─────────────────────────────────
+
+  describe('getChallengeText - 課題評価テキスト', () => {
+    it('負債30以上で深刻化テキスト', () => {
+      expect(getChallengeText(35, 5, 60)).toContain('深刻化');
+    });
+
+    it('負債15以上で注意テキスト', () => {
+      expect(getChallengeText(20, 5, 60)).toContain('注意');
+    });
+
+    it('速度10超で速度改善テキスト', () => {
+      expect(getChallengeText(10, 12, 60)).toContain('回答速度');
+    });
+
+    it('正答率50%未満で正答率向上テキスト', () => {
+      expect(getChallengeText(10, 8, 40)).toContain('正答率');
+    });
+
+    it('問題がない場合は高水準テキスト', () => {
+      expect(getChallengeText(5, 5, 80)).toContain('高水準');
+    });
+  });
+
+  // ── 定数データの構造検証 ─────────────────────────────
+
+  describe('定数データの構造検証', () => {
+    it('EVENTSは7つのイベントを含む', () => {
+      expect(EVENTS).toHaveLength(7);
+    });
+
+    it('各イベントに必須プロパティが存在する', () => {
+      EVENTS.forEach((event) => {
+        expect(event.id).toBeDefined();
+        expect(event.nm).toBeDefined();
+        expect(event.ic).toBeDefined();
+        expect(event.ds).toBeDefined();
+        expect(event.color).toBeDefined();
+      });
+    });
+
+    it('EMERGENCY_EVENTのidはemergency', () => {
+      expect(EMERGENCY_EVENT.id).toBe('emergency');
+    });
+
+    it('INITIAL_GAME_STATSの初期値がゼロ', () => {
+      expect(INITIAL_GAME_STATS.tc).toBe(0);
+      expect(INITIAL_GAME_STATS.tq).toBe(0);
+      expect(INITIAL_GAME_STATS.debt).toBe(0);
+      expect(INITIAL_GAME_STATS.sp).toEqual([]);
+    });
+
+    it('GRADESは降順にソートされている', () => {
+      for (let i = 0; i < GRADES.length - 1; i++) {
+        expect(GRADES[i].min).toBeGreaterThan(GRADES[i + 1].min);
+      }
+    });
+
+    it('CATEGORY_NAMESに全イベントIDのマッピングが存在する', () => {
+      EVENTS.forEach((event) => {
+        expect(CATEGORY_NAMES[event.id]).toBeDefined();
+      });
+      expect(CATEGORY_NAMES['emergency']).toBeDefined();
+    });
+  });
+});

--- a/src/features/agile-quiz-sugoroku/__tests__/game-logic.test.ts
+++ b/src/features/agile-quiz-sugoroku/__tests__/game-logic.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Agile Quiz Sugoroku - ゲームロジックのテスト
+ */
+import {
+  shuffle,
+  average,
+  percentage,
+  clamp,
+  pickQuestion,
+  makeEvents,
+  createSprintSummary,
+} from '../game-logic';
+import { EVENTS } from '../constants';
+import { AnswerResult } from '../types';
+
+describe('Agile Quiz Sugoroku - ゲームロジック', () => {
+  // ── average ──────────────────────────────────────────
+
+  describe('average - 平均値の計算', () => {
+    it('空配列の場合は0を返す', () => {
+      expect(average([])).toBe(0);
+    });
+
+    it('単一要素はそのまま返す', () => {
+      expect(average([5])).toBe(5);
+    });
+
+    it('複数要素の平均を正しく計算する', () => {
+      expect(average([2, 4, 6])).toBe(4);
+      expect(average([10, 20, 30, 40])).toBe(25);
+    });
+
+    it('小数を含む場合も正しく計算する', () => {
+      expect(average([1.5, 2.5])).toBe(2);
+    });
+  });
+
+  // ── percentage ───────────────────────────────────────
+
+  describe('percentage - パーセンテージの計算', () => {
+    it('分母が0の場合は0を返す', () => {
+      expect(percentage(5, 0)).toBe(0);
+    });
+
+    it('全問正解で100%を返す', () => {
+      expect(percentage(7, 7)).toBe(100);
+    });
+
+    it('3問中2問正解で67%を返す', () => {
+      expect(percentage(2, 3)).toBe(67);
+    });
+
+    it('0問正解で0%を返す', () => {
+      expect(percentage(0, 5)).toBe(0);
+    });
+  });
+
+  // ── clamp ────────────────────────────────────────────
+
+  describe('clamp - 値の範囲制限', () => {
+    it('範囲内の値はそのまま返す', () => {
+      expect(clamp(50, 0, 100)).toBe(50);
+    });
+
+    it('下限未満の値は下限にクランプされる', () => {
+      expect(clamp(-10, 0, 100)).toBe(0);
+    });
+
+    it('上限超過の値は上限にクランプされる', () => {
+      expect(clamp(150, 0, 100)).toBe(100);
+    });
+
+    it('境界値の場合はそのまま返す', () => {
+      expect(clamp(0, 0, 100)).toBe(0);
+      expect(clamp(100, 0, 100)).toBe(100);
+    });
+  });
+
+  // ── shuffle ──────────────────────────────────────────
+
+  describe('shuffle - 配列のシャッフル', () => {
+    it('元の配列を変更しない', () => {
+      const original = [1, 2, 3, 4, 5];
+      const copy = [...original];
+      shuffle(original);
+      expect(original).toEqual(copy);
+    });
+
+    it('シャッフル結果は同じ要素を含む', () => {
+      const arr = [1, 2, 3, 4, 5];
+      const result = shuffle(arr);
+      expect(result.sort()).toEqual(arr.sort());
+    });
+
+    it('空配列はそのまま返す', () => {
+      expect(shuffle([])).toEqual([]);
+    });
+
+    it('単一要素はそのまま返す', () => {
+      expect(shuffle([42])).toEqual([42]);
+    });
+  });
+
+  // ── pickQuestion ─────────────────────────────────────
+
+  describe('pickQuestion - 問題の選択', () => {
+    beforeEach(() => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('指定カテゴリから問題を選択する', () => {
+      const { question, index } = pickQuestion('planning');
+      expect(question).toBeDefined();
+      expect(question.q).toBeDefined();
+      expect(question.o).toHaveLength(4);
+      expect(typeof question.a).toBe('number');
+      expect(index).toBe(0);
+    });
+
+    it('存在しないカテゴリはplanningから選択する', () => {
+      const fromUnknown = pickQuestion('nonexistent');
+      const fromPlanning = pickQuestion('planning');
+      expect(fromUnknown.question.q).toBe(fromPlanning.question.q);
+    });
+
+    it('使用済みインデックスを避けて未使用の問題を選ぶ', () => {
+      // インデックス0を使用済みにする
+      const used = new Set([0]);
+      const { index } = pickQuestion('planning', used);
+      expect(index).not.toBe(0);
+    });
+
+    it('全問題が使用済みの場合でもランダムに選択する', () => {
+      // 十分な数のインデックスを使用済みにする
+      const used = new Set(Array.from({ length: 100 }, (_, i) => i));
+      const { question } = pickQuestion('planning', used);
+      expect(question).toBeDefined();
+    });
+  });
+
+  // ── makeEvents ───────────────────────────────────────
+
+  describe('makeEvents - スプリントイベントの生成', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('7つの標準イベントが返される', () => {
+      const events = makeEvents(0, 0);
+      expect(events).toHaveLength(7);
+    });
+
+    it('最初のスプリントでは緊急対応が発生しない', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      const events = makeEvents(0, 0);
+      const hasEmergency = events.some((e) => e.id === 'emergency');
+      expect(hasEmergency).toBe(false);
+    });
+
+    it('2スプリント目以降で確率条件を満たすと緊急対応が挿入される', () => {
+      // Math.random が常に 0 → probability > 0 なので必ず挿入
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      const events = makeEvents(1, 0);
+      const hasEmergency = events.some((e) => e.id === 'emergency');
+      expect(hasEmergency).toBe(true);
+    });
+
+    it('緊急対応は位置1〜3のいずれかに挿入される', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      const events = makeEvents(1, 0);
+      // position = minPosition(1) + floor(0 * 3) = 1
+      expect(events[1].id).toBe('emergency');
+    });
+
+    it('確率が低く乱数が高い場合は緊急対応が発生しない', () => {
+      // probability = min(0.5, 0.1 + 0*0.004) = 0.1 < 0.99
+      jest.spyOn(Math, 'random').mockReturnValue(0.99);
+      const events = makeEvents(1, 0);
+      const hasEmergency = events.some((e) => e.id === 'emergency');
+      expect(hasEmergency).toBe(false);
+    });
+
+    it('負債が高いと緊急対応の確率が上がる', () => {
+      // debt=100 → probability = min(0.5, 0.1 + 100*0.004) = 0.5
+      jest.spyOn(Math, 'random').mockReturnValue(0.49);
+      const events = makeEvents(1, 100);
+      const hasEmergency = events.some((e) => e.id === 'emergency');
+      expect(hasEmergency).toBe(true);
+    });
+  });
+
+  // ── createSprintSummary ──────────────────────────────
+
+  describe('createSprintSummary - スプリント集計', () => {
+    it('全問正解時の正答率は100%になる', () => {
+      const answers: AnswerResult[] = [
+        { c: true, s: 3.0, e: 'planning' },
+        { c: true, s: 4.0, e: 'impl1' },
+        { c: true, s: 5.0, e: 'test1' },
+      ];
+      const summary = createSprintSummary(answers, 0, 0);
+      expect(summary.pct).toBe(100);
+      expect(summary.cor).toBe(3);
+      expect(summary.tot).toBe(3);
+    });
+
+    it('全問不正解時の正答率は0%になる', () => {
+      const answers: AnswerResult[] = [
+        { c: false, s: 3.0, e: 'planning' },
+        { c: false, s: 4.0, e: 'impl1' },
+      ];
+      const summary = createSprintSummary(answers, 0, 0);
+      expect(summary.pct).toBe(0);
+      expect(summary.cor).toBe(0);
+    });
+
+    it('カテゴリ別の正答数と出題数が正しく集計される', () => {
+      const answers: AnswerResult[] = [
+        { c: true, s: 3.0, e: 'planning' },
+        { c: false, s: 4.0, e: 'planning' },
+        { c: true, s: 5.0, e: 'impl1' },
+      ];
+      const summary = createSprintSummary(answers, 0, 0);
+      expect(summary.cats['planning']).toEqual({ c: 1, t: 2 });
+      expect(summary.cats['impl1']).toEqual({ c: 1, t: 1 });
+    });
+
+    it('平均回答速度が正しく計算される', () => {
+      const answers: AnswerResult[] = [
+        { c: true, s: 2.0, e: 'planning' },
+        { c: true, s: 4.0, e: 'impl1' },
+      ];
+      const summary = createSprintSummary(answers, 0, 0);
+      expect(summary.spd).toBe(3.0);
+    });
+
+    it('スプリント番号は1始まりで記録される', () => {
+      const answers: AnswerResult[] = [{ c: true, s: 3.0, e: 'planning' }];
+      const summary = createSprintSummary(answers, 0, 0);
+      expect(summary.sp).toBe(1);
+    });
+
+    it('緊急対応の有無と成功数が正しく記録される', () => {
+      const answers: AnswerResult[] = [
+        { c: true, s: 3.0, e: 'emergency' },
+        { c: false, s: 4.0, e: 'emergency' },
+        { c: true, s: 5.0, e: 'planning' },
+      ];
+      const summary = createSprintSummary(answers, 0, 10);
+      expect(summary.em).toBe(true);
+      expect(summary.emOk).toBe(1);
+      expect(summary.debt).toBe(10);
+    });
+
+    it('緊急対応がない場合はem=false, emOk=0', () => {
+      const answers: AnswerResult[] = [
+        { c: true, s: 3.0, e: 'planning' },
+      ];
+      const summary = createSprintSummary(answers, 0, 0);
+      expect(summary.em).toBe(false);
+      expect(summary.emOk).toBe(0);
+    });
+  });
+});

--- a/src/features/agile-quiz-sugoroku/__tests__/questions.test.ts
+++ b/src/features/agile-quiz-sugoroku/__tests__/questions.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Agile Quiz Sugoroku - 問題データの構造検証テスト
+ */
+import { QUESTIONS } from '../quiz-data';
+
+describe('Agile Quiz Sugoroku - 問題データの構造検証', () => {
+  const expectedCategories = [
+    'planning',
+    'impl1',
+    'test1',
+    'refinement',
+    'impl2',
+    'test2',
+    'review',
+    'emergency',
+  ];
+
+  it('全カテゴリの問題データが存在する', () => {
+    expectedCategories.forEach((category) => {
+      expect(QUESTIONS[category]).toBeDefined();
+      expect(QUESTIONS[category].length).toBeGreaterThan(0);
+    });
+  });
+
+  it.each(expectedCategories)(
+    '%s: 全問題にq(問題文), o(4択), a(0-3)が含まれる',
+    (category) => {
+      QUESTIONS[category].forEach((question, index) => {
+        expect(question.q).toBeDefined();
+        expect(typeof question.q).toBe('string');
+        expect(question.q.length).toBeGreaterThan(0);
+
+        expect(question.o).toBeDefined();
+        expect(question.o).toHaveLength(4);
+        question.o.forEach((option) => {
+          expect(typeof option).toBe('string');
+        });
+
+        expect(question.a).toBeDefined();
+        expect(question.a).toBeGreaterThanOrEqual(0);
+        expect(question.a).toBeLessThanOrEqual(3);
+      });
+    }
+  );
+
+  it('各カテゴリに十分な数の問題がある（5問以上）', () => {
+    expectedCategories.forEach((category) => {
+      expect(QUESTIONS[category].length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  it('選択肢の正解インデックスが選択肢配列の範囲内にある', () => {
+    expectedCategories.forEach((category) => {
+      QUESTIONS[category].forEach((question) => {
+        expect(question.a).toBeLessThan(question.o.length);
+      });
+    });
+  });
+});

--- a/src/features/agile-quiz-sugoroku/game-logic.ts
+++ b/src/features/agile-quiz-sugoroku/game-logic.ts
@@ -1,0 +1,127 @@
+/**
+ * Agile Quiz Sugoroku - ゲームロジック（純粋関数）
+ *
+ * useGame.ts から抽出した状態非依存のユーティリティ関数群。
+ * テスト容易性と再利用性のために分離。
+ */
+import {
+  GameEvent,
+  Question,
+  AnswerResult,
+  SprintSummary,
+  CategoryStats,
+} from './types';
+import { CONFIG, EVENTS, EMERGENCY_EVENT, DEBT_EVENTS, getDebtPoints } from './constants';
+import { QUESTIONS } from './quiz-data';
+
+/** 配列をシャッフル */
+export function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/** 平均値を計算 */
+export function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** パーセンテージを計算 */
+export function percentage(numerator: number, denominator: number): number {
+  if (denominator === 0) return 0;
+  return Math.round((numerator / denominator) * 100);
+}
+
+/** 値を範囲内にクランプ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** 問題を選択 */
+export function pickQuestion(
+  eventId: string,
+  usedIndices?: Set<number>
+): { question: Question; index: number } {
+  const questions = QUESTIONS[eventId] ?? QUESTIONS.planning;
+  const used = usedIndices ?? new Set<number>();
+
+  // 未使用の問題インデックスを取得
+  const available: number[] = [];
+  for (let i = 0; i < questions.length; i++) {
+    if (!used.has(i)) {
+      available.push(i);
+    }
+  }
+
+  // 未使用があればそこから、なければランダム
+  const index =
+    available.length > 0
+      ? available[Math.floor(Math.random() * available.length)]
+      : Math.floor(Math.random() * questions.length);
+
+  return { question: questions[index], index };
+}
+
+/** スプリントイベントを生成（緊急対応の発生判定含む） */
+export function makeEvents(sprintNumber: number, debt: number): GameEvent[] {
+  const events = [...EVENTS];
+
+  // 2スプリント目以降で緊急対応が発生する可能性
+  if (sprintNumber > 0) {
+    const probability = Math.min(
+      CONFIG.emergency.maxProbability,
+      CONFIG.emergency.base + debt * CONFIG.emergency.debtMultiplier
+    );
+
+    if (Math.random() < probability) {
+      // ランダムな位置（1〜4）に緊急対応を挿入
+      const position =
+        CONFIG.emergency.minPosition +
+        Math.floor(
+          Math.random() *
+            (CONFIG.emergency.maxPosition - CONFIG.emergency.minPosition)
+        );
+      events[position] = { ...EMERGENCY_EVENT };
+    }
+  }
+
+  return events;
+}
+
+/** スプリント集計を生成 */
+export function createSprintSummary(
+  answers: AnswerResult[],
+  sprintNumber: number,
+  debt: number
+): SprintSummary {
+  let correctCount = 0;
+  answers.forEach((a) => {
+    if (a.c) correctCount++;
+  });
+
+  // カテゴリ別統計
+  const cats: CategoryStats = {};
+  answers.forEach((a) => {
+    if (!cats[a.e]) {
+      cats[a.e] = { c: 0, t: 0 };
+    }
+    cats[a.e].t++;
+    if (a.c) cats[a.e].c++;
+  });
+
+  return {
+    sp: sprintNumber + 1,
+    pct: percentage(correctCount, answers.length),
+    cor: correctCount,
+    tot: answers.length,
+    spd: average(answers.map((a) => a.s)),
+    debt,
+    em: answers.some((a) => a.e === 'emergency'),
+    emOk: answers.filter((a) => a.e === 'emergency' && a.c).length,
+    cats,
+  };
+}

--- a/src/features/agile-quiz-sugoroku/hooks/useGame.ts
+++ b/src/features/agile-quiz-sugoroku/hooks/useGame.ts
@@ -10,130 +10,23 @@ import {
   SprintSummary,
   GameStats,
   DerivedStats,
-  CategoryStats,
 } from '../types';
 import {
-  CONFIG,
   EVENTS,
-  EMERGENCY_EVENT,
   DEBT_EVENTS,
   getDebtPoints,
   INITIAL_GAME_STATS,
 } from '../constants';
-import { QUESTIONS } from '../quiz-data';
 import { playSfxCorrect, playSfxIncorrect } from '../audio/sound';
-
-/** 配列をシャッフル */
-function shuffle<T>(array: T[]): T[] {
-  const result = [...array];
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [result[i], result[j]] = [result[j], result[i]];
-  }
-  return result;
-}
-
-/** 平均値を計算 */
-function average(values: number[]): number {
-  if (values.length === 0) return 0;
-  return values.reduce((sum, v) => sum + v, 0) / values.length;
-}
-
-/** パーセンテージを計算 */
-function percentage(numerator: number, denominator: number): number {
-  if (denominator === 0) return 0;
-  return Math.round((numerator / denominator) * 100);
-}
-
-/** 値を範囲内にクランプ */
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
-/** 問題を選択 */
-function pickQuestion(
-  eventId: string,
-  usedIndices?: Set<number>
-): { question: Question; index: number } {
-  const questions = QUESTIONS[eventId] ?? QUESTIONS.planning;
-  const used = usedIndices ?? new Set<number>();
-
-  // 未使用の問題インデックスを取得
-  const available: number[] = [];
-  for (let i = 0; i < questions.length; i++) {
-    if (!used.has(i)) {
-      available.push(i);
-    }
-  }
-
-  // 未使用があればそこから、なければランダム
-  const index =
-    available.length > 0
-      ? available[Math.floor(Math.random() * available.length)]
-      : Math.floor(Math.random() * questions.length);
-
-  return { question: questions[index], index };
-}
-
-/** スプリントイベントを生成（緊急対応の発生判定含む） */
-function makeEvents(sprintNumber: number, debt: number): GameEvent[] {
-  const events = [...EVENTS];
-
-  // 2スプリント目以降で緊急対応が発生する可能性
-  if (sprintNumber > 0) {
-    const probability = Math.min(
-      CONFIG.emergency.maxProbability,
-      CONFIG.emergency.base + debt * CONFIG.emergency.debtMultiplier
-    );
-
-    if (Math.random() < probability) {
-      // ランダムな位置（1〜4）に緊急対応を挿入
-      const position =
-        CONFIG.emergency.minPosition +
-        Math.floor(
-          Math.random() *
-            (CONFIG.emergency.maxPosition - CONFIG.emergency.minPosition)
-        );
-      events[position] = { ...EMERGENCY_EVENT };
-    }
-  }
-
-  return events;
-}
-
-/** スプリント集計を生成 */
-function createSprintSummary(
-  answers: AnswerResult[],
-  sprintNumber: number,
-  debt: number
-): SprintSummary {
-  let correctCount = 0;
-  answers.forEach((a) => {
-    if (a.c) correctCount++;
-  });
-
-  // カテゴリ別統計
-  const cats: CategoryStats = {};
-  answers.forEach((a) => {
-    if (!cats[a.e]) {
-      cats[a.e] = { c: 0, t: 0 };
-    }
-    cats[a.e].t++;
-    if (a.c) cats[a.e].c++;
-  });
-
-  return {
-    sp: sprintNumber + 1,
-    pct: percentage(correctCount, answers.length),
-    cor: correctCount,
-    tot: answers.length,
-    spd: average(answers.map((a) => a.s)),
-    debt,
-    em: answers.some((a) => a.e === 'emergency'),
-    emOk: answers.filter((a) => a.e === 'emergency' && a.c).length,
-    cats,
-  };
-}
+import {
+  shuffle,
+  average,
+  percentage,
+  clamp,
+  pickQuestion,
+  makeEvents,
+  createSprintSummary,
+} from '../game-logic';
 
 export interface UseGameReturn {
   /** 現在のフェーズ */

--- a/src/features/air-hockey/core/Physics.test.ts
+++ b/src/features/air-hockey/core/Physics.test.ts
@@ -1,4 +1,5 @@
 import { Physics } from './physics';
+import { CONSTANTS } from './constants';
 
 describe('Physics Module', () => {
   describe('detectCollision', () => {
@@ -45,6 +46,68 @@ describe('Physics Module', () => {
       expect(res.x).toBe(15); // radius 10 + 5 padding
       // expect(res.vx).toBe(5 * 0.95); // abs(vx) * 0.95
       expect(res.vx).toBeGreaterThan(0);
+    });
+  });
+
+  describe('reflectOffSurface - 面での反射', () => {
+    it('法線方向に押し出されて速度が反転する', () => {
+      const obj = { x: 10, y: 10, vx: 5, vy: 0 };
+      const collision = { nx: -1, ny: 0, penetration: 3 };
+      const result = Physics.reflectOffSurface(obj, collision);
+
+      // x = 10 + (-1) * (3+1) = 6
+      expect(result.x).toBeCloseTo(6);
+      // 反射: dot = 5*(-1) + 0*0 = -5
+      // vx = (5 - 2*(-5)*(-1)) * 0.9 = (5 - 10) * 0.9 = -4.5
+      expect(result.vx).toBeCloseTo(-4.5);
+    });
+
+    it('元のオブジェクトを変更しない', () => {
+      const obj = { x: 10, y: 10, vx: 5, vy: 0 };
+      const collision = { nx: -1, ny: 0, penetration: 3 };
+      Physics.reflectOffSurface(obj, collision);
+      expect(obj.x).toBe(10);
+      expect(obj.vx).toBe(5);
+    });
+
+    it('斜めの法線でも正しく反射する', () => {
+      const nx = Math.sqrt(2) / 2;
+      const ny = Math.sqrt(2) / 2;
+      const obj = { x: 0, y: 0, vx: 5, vy: 5 };
+      const collision = { nx, ny, penetration: 2 };
+      const result = Physics.reflectOffSurface(obj, collision);
+      // 押し出し方向が法線方向であることを確認
+      expect(result.x).toBeGreaterThan(obj.x);
+      expect(result.y).toBeGreaterThan(obj.y);
+    });
+  });
+
+  describe('applyFriction - 摩擦の適用', () => {
+    it('速度に摩擦係数が適用される', () => {
+      const obj = { x: 100, y: 100, vx: 10, vy: 10 };
+      const result = Physics.applyFriction(obj);
+      expect(result.vx).toBeCloseTo(10 * CONSTANTS.PHYSICS.FRICTION);
+      expect(result.vy).toBeCloseTo(10 * CONSTANTS.PHYSICS.FRICTION);
+    });
+
+    it('位置は変更されない', () => {
+      const obj = { x: 100, y: 200, vx: 10, vy: 10 };
+      const result = Physics.applyFriction(obj);
+      expect(result.x).toBe(100);
+      expect(result.y).toBe(200);
+    });
+
+    it('最低速度以下にならない', () => {
+      const obj = { x: 0, y: 0, vx: 0.5, vy: 0.5 };
+      const result = Physics.applyFriction(obj);
+      const speed = Math.sqrt(result.vx ** 2 + result.vy ** 2);
+      expect(speed).toBeGreaterThanOrEqual(CONSTANTS.PHYSICS.MIN_SPEED);
+    });
+
+    it('元のオブジェクトを変更しない', () => {
+      const obj = { x: 0, y: 0, vx: 10, vy: 10 };
+      Physics.applyFriction(obj);
+      expect(obj.vx).toBe(10);
     });
   });
 });

--- a/src/features/air-hockey/core/entities.test.ts
+++ b/src/features/air-hockey/core/entities.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Air Hockey - エンティティ生成のテスト
+ */
+import { EntityFactory } from './entities';
+import { CONSTANTS } from './constants';
+
+const { WIDTH: W, HEIGHT: H } = CONSTANTS.CANVAS;
+
+describe('Air Hockey - エンティティ生成', () => {
+  // ── EntityFactory.createMallet ───────────────────────
+
+  describe('EntityFactory.createMallet - マレット生成', () => {
+    it('指定座標に生成される', () => {
+      const mallet = EntityFactory.createMallet(100, 200);
+      expect(mallet.x).toBe(100);
+      expect(mallet.y).toBe(200);
+    });
+
+    it('初期速度は0', () => {
+      const mallet = EntityFactory.createMallet(100, 200);
+      expect(mallet.vx).toBe(0);
+      expect(mallet.vy).toBe(0);
+    });
+  });
+
+  // ── EntityFactory.createPuck ─────────────────────────
+
+  describe('EntityFactory.createPuck - パック生成', () => {
+    it('指定座標に生成される', () => {
+      const puck = EntityFactory.createPuck(150, 300);
+      expect(puck.x).toBe(150);
+      expect(puck.y).toBe(300);
+    });
+
+    it('デフォルト初期速度 vy=1.5 で生成される', () => {
+      const puck = EntityFactory.createPuck(150, 300);
+      expect(puck.vx).toBe(0);
+      expect(puck.vy).toBe(1.5);
+    });
+
+    it('カスタム速度で生成できる', () => {
+      const puck = EntityFactory.createPuck(150, 300, 2, -3);
+      expect(puck.vx).toBe(2);
+      expect(puck.vy).toBe(-3);
+    });
+
+    it('パックは初期状態で可視', () => {
+      const puck = EntityFactory.createPuck(150, 300);
+      expect(puck.visible).toBe(true);
+      expect(puck.invisibleCount).toBe(0);
+    });
+  });
+
+  // ── EntityFactory.createGameState ────────────────────
+
+  describe('EntityFactory.createGameState - ゲーム状態初期化', () => {
+    it('プレイヤーとCPUのマレットが正しく配置される', () => {
+      const state = EntityFactory.createGameState();
+      expect(state.player.x).toBe(W / 2);
+      expect(state.player.y).toBe(H - 70);
+      expect(state.cpu.x).toBe(W / 2);
+      expect(state.cpu.y).toBe(70);
+    });
+
+    it('パックが1つ生成される', () => {
+      const state = EntityFactory.createGameState();
+      expect(state.pucks).toHaveLength(1);
+    });
+
+    it('初期アイテムは空', () => {
+      const state = EntityFactory.createGameState();
+      expect(state.items).toEqual([]);
+    });
+
+    it('初期エフェクトがリセットされている', () => {
+      const state = EntityFactory.createGameState();
+      expect(state.effects.player.speed).toBeNull();
+      expect(state.effects.player.invisible).toBe(0);
+      expect(state.effects.cpu.speed).toBeNull();
+      expect(state.effects.cpu.invisible).toBe(0);
+    });
+
+    it('ゴールエフェクトとフラッシュがnull', () => {
+      const state = EntityFactory.createGameState();
+      expect(state.goalEffect).toBeNull();
+      expect(state.flash).toBeNull();
+    });
+  });
+});

--- a/src/features/air-hockey/core/items.test.ts
+++ b/src/features/air-hockey/core/items.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Air Hockey - アイテムエフェクトのテスト
+ */
+import { ItemEffects, applyItemEffect } from './items';
+import { GameState, GameEffects } from './types';
+import { EntityFactory } from './entities';
+
+/** テスト用のゲーム状態を生成 */
+const createTestGameState = (overrides: Partial<GameState> = {}): GameState => ({
+  ...EntityFactory.createGameState(),
+  ...overrides,
+});
+
+describe('Air Hockey - アイテムエフェクト', () => {
+  // ── ItemEffects.split ────────────────────────────────
+
+  describe('ItemEffects.split - パック分裂', () => {
+    it('パック1つの場合は3つに分裂する', () => {
+      const game = createTestGameState();
+      expect(game.pucks).toHaveLength(1);
+      const result = ItemEffects.split(game);
+      expect(result.pucks).toHaveLength(3);
+    });
+
+    it('分裂後のパックは元のパック位置付近に生成される', () => {
+      const game = createTestGameState();
+      const originalX = game.pucks[0].x;
+      const result = ItemEffects.split(game);
+      result.pucks!.forEach((puck) => {
+        expect(Math.abs(puck.x - originalX)).toBeLessThanOrEqual(20);
+      });
+    });
+
+    it('既に複数パックの場合は分裂しない', () => {
+      const game = createTestGameState({
+        pucks: [
+          EntityFactory.createPuck(100, 300),
+          EntityFactory.createPuck(200, 300),
+        ],
+      });
+      const result = ItemEffects.split(game);
+      expect(result.pucks).toBeUndefined();
+    });
+  });
+
+  // ── ItemEffects.speed ────────────────────────────────
+
+  describe('ItemEffects.speed - スピードアップ', () => {
+    it('ターゲットのspeedエフェクトが設定される', () => {
+      const game = createTestGameState();
+      const result = ItemEffects.speed(game, 'player');
+      expect(result.effects!.player.speed).not.toBeNull();
+      expect(result.effects!.player.speed!.duration).toBe(8000);
+    });
+
+    it('cpu側にもスピードエフェクトが設定できる', () => {
+      const game = createTestGameState();
+      const result = ItemEffects.speed(game, 'cpu');
+      expect(result.effects!.cpu.speed).not.toBeNull();
+    });
+  });
+
+  // ── ItemEffects.invisible ────────────────────────────
+
+  describe('ItemEffects.invisible - 透明化', () => {
+    it('ターゲットのinvisibleカウントが設定される', () => {
+      const game = createTestGameState();
+      const result = ItemEffects.invisible(game, 'player');
+      expect(result.effects!.player.invisible).toBe(5);
+    });
+
+    it('cpu側にも透明化が設定できる', () => {
+      const game = createTestGameState();
+      const result = ItemEffects.invisible(game, 'cpu');
+      expect(result.effects!.cpu.invisible).toBe(5);
+    });
+  });
+
+  // ── applyItemEffect ──────────────────────────────────
+
+  describe('applyItemEffect - エフェクト統合適用', () => {
+    it('splitアイテムの適用でパック分裂とflashが設定される', () => {
+      const game = createTestGameState();
+      const now = Date.now();
+      const result = applyItemEffect(game, { id: 'split' }, 'player', now);
+      expect(result.pucks).toHaveLength(3);
+      expect(result.flash).toEqual({ type: 'split', time: now });
+    });
+
+    it('speedアイテムの適用でエフェクトとflashが設定される', () => {
+      const game = createTestGameState();
+      const now = Date.now();
+      const result = applyItemEffect(game, { id: 'speed' }, 'player', now);
+      expect(result.effects!.player.speed).not.toBeNull();
+      expect(result.flash).toEqual({ type: 'speed', time: now });
+    });
+
+    it('invisibleアイテムの適用でエフェクトとflashが設定される', () => {
+      const game = createTestGameState();
+      const now = Date.now();
+      const result = applyItemEffect(game, { id: 'invisible' }, 'cpu', now);
+      expect(result.effects!.cpu.invisible).toBe(5);
+      expect(result.flash).toEqual({ type: 'invisible', time: now });
+    });
+  });
+});

--- a/src/features/keys-and-arms/__tests__/difficulty.test.ts
+++ b/src/features/keys-and-arms/__tests__/difficulty.test.ts
@@ -1,0 +1,163 @@
+// @ts-nocheck
+/**
+ * Keys & Arms - 難易度設定のテスト
+ */
+import { Difficulty } from '../difficulty';
+
+describe('Keys & Arms - 難易度設定', () => {
+  // ── beatLength ───────────────────────────────────────
+
+  describe('beatLength - ビート長', () => {
+    it('ループ1で34フレーム', () => {
+      expect(Difficulty.beatLength(1)).toBe(34);
+    });
+
+    it('ループ2で27フレーム', () => {
+      expect(Difficulty.beatLength(2)).toBe(27);
+    });
+
+    it('ループ3で20フレーム', () => {
+      expect(Difficulty.beatLength(3)).toBe(20);
+    });
+
+    it('ループ4以降は徐々に減少する', () => {
+      // loop=4: max(14, 20-(4-3)*2) = max(14,18) = 18
+      expect(Difficulty.beatLength(4)).toBe(18);
+      // loop=5: max(14, 20-(5-3)*2) = max(14,16) = 16
+      expect(Difficulty.beatLength(5)).toBe(16);
+    });
+
+    it('最低14フレームを下回らない', () => {
+      expect(Difficulty.beatLength(10)).toBe(14);
+      expect(Difficulty.beatLength(20)).toBe(14);
+    });
+  });
+
+  // ── hazardCycle ──────────────────────────────────────
+
+  describe('hazardCycle - ハザードサイクル', () => {
+    it('ループ1、base6で5を返す', () => {
+      // max(6-3, 6-1) = max(3,5) = 5
+      expect(Difficulty.hazardCycle(1, 6)).toBe(5);
+    });
+
+    it('ループが高いとサイクルが短くなる', () => {
+      expect(Difficulty.hazardCycle(3, 6)).toBe(3);
+    });
+
+    it('下限 base-3 を下回らない', () => {
+      // max(6-3, 6-10) = max(3,-4) = 3
+      expect(Difficulty.hazardCycle(10, 6)).toBe(3);
+    });
+  });
+
+  // ── bossArmSpeed / bossArmRest ───────────────────────
+
+  describe('bossArmSpeed - ボスアームの速度', () => {
+    it('ループ1では3を返す', () => {
+      expect(Difficulty.bossArmSpeed(1)).toBe(3);
+    });
+
+    it('ループ2以降では2を返す', () => {
+      expect(Difficulty.bossArmSpeed(2)).toBe(2);
+      expect(Difficulty.bossArmSpeed(5)).toBe(2);
+    });
+  });
+
+  describe('bossArmRest - ボスアームの休憩時間', () => {
+    it('ループ別に正しい値を返す', () => {
+      expect(Difficulty.bossArmRest(1)).toBe(5);
+      expect(Difficulty.bossArmRest(2)).toBe(4);
+      expect(Difficulty.bossArmRest(3)).toBe(3);
+      expect(Difficulty.bossArmRest(4)).toBe(2);
+    });
+
+    it('ループ5以上でも2を下回らない', () => {
+      expect(Difficulty.bossArmRest(5)).toBe(2);
+      expect(Difficulty.bossArmRest(10)).toBe(2);
+    });
+  });
+
+  // ── grassGoal / grassEnemyMix ────────────────────────
+
+  describe('grassGoal - ステージ2の目標キル数', () => {
+    it('ループ1で14', () => {
+      expect(Difficulty.grassGoal(1)).toBe(14);
+    });
+
+    it('ループ数に比例して増加する', () => {
+      expect(Difficulty.grassGoal(2)).toBe(18);
+      expect(Difficulty.grassGoal(3)).toBe(22);
+    });
+  });
+
+  describe('grassEnemyMix - ステージ2の敵構成', () => {
+    it('ループ1ではシフターのみ（ダッシャーなし）', () => {
+      const mix = Difficulty.grassEnemyMix(1);
+      expect(mix.shifter).toBe(0.15);
+      expect(mix.dasher).toBe(0);
+    });
+
+    it('ループ2でダッシャーが登場する', () => {
+      const mix = Difficulty.grassEnemyMix(2);
+      expect(mix.shifter).toBe(0.25);
+      expect(mix.dasher).toBe(0.3);
+    });
+
+    it('ループ3以降で最大確率になる', () => {
+      const mix = Difficulty.grassEnemyMix(3);
+      expect(mix.shifter).toBe(0.3);
+      expect(mix.dasher).toBe(0.45);
+    });
+
+    it('ループ5以降もループ3と同じ値', () => {
+      const mix = Difficulty.grassEnemyMix(5);
+      expect(mix).toEqual({ shifter: 0.3, dasher: 0.45 });
+    });
+  });
+
+  // ── cageMax ──────────────────────────────────────────
+
+  describe('cageMax - ケージ進捗上限', () => {
+    it('ループ1で65', () => {
+      expect(Difficulty.cageMax(1)).toBe(65);
+    });
+
+    it('ループ数に比例して増加する', () => {
+      expect(Difficulty.cageMax(2)).toBe(80);
+      expect(Difficulty.cageMax(3)).toBe(95);
+    });
+  });
+
+  // ── isTrueEnding ─────────────────────────────────────
+
+  describe('isTrueEnding - 真エンディング判定', () => {
+    it('ループ1-2ではfalse', () => {
+      expect(Difficulty.isTrueEnding(1)).toBe(false);
+      expect(Difficulty.isTrueEnding(2)).toBe(false);
+    });
+
+    it('ループ3以上でtrue', () => {
+      expect(Difficulty.isTrueEnding(3)).toBe(true);
+      expect(Difficulty.isTrueEnding(5)).toBe(true);
+    });
+  });
+
+  // ── bossShields ──────────────────────────────────────
+
+  describe('bossShields - ボスシールド数', () => {
+    it('獲得0で1（ベース）', () => {
+      expect(Difficulty.bossShields(0)).toBe(1);
+    });
+
+    it('獲得数に応じて増加する', () => {
+      expect(Difficulty.bossShields(1)).toBe(2);
+      expect(Difficulty.bossShields(3)).toBe(4);
+    });
+
+    it('上限5を超えない', () => {
+      expect(Difficulty.bossShields(4)).toBe(5);
+      expect(Difficulty.bossShields(10)).toBe(5);
+    });
+  });
+});

--- a/src/features/keys-and-arms/difficulty.ts
+++ b/src/features/keys-and-arms/difficulty.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+/**
+ * Keys & Arms - 難易度パラメータ
+ *
+ * engine.ts から抽出した純粋関数群。
+ * ゲームバランスに関する全パラメータを管理する。
+ */
+
+/** 値を範囲内にクランプ */
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+
+/** DbC アサーション（テスト時にはエラーを投げる） */
+const assert = (cond, msg = 'Assertion failed') => { if (!cond) throw new Error(msg); };
+
+export const Difficulty = {
+  /** Beat length in ticks for a given loop (lower = faster) */
+  beatLength(loop) {
+    assert(loop >= 1, 'loop must be >= 1');
+    if (loop <= 3) return Math.max(20, 34 - (loop - 1) * 7);
+    return Math.max(14, 20 - (loop - 3) * 2);
+  },
+
+  /** Hazard cycle period for cave traps/enemies. Floor = base - 3 */
+  hazardCycle(loop, base) {
+    assert(base >= 3, 'base period must be >= 3');
+    return Math.max(base - 3, base - loop);
+  },
+
+  /** Boss arm speed (beats per move) for a given loop */
+  bossArmSpeed(loop) { return loop <= 1 ? 3 : 2; },
+
+  /** Boss arm rest time for a given loop */
+  bossArmRest(loop) {
+    return [5, 4, 3, 2][clamp(loop - 1, 0, 3)];
+  },
+
+  /** Stage 2 enemy goal count */
+  grassGoal(loop) { return 10 + loop * 4; },
+
+  /** Stage 2 enemy composition probabilities → {shifterChance, dasherChance} */
+  grassEnemyMix(loop) {
+    if (loop === 1) return { shifter: .15, dasher: 0 };
+    if (loop === 2) return { shifter: .25, dasher: .3 };
+    return { shifter: .3, dasher: .45 };
+  },
+
+  /** Cage max progress for a given loop */
+  cageMax(loop) { return 50 + loop * 15; },
+
+  /** Is this loop the true ending? */
+  isTrueEnding(loop) { return loop >= 3; },
+
+  /** Shield count for boss stage: base 1 + earned from Stage 2 */
+  bossShields(earned) { return Math.min(5, 1 + earned); }
+};

--- a/src/features/keys-and-arms/engine.ts
+++ b/src/features/keys-and-arms/engine.ts
@@ -14,6 +14,10 @@ export interface Engine {
   handleKeyUp(key: string): void;
 }
 
+// Difficulty モジュールは difficulty.ts に分離済み
+// クロージャ内で使用するためインポート名を変更
+import { Difficulty as DifficultyModule } from './difficulty';
+
 export function createEngine(canvas: HTMLCanvasElement): Engine {
 
 
@@ -275,48 +279,9 @@ let earnedShields=0; // shields earned in Stage 2, carried to Stage 3
 /* ================================================================
    DIFFICULTY CONFIG — Pure functions, no side effects
    Open for extension: add new loops by extending the table
+   分離先: ./difficulty.ts
    ================================================================ */
-const Difficulty = {
-  /** Beat length in ticks for a given loop (lower = faster) */
-  beatLength(loop) {
-    assert(loop >= 1, 'loop must be >= 1');
-    if (loop <= 3) return Math.max(20, 34 - (loop - 1) * 7);
-    return Math.max(14, 20 - (loop - 3) * 2);
-  },
-
-  /** Hazard cycle period for cave traps/enemies. Floor = base - 3 */
-  hazardCycle(loop, base) {
-    assert(base >= 3, 'base period must be >= 3');
-    return Math.max(base - 3, base - loop);
-  },
-
-  /** Boss arm speed (beats per move) for a given loop */
-  bossArmSpeed(loop) { return loop <= 1 ? 3 : 2; },
-
-  /** Boss arm rest time for a given loop */
-  bossArmRest(loop) {
-    return [5, 4, 3, 2][clamp(loop - 1, 0, 3)];
-  },
-
-  /** Stage 2 enemy goal count */
-  grassGoal(loop) { return 10 + loop * 4; },
-
-  /** Stage 2 enemy composition probabilities → {shifterChance, dasherChance} */
-  grassEnemyMix(loop) {
-    if (loop === 1) return { shifter: .15, dasher: 0 };
-    if (loop === 2) return { shifter: .25, dasher: .3 };
-    return { shifter: .3, dasher: .45 };
-  },
-
-  /** Cage max progress for a given loop */
-  cageMax(loop) { return 50 + loop * 15; },
-
-  /** Is this loop the true ending? */
-  isTrueEnding(loop) { return loop >= 3; },
-
-  /** Shield count for boss stage: base 1 + earned from Stage 2 */
-  bossShields(earned) { return Math.min(5, 1 + earned); }
-};
+const Difficulty = DifficultyModule;
 /** BL() — current beat length. Delegates to pure Difficulty module. */
 function BL() { return Difficulty.beatLength(loop); }
 /** Standard 2-beat duration (damage invulnerability, counter cooldown, etc.) */

--- a/src/features/labyrinth-echo/LabyrinthEchoGame.tsx
+++ b/src/features/labyrinth-echo/LabyrinthEchoGame.tsx
@@ -2,6 +2,13 @@
 // @ts-nocheck
 import { useState, useCallback, useEffect, useRef, useMemo, Component } from "react";
 import { Storage, SAVE_KEY } from './storage';
+import {
+  invariant, CFG, DIFFICULTY, STATUS_META, UNLOCKS,
+  clamp, rand, shuffle, FX_MULT, FX_BOOL, FX_DEFAULTS,
+  computeFx, createPlayer, evalCond, resolveOutcome,
+  applyModifiers, applyToPlayer, computeDrain,
+  classifyImpact, computeProgress,
+} from './game-logic';
 
 // ╔══════════════════════════════════════════════════════════════╗
 // ║  迷宮の残響 — v6: Polish / Audio Toggle / Hints / QoL        ║
@@ -17,15 +24,7 @@ declare global {
 // ============================================================
 // §1. CONTRACTS & ERROR HANDLING
 // ============================================================
-
-/** Design-by-Contract assertion — throws on violation */
-const invariant = (cond, ctx, detail = "") => {
-  if (!cond) {
-    const msg = `[迷宮の残響] Invariant violation in ${ctx}${detail ? `: ${detail}` : ""}`;
-    console.error(msg);
-    throw new Error(msg);
-  }
-};
+// invariant は './game-logic' からインポート済み
 
 /** Safely execute a synchronous callback */
 const safeSync = (fn, ctx) => {
@@ -152,15 +151,7 @@ const AudioEngine = (() => {
 // ============================================================
 // §4. GAME CONFIGURATION (OCP: extend via data, not code)
 // ============================================================
-
-const CFG = Object.freeze({
-  EVENTS_PER_FLOOR: 3,
-  MAX_FLOOR: 5,
-  BASE_HP: 55,
-  BASE_MN: 35,
-  BASE_INF: 5,
-  BOSS_EVENT_ID: "e030",
-});
+// CFG, DIFFICULTY, STATUS_META, UNLOCKS は './game-logic' からインポート済み
 
 /** Floor metadata — names/descriptions/colors match original design */
 const FLOOR_META = Object.freeze({
@@ -178,28 +169,7 @@ const EVENT_TYPE = Object.freeze({
   rest:        { label: "安 息", colors: ["#4ade80", "rgba(74,222,128,0.08)",  "rgba(74,222,128,0.2)"]  },
 });
 
-const STATUS_META = Object.freeze({
-  "負傷": { colors: ["#f87171", "rgba(248,113,113,0.08)", "rgba(248,113,113,0.18)"], tick: null },
-  "混乱": { colors: ["#c084fc", "rgba(192,132,252,0.08)", "rgba(192,132,252,0.18)"], tick: null },
-  "出血": { colors: ["#fb7185", "rgba(251,113,133,0.08)", "rgba(251,113,133,0.18)"], tick: { hp: -5, mn: 0 } },
-  "恐怖": { colors: ["#a78bfa", "rgba(167,139,250,0.08)", "rgba(167,139,250,0.18)"], tick: { hp: 0, mn: -4 } },
-  "呪い": { colors: ["#fb923c", "rgba(251,146,60,0.08)",  "rgba(251,146,60,0.18)"],  tick: null },
-});
 
-const DIFFICULTY = Object.freeze([
-  { id: "easy",   name: "探索者", sub: "初心者向け", color: "#4ade80", icon: "🌿",
-    desc: "体力・精神にゆとりがあり、迷宮の侵蝕も穏やか。物語を楽しみたい方に。",
-    hpMod: 12, mnMod: 8, drainMod: 0, dmgMult: 0.8, kpDeath: 1, kpWin: 2 },
-  { id: "normal", name: "挑戦者", sub: "標準難度",   color: "#818cf8", icon: "⚔",
-    desc: "均衡の取れた難易度。判断力と運の両方が試される。",
-    hpMod: 0,  mnMod: 0,  drainMod: -1, dmgMult: 1, kpDeath: 1, kpWin: 3 },
-  { id: "hard",   name: "求道者", sub: "上級者向け", color: "#f59e0b", icon: "🔥",
-    desc: "初期値が低く侵蝕が激しい。知識と経験を総動員しなければ生還は困難。",
-    hpMod: -15, mnMod: -12, drainMod: -3, dmgMult: 1.35, kpDeath: 2, kpWin: 5 },
-  { id: "abyss",  name: "修羅",   sub: "最高難度",   color: "#ef4444", icon: "💀",
-    desc: "全てが致命的。一つの判断ミスが死に直結する。真の強者のみが挑む領域。",
-    hpMod: -25, mnMod: -20, drainMod: -5, dmgMult: 1.8, kpDeath: 3, kpWin: 8 },
-]);
 
 /** Canonical empty meta state — single source of truth for init and reset (DRY) */
 const FRESH_META = Object.freeze({
@@ -208,206 +178,13 @@ const FRESH_META = Object.freeze({
   lastRun: null, title: null,
 });
 
-const UNLOCKS = Object.freeze([
-  // ── 基本（BASIC: total cost ~130, always available） ──
-  { id: "u1",  name: "探索者の直感", desc: "初期情報値 +3",          cost: 3, icon: "◈",  cat: "basic", fx: { infoBonus: 3 } },
-  { id: "u2",  name: "鋼の心臓",     desc: "初期HP +5",             cost: 3, icon: "♥",  cat: "basic", fx: { hpBonus: 5 } },
-  { id: "u3",  name: "冷静沈着",     desc: "初期精神力 +4",         cost: 3, icon: "◎",  cat: "basic", fx: { mentalBonus: 4 } },
-  { id: "u4",  name: "古文書の知識", desc: "情報取得量 +10%",       cost: 6, icon: "✧",  cat: "basic", fx: { infoMult: 1.1 } },
-  { id: "u5",  name: "回復体質",     desc: "回復効果 +12%",         cost: 6, icon: "✦",  cat: "basic", fx: { healMult: 1.12 } },
-  { id: "u6",  name: "危機察知",     desc: "HP低下時、条件判定が緩和", cost: 8, icon: "⚡", cat: "basic", fx: { dangerSense: true } },
-  { id: "u7",  name: "精神防壁",     desc: "精神ダメージ -8%",      cost: 6, icon: "◉",  cat: "basic", fx: { mnReduce: 0.92 } },
-  { id: "u8",  name: "止血の知識",   desc: "出血ダメージ半減",       cost: 4, icon: "❋",  cat: "basic", fx: { bleedReduce: true } },
-  { id: "u9",  name: "鉄の体躯",     desc: "初期HP +8",             cost: 5, icon: "♦",  cat: "basic", fx: { hpBonus: 8 } },
-  { id: "u10", name: "瞑想の心得",   desc: "初期精神力 +6",         cost: 5, icon: "☯",  cat: "basic", fx: { mentalBonus: 6 } },
-  { id: "u11", name: "博識",         desc: "初期情報値 +5",         cost: 5, icon: "📖", cat: "basic", fx: { infoBonus: 5 } },
-  { id: "u12", name: "不屈の意志",   desc: "精神ドレイン無効化",     cost: 10, icon: "☀",  cat: "basic", fx: { drainImmune: true } },
-  { id: "u13", name: "頑強な肉体",   desc: "HPダメージ -5%",        cost: 8, icon: "🛡",  cat: "basic", fx: { hpReduce: 0.95 } },
-  { id: "u14", name: "迷宮の記憶",   desc: "情報取得量 +15%",       cost: 8, icon: "🔮", cat: "basic", fx: { infoMult: 1.15 } },
-  { id: "u15", name: "生存本能",     desc: "初期HP +12",            cost: 8, icon: "💪", cat: "basic", fx: { hpBonus: 12 } },
-  { id: "u16", name: "深淵の耐性",   desc: "初期精神力 +8",         cost: 7, icon: "🌙", cat: "basic", fx: { mentalBonus: 8 } },
-  { id: "u17", name: "解読者の目",   desc: "初期情報値 +6",         cost: 7, icon: "👁",  cat: "basic", fx: { infoBonus: 6 } },
-  { id: "u18", name: "応急手当",     desc: "回復効果 +15%（重複可）", cost: 8, icon: "💊", cat: "basic", fx: { healMult: 1.15 } },
-  { id: "u19", name: "鋼の精神",     desc: "精神ダメージ -12%（重複可）", cost: 10, icon: "🧠", cat: "basic", fx: { mnReduce: 0.88 } },
-  { id: "u20", name: "不死身の体",   desc: "HPダメージ -8%（重複可）",   cost: 10, icon: "⛊",  cat: "basic", fx: { hpReduce: 0.92 } },
-  // ── 特別（SPECIAL: 修羅クリア必須、高コスト） ──
-  { id: "u21", name: "二度目の命",   desc: "HP/精神が0になった時、一度だけ半分回復して復活", cost: 35, icon: "🔄", cat: "special", gate: "abyss", fx: { secondLife: true } },
-  { id: "u22", name: "呪い耐性",     desc: "呪い状態異常を完全無効化",   cost: 18, icon: "🛡",  cat: "special", gate: "abyss", fx: { curseImmune: true } },
-  { id: "u23", name: "連鎖の記憶",   desc: "連続イベントの発生確率が上昇", cost: 15, icon: "🔗", cat: "special", gate: "abyss", fx: { chainBoost: true } },
-  { id: "u24", name: "交渉術",       desc: "遭遇イベントの精神条件が緩和", cost: 18, icon: "🤝", cat: "special", gate: "abyss", fx: { negotiator: true } },
-  { id: "u25", name: "第六感",       desc: "精神低下時、精神条件判定を緩和", cost: 22, icon: "👁‍🗨", cat: "special", gate: "abyss", fx: { mentalSense: true } },
-  { id: "u26", name: "歴戦の傷",     desc: "初期HP +12、初期精神力 +10", cost: 28, icon: "⚔",  cat: "special", gate: "abyss", fx: { hpBonus: 12, mentalBonus: 10 } },
-  { id: "u27", name: "叡智の結晶",   desc: "初期情報値 +6、情報取得量 +10%", cost: 25, icon: "💎", cat: "special", gate: "abyss", fx: { infoBonus: 6, infoMult: 1.1 } },
-  { id: "u28", name: "全ダメージ軽減",desc: "HPダメージ -5%、精神ダメージ -5%", cost: 25, icon: "🌀", cat: "special", gate: "abyss", fx: { hpReduce: 0.95, mnReduce: 0.95 } },
-  { id: "u29", name: "迷宮の寵児",   desc: "全初期ステータス +5",    cost: 40, icon: "✨", cat: "special", gate: "abyss", fx: { hpBonus: 5, mentalBonus: 5, infoBonus: 5 } },
-  { id: "u30", name: "完全回復",     desc: "回復効果 +20%（重複可）", cost: 22, icon: "💚", cat: "special", gate: "abyss", fx: { healMult: 1.2 } },
-  // ── 難易度クリア報酬（TROPHY: 勲章的な微効果） ──
-  { id: "u31", name: "探索者の証",   desc: "全初期ステータス +1",    cost: 0, icon: "🌿", cat: "trophy", req: "easy",   fx: { hpBonus: 1, mentalBonus: 1, infoBonus: 1 } },
-  { id: "u32", name: "挑戦者の証",   desc: "回復効果 +5%、情報取得量 +5%", cost: 0, icon: "⚔",  cat: "trophy", req: "normal", fx: { healMult: 1.05, infoMult: 1.05 } },
-  { id: "u33", name: "求道者の証",   desc: "全ステータス +2、HPダメージ -2%", cost: 0, icon: "🔥", cat: "trophy", req: "hard",   fx: { hpBonus: 2, mentalBonus: 2, infoBonus: 2, hpReduce: 0.98 } },
-  { id: "u34", name: "修羅の証",     desc: "全ステータス +3、全ダメージ -3%", cost: 0, icon: "💀", cat: "trophy", req: "abyss", fx: { hpBonus: 3, mentalBonus: 3, infoBonus: 3, hpReduce: 0.97, mnReduce: 0.97 } },
-  { id: "u35", name: "完全制覇の印", desc: "全ステータス +5、回復 +8%、情報 +8%", cost: 0, icon: "👑", cat: "trophy", req: "abyss_perfect", fx: { hpBonus: 5, mentalBonus: 5, infoBonus: 5, healMult: 1.08, infoMult: 1.08 } },
-  // ── 実績解放（ACHIEVEMENT: 条件厳格化、微効果） ──
-  { id: "u36", name: "百戦錬磨",     desc: "全初期ステータス +2",    cost: 0, icon: "🏅", cat: "achieve", achReq: (m) => m.runs >= 20,   achDesc: "20回探索する", fx: { hpBonus: 2, mentalBonus: 2, infoBonus: 2 } },
-  { id: "u37", name: "生還の達人",   desc: "回復効果 +8%、精神ダメージ -3%", cost: 0, icon: "🏆", cat: "achieve", achReq: (m) => m.escapes >= 8, achDesc: "8回生還する", fx: { healMult: 1.08, mnReduce: 0.97 } },
-  { id: "u38", name: "博覧強記",     desc: "初期情報値 +3、情報取得量 +8%", cost: 0, icon: "📚", cat: "achieve", achReq: (m) => m.totalEvents >= 80, achDesc: "累計80イベントをクリアする", fx: { infoBonus: 3, infoMult: 1.08 } },
-  { id: "u39", name: "死線を越えて", desc: "全ダメージ -3%",          cost: 0, icon: "☠",  cat: "achieve", achReq: (m) => (m.totalDeaths ?? 0) >= 15, achDesc: "15回死亡する", fx: { hpReduce: 0.97, mnReduce: 0.97 } },
-  { id: "u40", name: "エンディングコレクター", desc: "全初期ステータス +3", cost: 0, icon: "🎭", cat: "achieve", achReq: (m) => (m.endings?.length ?? 0) >= 8, achDesc: "8種類のEDを見る", fx: { hpBonus: 3, mentalBonus: 3, infoBonus: 3 } },
-]);
 // ============================================================
 // §5. PURE GAME LOGIC (no side effects, no React)
 // ============================================================
-
-const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
-const rand  = (a, b) => Math.floor(Math.random() * (b - a + 1)) + a;
-const shuffle = (arr) => {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [a[i], a[j]] = [a[j], a[i]]; }
-  return a;
-};
-
-/** FX key classification for merge strategy */
-const FX_MULT = new Set(["infoMult", "healMult", "mnReduce", "hpReduce"]);
-const FX_BOOL = new Set(["dangerSense", "bleedReduce", "drainImmune", "curseImmune", "secondLife", "chainBoost", "negotiator", "mentalSense"]);
-const FX_DEFAULTS = Object.freeze({ hpBonus: 0, mentalBonus: 0, infoBonus: 0, infoMult: 1, healMult: 1, dangerSense: false, mnReduce: 1, bleedReduce: false, drainImmune: false, hpReduce: 1, curseImmune: false, secondLife: false, chainBoost: false, negotiator: false, mentalSense: false });
-
-/**
- * Merge all unlock effects into a single FX object.
- * @pre  each id in unlockIds exists in UNLOCKS
- * @post returned object has every key in FX_DEFAULTS
- */
-const computeFx = (unlockIds) => {
-  const fx = { ...FX_DEFAULTS };
-  for (const uid of unlockIds) {
-    const def = UNLOCKS.find(u => u.id === uid);
-    if (!def?.fx) continue;
-    for (const [k, v] of Object.entries(def.fx)) {
-      if (FX_MULT.has(k))      fx[k] *= v;
-      else if (FX_BOOL.has(k)) fx[k] = v;
-      else                      fx[k] += v;
-    }
-  }
-  return fx;
-};
-
-/**
- * Create initial player state for a new run.
- * @pre  diff != null && fx != null
- * @post hp > 0 && mn > 0
- */
-const createPlayer = (diff, fx) => {
-  invariant(diff != null, "createPlayer", "diff is required");
-  invariant(fx != null, "createPlayer", "fx is required");
-  const hp = CFG.BASE_HP + fx.hpBonus + diff.hpMod;
-  const mn = CFG.BASE_MN + fx.mentalBonus + diff.mnMod;
-  return { hp, maxHp: hp, mn, maxMn: mn, inf: CFG.BASE_INF + fx.infoBonus, st: [] };
-};
-
-/**
- * Evaluate a condition string against player state.
- * @param cond — "default" | "status:X" | "hp>N" | "mn>N" | "inf>N"
- */
-const evalCond = (cond, player, fx) => {
-  if (cond === "default") return true;
-  if (cond.startsWith("status:")) return player.st.includes(cond.slice(7));
-  if (cond.startsWith("hp>")) {
-    const t = parseInt(cond.slice(3), 10);
-    return ((fx.dangerSense && player.hp < 30) ? player.hp + 20 : player.hp) > t;
-  }
-  if (cond.startsWith("hp<"))  return player.hp  < parseInt(cond.slice(3), 10);
-  if (cond.startsWith("mn>")) {
-    const t = parseInt(cond.slice(3), 10);
-    let mn = player.mn;
-    if (fx.negotiator)  mn += 8;  // 交渉術
-    if (fx.mentalSense && player.mn < 25) mn += 15; // 第六感
-    return mn > t;
-  }
-  if (cond.startsWith("mn<"))  return player.mn  < parseInt(cond.slice(3), 10);
-  if (cond.startsWith("inf>")) return player.inf > parseInt(cond.slice(4), 10);
-  if (cond.startsWith("inf<")) return player.inf < parseInt(cond.slice(4), 10);
-  console.warn(`[evalCond] Unknown format: "${cond}"`);
-  return true;
-};
-
-/**
- * Resolve which outcome applies for a choice.
- * @pre choice.o is a non-empty array
- */
-const resolveOutcome = (choice, player, fx) => {
-  invariant(choice?.o?.length > 0, "resolveOutcome", "choice must have outcomes");
-  for (const o of choice.o) {
-    if (o.c !== "default" && evalCond(o.c, player, fx)) return o;
-  }
-  return choice.o.find(o => o.c === "default") ?? choice.o[0];
-};
-
-/**
- * Apply fx/diff modifiers to raw outcome values. Pure.
- * @returns { hp, mn, inf }
- */
-const applyModifiers = (outcome, fx, diff, playerStatuses) => {
-  let hp = outcome.hp ?? 0, mn = outcome.mn ?? 0, inf = outcome.inf ?? 0;
-  if (hp > 0) hp = Math.round(hp * fx.healMult);
-  if (hp < 0) hp = Math.round(hp * fx.hpReduce);
-  if (diff?.dmgMult !== 1) {
-    if (hp < 0) hp = Math.round(hp * diff.dmgMult);
-    if (mn < 0) mn = Math.round(mn * diff.dmgMult);
-  }
-  if (inf > 0) inf = Math.round(inf * fx.infoMult);
-  if (mn < 0)  mn = Math.round(mn * fx.mnReduce);
-  if (playerStatuses.includes("呪い") && inf > 0) inf = Math.round(inf * 0.5);
-  return { hp, mn, inf };
-};
-
-/**
- * Apply stat changes + status flag to player. Pure.
- */
-const applyToPlayer = (player, { hp, mn, inf }, flag) => {
-  let sts = [...player.st];
-  if (flag?.startsWith("add:"))    { const s = flag.slice(4); if (!sts.includes(s)) sts.push(s); }
-  if (flag?.startsWith("remove:")) { sts = sts.filter(s => s !== flag.slice(7)); }
-  return {
-    ...player,
-    hp:  clamp(player.hp + hp, 0, player.maxHp),
-    mn:  clamp(player.mn + mn, 0, player.maxMn),
-    inf: Math.max(0, player.inf + inf),
-    st:  sts,
-  };
-};
-
-/**
- * Compute per-turn drain (labyrinth + status ticks). Pure.
- * @returns { player, drain: {hp,mn}|null }
- */
-const computeDrain = (player, fx, diff) => {
-  const base = diff ? diff.drainMod : -1;
-  let hpD = 0, mnD = fx.drainImmune ? 0 : base;
-  for (const s of player.st) {
-    const tick = STATUS_META[s]?.tick;
-    if (!tick) continue;
-    let h = tick.hp;
-    const m = tick.mn;
-    if (s === "出血" && fx.bleedReduce) h = Math.round(h * 0.5);
-    hpD += h; mnD += m;
-  }
-  if (hpD === 0 && mnD === 0) return { player, drain: null };
-  return {
-    player: { ...player, hp: clamp(player.hp + hpD, 0, player.maxHp), mn: clamp(player.mn + mnD, 0, player.maxMn) },
-    drain: { hp: hpD, mn: mnD },
-  };
-};
-
-/** Classify impact for audio/visual feedback */
-const classifyImpact = (hp, mn) => {
-  if (hp < -15) return "bigDmg";
-  if (hp < 0 || mn < -10) return "dmg";
-  if (hp > 0) return "heal";
-  return null;
-};
-
-/** Overall progress 0-100 */
-const computeProgress = (floor, step) =>
-  Math.min(100, ((floor - 1) * CFG.EVENTS_PER_FLOOR + step) / (CFG.MAX_FLOOR * CFG.EVENTS_PER_FLOOR) * 100);
+// clamp, rand, shuffle, FX_MULT, FX_BOOL, FX_DEFAULTS,
+// computeFx, createPlayer, evalCond, resolveOutcome,
+// applyModifiers, applyToPlayer, computeDrain,
+// classifyImpact, computeProgress は './game-logic' からインポート済み
 
 /** Vignette visual effect from player health */
 const computeVignette = (player) => {

--- a/src/features/labyrinth-echo/__tests__/game-logic.test.ts
+++ b/src/features/labyrinth-echo/__tests__/game-logic.test.ts
@@ -1,0 +1,395 @@
+// @ts-nocheck
+/**
+ * 迷宮の残響 - ゲームロジックのテスト
+ */
+import {
+  CFG, DIFFICULTY, FX_DEFAULTS,
+  computeFx, createPlayer, evalCond, resolveOutcome,
+  applyModifiers, applyToPlayer, computeDrain,
+  classifyImpact, computeProgress, clamp,
+} from '../game-logic';
+
+/** テスト用デフォルトFX */
+const defaultFx = () => ({ ...FX_DEFAULTS });
+
+/** テスト用プレイヤー生成ヘルパー */
+const makePlayer = (overrides = {}) => ({
+  hp: 55, maxHp: 55, mn: 35, maxMn: 35, inf: 5, st: [],
+  ...overrides,
+});
+
+/** テスト用難易度（normal） */
+const normalDiff = DIFFICULTY.find(d => d.id === 'normal');
+const easyDiff = DIFFICULTY.find(d => d.id === 'easy');
+const hardDiff = DIFFICULTY.find(d => d.id === 'hard');
+
+describe('迷宮の残響 - ゲームロジック', () => {
+  // ── computeFx ────────────────────────────────────────
+
+  describe('computeFx - アンロック効果の合算', () => {
+    it('空リストではデフォルト値を返す', () => {
+      const fx = computeFx([]);
+      expect(fx).toEqual(FX_DEFAULTS);
+    });
+
+    it('加算型FXは足し算で合算する', () => {
+      // u1: infoBonus:3, u2: hpBonus:5
+      const fx = computeFx(['u1', 'u2']);
+      expect(fx.infoBonus).toBe(3);
+      expect(fx.hpBonus).toBe(5);
+    });
+
+    it('乗算型FXは掛け算で合算する', () => {
+      // u4: infoMult:1.1, u14: infoMult:1.15
+      const fx = computeFx(['u4', 'u14']);
+      expect(fx.infoMult).toBeCloseTo(1.1 * 1.15, 5);
+    });
+
+    it('ブール型FXはtrueで上書きする', () => {
+      // u6: dangerSense:true
+      const fx = computeFx(['u6']);
+      expect(fx.dangerSense).toBe(true);
+    });
+
+    it('複合FXは各型で正しく処理される', () => {
+      // u26: hpBonus:12, mentalBonus:10 (加算型2つ)
+      const fx = computeFx(['u26']);
+      expect(fx.hpBonus).toBe(12);
+      expect(fx.mentalBonus).toBe(10);
+    });
+
+    it('存在しないIDは無視される', () => {
+      const fx = computeFx(['nonexistent']);
+      expect(fx).toEqual(FX_DEFAULTS);
+    });
+  });
+
+  // ── createPlayer ─────────────────────────────────────
+
+  describe('createPlayer - プレイヤー初期状態', () => {
+    it('normal難易度でデフォルトFXの初期値が正しい', () => {
+      const fx = defaultFx();
+      const player = createPlayer(normalDiff, fx);
+      expect(player.hp).toBe(CFG.BASE_HP + normalDiff.hpMod);
+      expect(player.mn).toBe(CFG.BASE_MN + normalDiff.mnMod);
+      expect(player.inf).toBe(CFG.BASE_INF);
+      expect(player.st).toEqual([]);
+    });
+
+    it('easy難易度ではHP/MNが高い', () => {
+      const fx = defaultFx();
+      const player = createPlayer(easyDiff, fx);
+      expect(player.hp).toBe(CFG.BASE_HP + easyDiff.hpMod);
+      expect(player.mn).toBe(CFG.BASE_MN + easyDiff.mnMod);
+    });
+
+    it('hard難易度ではHP/MNが低い', () => {
+      const fx = defaultFx();
+      const player = createPlayer(hardDiff, fx);
+      expect(player.hp).toBe(CFG.BASE_HP + hardDiff.hpMod);
+      expect(player.mn).toBe(CFG.BASE_MN + hardDiff.mnMod);
+    });
+
+    it('アンロック効果が反映される', () => {
+      const fx = { ...defaultFx(), hpBonus: 10, mentalBonus: 5, infoBonus: 3 };
+      const player = createPlayer(normalDiff, fx);
+      expect(player.hp).toBe(CFG.BASE_HP + 10 + normalDiff.hpMod);
+      expect(player.mn).toBe(CFG.BASE_MN + 5 + normalDiff.mnMod);
+      expect(player.inf).toBe(CFG.BASE_INF + 3);
+    });
+
+    it('maxHpとmaxMnがhpとmnに一致する', () => {
+      const player = createPlayer(normalDiff, defaultFx());
+      expect(player.maxHp).toBe(player.hp);
+      expect(player.maxMn).toBe(player.mn);
+    });
+  });
+
+  // ── evalCond ─────────────────────────────────────────
+
+  describe('evalCond - 条件評価', () => {
+    it('"default"条件は常にtrueを返す', () => {
+      expect(evalCond('default', makePlayer(), defaultFx())).toBe(true);
+    });
+
+    it('"status:呪い"条件: 呪い状態ならtrue', () => {
+      const player = makePlayer({ st: ['呪い'] });
+      expect(evalCond('status:呪い', player, defaultFx())).toBe(true);
+    });
+
+    it('"status:呪い"条件: 呪い状態でなければfalse', () => {
+      const player = makePlayer({ st: [] });
+      expect(evalCond('status:呪い', player, defaultFx())).toBe(false);
+    });
+
+    it('"hp>30"条件: HPが31以上ならtrue', () => {
+      expect(evalCond('hp>30', makePlayer({ hp: 31 }), defaultFx())).toBe(true);
+      expect(evalCond('hp>30', makePlayer({ hp: 30 }), defaultFx())).toBe(false);
+    });
+
+    it('dangerSenseによるHP判定ボーナス: HP<30なら+20', () => {
+      const fx = { ...defaultFx(), dangerSense: true };
+      // HP=20, 閾値30 → 20+20=40 > 30 → true
+      expect(evalCond('hp>30', makePlayer({ hp: 20 }), fx)).toBe(true);
+      // HP=40, 閾値30 → dangerSense不適用(HP>=30) → 40 > 30 → true
+      expect(evalCond('hp>30', makePlayer({ hp: 40 }), fx)).toBe(true);
+    });
+
+    it('"mn>20"条件: 精神力が21以上ならtrue', () => {
+      expect(evalCond('mn>20', makePlayer({ mn: 21 }), defaultFx())).toBe(true);
+      expect(evalCond('mn>20', makePlayer({ mn: 20 }), defaultFx())).toBe(false);
+    });
+
+    it('交渉術によるMN判定ボーナス: +8', () => {
+      const fx = { ...defaultFx(), negotiator: true };
+      // mn=15, 閾値20 → 15+8=23 > 20 → true
+      expect(evalCond('mn>20', makePlayer({ mn: 15 }), fx)).toBe(true);
+    });
+
+    it('第六感によるMN判定ボーナス: MN<25なら+15', () => {
+      const fx = { ...defaultFx(), mentalSense: true };
+      // mn=10, 閾値20 → 10+15=25 > 20 → true
+      expect(evalCond('mn>20', makePlayer({ mn: 10 }), fx)).toBe(true);
+    });
+
+    it('"inf>5"条件: 情報値が6以上ならtrue', () => {
+      expect(evalCond('inf>5', makePlayer({ inf: 6 }), defaultFx())).toBe(true);
+      expect(evalCond('inf>5', makePlayer({ inf: 5 }), defaultFx())).toBe(false);
+    });
+
+    it('"hp<20"条件: HPが20未満ならtrue', () => {
+      expect(evalCond('hp<20', makePlayer({ hp: 19 }), defaultFx())).toBe(true);
+      expect(evalCond('hp<20', makePlayer({ hp: 20 }), defaultFx())).toBe(false);
+    });
+  });
+
+  // ── applyModifiers ───────────────────────────────────
+
+  describe('applyModifiers - 修正値の適用', () => {
+    it('healMultによる回復倍率が適用される', () => {
+      const fx = { ...defaultFx(), healMult: 1.5 };
+      const result = applyModifiers({ hp: 10, mn: 0, inf: 0 }, fx, normalDiff, []);
+      expect(result.hp).toBe(Math.round(10 * 1.5));
+    });
+
+    it('hpReduceによるダメージ軽減が適用される', () => {
+      const fx = { ...defaultFx(), hpReduce: 0.9 };
+      const result = applyModifiers({ hp: -10, mn: 0, inf: 0 }, fx, normalDiff, []);
+      expect(result.hp).toBe(Math.round(-10 * 0.9));
+    });
+
+    it('難易度倍率のダメージ適用（hard）', () => {
+      const fx = defaultFx();
+      const result = applyModifiers({ hp: -10, mn: -5, inf: 0 }, fx, hardDiff, []);
+      expect(result.hp).toBe(Math.round(Math.round(-10 * 1) * hardDiff.dmgMult));
+      expect(result.mn).toBe(Math.round(Math.round(-5 * hardDiff.dmgMult) * 1));
+    });
+
+    it('infoMultによる情報取得量の倍率が適用される', () => {
+      const fx = { ...defaultFx(), infoMult: 1.2 };
+      const result = applyModifiers({ hp: 0, mn: 0, inf: 10 }, fx, normalDiff, []);
+      expect(result.inf).toBe(Math.round(10 * 1.2));
+    });
+
+    it('呪い状態時の情報取得量が半減する', () => {
+      const fx = defaultFx();
+      const result = applyModifiers({ hp: 0, mn: 0, inf: 10 }, fx, normalDiff, ['呪い']);
+      expect(result.inf).toBe(Math.round(10 * 0.5));
+    });
+
+    it('mnReduceによる精神ダメージ軽減が適用される', () => {
+      const fx = { ...defaultFx(), mnReduce: 0.8 };
+      const result = applyModifiers({ hp: 0, mn: -10, inf: 0 }, fx, normalDiff, []);
+      expect(result.mn).toBe(Math.round(-10 * 0.8));
+    });
+  });
+
+  // ── applyToPlayer ────────────────────────────────────
+
+  describe('applyToPlayer - プレイヤー状態更新', () => {
+    it('HP/MN/情報値の加算が正しく適用される', () => {
+      const player = makePlayer({ hp: 30, mn: 20, inf: 5 });
+      const updated = applyToPlayer(player, { hp: 10, mn: 5, inf: 3 }, null);
+      expect(updated.hp).toBe(40);
+      expect(updated.mn).toBe(25);
+      expect(updated.inf).toBe(8);
+    });
+
+    it('HPは0〜maxHpにクランプされる', () => {
+      const player = makePlayer({ hp: 50, maxHp: 55 });
+      const updated = applyToPlayer(player, { hp: 20, mn: 0, inf: 0 }, null);
+      expect(updated.hp).toBe(55);
+    });
+
+    it('HPが0以下にならない', () => {
+      const player = makePlayer({ hp: 5 });
+      const updated = applyToPlayer(player, { hp: -20, mn: 0, inf: 0 }, null);
+      expect(updated.hp).toBe(0);
+    });
+
+    it('"add:呪い"フラグで呪い状態が追加される', () => {
+      const player = makePlayer();
+      const updated = applyToPlayer(player, { hp: 0, mn: 0, inf: 0 }, 'add:呪い');
+      expect(updated.st).toContain('呪い');
+    });
+
+    it('既に持っている状態異常は重複追加されない', () => {
+      const player = makePlayer({ st: ['呪い'] });
+      const updated = applyToPlayer(player, { hp: 0, mn: 0, inf: 0 }, 'add:呪い');
+      expect(updated.st.filter(s => s === '呪い')).toHaveLength(1);
+    });
+
+    it('"remove:呪い"フラグで呪い状態が除去される', () => {
+      const player = makePlayer({ st: ['呪い', '出血'] });
+      const updated = applyToPlayer(player, { hp: 0, mn: 0, inf: 0 }, 'remove:呪い');
+      expect(updated.st).not.toContain('呪い');
+      expect(updated.st).toContain('出血');
+    });
+
+    it('元のプレイヤーオブジェクトは変更されない', () => {
+      const player = makePlayer();
+      const originalHp = player.hp;
+      applyToPlayer(player, { hp: -10, mn: 0, inf: 0 }, null);
+      expect(player.hp).toBe(originalHp);
+    });
+  });
+
+  // ── computeDrain ─────────────────────────────────────
+
+  describe('computeDrain - ドレイン計算', () => {
+    it('状態異常なしかつドレイン免疫時はドレインなし', () => {
+      const fx = { ...defaultFx(), drainImmune: true };
+      const player = makePlayer();
+      const { drain } = computeDrain(player, fx, normalDiff);
+      expect(drain).toBeNull();
+    });
+
+    it('ドレイン免疫でない場合は精神ドレインが発生する', () => {
+      const fx = defaultFx();
+      const player = makePlayer();
+      const { drain } = computeDrain(player, fx, normalDiff);
+      // normalDiff.drainMod = -1
+      expect(drain).not.toBeNull();
+      expect(drain.mn).toBe(-1);
+    });
+
+    it('出血ダメージが適用される', () => {
+      const fx = { ...defaultFx(), drainImmune: true };
+      const player = makePlayer({ st: ['出血'] });
+      const { drain } = computeDrain(player, fx, normalDiff);
+      expect(drain).not.toBeNull();
+      expect(drain.hp).toBe(-5); // 出血tick: hp=-5
+    });
+
+    it('bleedReduceで出血ダメージが半減する', () => {
+      const fx = { ...defaultFx(), drainImmune: true, bleedReduce: true };
+      const player = makePlayer({ st: ['出血'] });
+      const { drain } = computeDrain(player, fx, normalDiff);
+      expect(drain.hp).toBe(Math.round(-5 * 0.5));
+    });
+
+    it('恐怖による精神ダメージが適用される', () => {
+      const fx = { ...defaultFx(), drainImmune: true };
+      const player = makePlayer({ st: ['恐怖'] });
+      const { drain } = computeDrain(player, fx, normalDiff);
+      expect(drain.mn).toBe(-4); // 恐怖tick: mn=-4
+    });
+
+    it('ドレイン後のプレイヤーHP/MNがクランプされる', () => {
+      const fx = defaultFx();
+      const player = makePlayer({ hp: 2, mn: 1, st: ['出血'] });
+      const { player: updated } = computeDrain(player, fx, normalDiff);
+      expect(updated.hp).toBeGreaterThanOrEqual(0);
+      expect(updated.mn).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ── classifyImpact ───────────────────────────────────
+
+  describe('classifyImpact - インパクト分類', () => {
+    it('HP -16以下で"bigDmg"を返す', () => {
+      expect(classifyImpact(-16, 0)).toBe('bigDmg');
+      expect(classifyImpact(-20, 0)).toBe('bigDmg');
+    });
+
+    it('HP -1〜-15で"dmg"を返す', () => {
+      expect(classifyImpact(-1, 0)).toBe('dmg');
+      expect(classifyImpact(-15, 0)).toBe('dmg');
+    });
+
+    it('MN -11以下で"dmg"を返す', () => {
+      expect(classifyImpact(0, -11)).toBe('dmg');
+    });
+
+    it('HP回復で"heal"を返す', () => {
+      expect(classifyImpact(5, 0)).toBe('heal');
+    });
+
+    it('変化なしでnullを返す', () => {
+      expect(classifyImpact(0, 0)).toBeNull();
+      expect(classifyImpact(0, -5)).toBeNull();
+    });
+  });
+
+  // ── computeProgress ──────────────────────────────────
+
+  describe('computeProgress - 進行度計算', () => {
+    it('最初の階・ステップ0で0%', () => {
+      expect(computeProgress(1, 0)).toBe(0);
+    });
+
+    it('最終階・最終ステップで100%', () => {
+      const progress = computeProgress(CFG.MAX_FLOOR, CFG.EVENTS_PER_FLOOR);
+      expect(progress).toBeCloseTo(100, 0);
+    });
+
+    it('途中の進行度が正しく計算される', () => {
+      // floor=2, step=1 → ((2-1)*3+1)/(5*3)*100 = 4/15*100 ≈ 26.67
+      const progress = computeProgress(2, 1);
+      expect(progress).toBeCloseTo(26.67, 0);
+    });
+
+    it('100%を超えない', () => {
+      expect(computeProgress(10, 10)).toBe(100);
+    });
+  });
+
+  // ── resolveOutcome ───────────────────────────────────
+
+  describe('resolveOutcome - 結果解決', () => {
+    it('条件一致するアウトカムを返す', () => {
+      const choice = {
+        o: [
+          { c: 'hp>50', text: 'HP高い' },
+          { c: 'default', text: 'デフォルト' },
+        ],
+      };
+      const player = makePlayer({ hp: 55 });
+      const result = resolveOutcome(choice, player, defaultFx());
+      expect(result.text).toBe('HP高い');
+    });
+
+    it('条件不一致の場合はdefaultを返す', () => {
+      const choice = {
+        o: [
+          { c: 'hp>80', text: 'HP超高い' },
+          { c: 'default', text: 'デフォルト' },
+        ],
+      };
+      const player = makePlayer({ hp: 30 });
+      const result = resolveOutcome(choice, player, defaultFx());
+      expect(result.text).toBe('デフォルト');
+    });
+
+    it('defaultがない場合は最初のアウトカムを返す', () => {
+      const choice = {
+        o: [
+          { c: 'hp>100', text: '条件不一致' },
+        ],
+      };
+      const player = makePlayer({ hp: 30 });
+      const result = resolveOutcome(choice, player, defaultFx());
+      expect(result.text).toBe('条件不一致');
+    });
+  });
+});

--- a/src/features/labyrinth-echo/__tests__/storage.test.ts
+++ b/src/features/labyrinth-echo/__tests__/storage.test.ts
@@ -1,0 +1,62 @@
+/**
+ * 迷宮の残響 - ストレージのテスト
+ */
+import { Storage, SAVE_KEY } from '../storage';
+
+describe('迷宮の残響 - ストレージ', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('Storage.save - データの保存', () => {
+    it('データを正しくlocalStorageに保存する', async () => {
+      const data = { runs: 5, kp: 10 };
+      await Storage.save(data);
+      const stored = localStorage.getItem(SAVE_KEY);
+      expect(JSON.parse(stored!)).toEqual(data);
+    });
+  });
+
+  describe('Storage.load - データの読み込み', () => {
+    it('保存済みデータを正しく読み込む', async () => {
+      const data = { runs: 3, escapes: 1 };
+      localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+      const loaded = await Storage.load();
+      expect(loaded).toEqual(data);
+    });
+
+    it('データがない場合はnullを返す', async () => {
+      const loaded = await Storage.load();
+      expect(loaded).toBeNull();
+    });
+
+    it('不正なJSONの場合はnullを返す', async () => {
+      localStorage.setItem(SAVE_KEY, '{invalid json');
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const loaded = await Storage.load();
+      expect(loaded).toBeNull();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('SAVE_KEY - セーブキー', () => {
+    it('正しいキー名が定義されている', () => {
+      expect(SAVE_KEY).toBe('labyrinth-echo-save');
+    });
+  });
+
+  describe('保存と読み込みの往復', () => {
+    it('保存したデータを正しく復元できる', async () => {
+      const data = {
+        runs: 10,
+        escapes: 5,
+        kp: 25,
+        unlocked: ['u1', 'u2'],
+        bestFl: 4,
+      };
+      await Storage.save(data);
+      const loaded = await Storage.load();
+      expect(loaded).toEqual(data);
+    });
+  });
+});

--- a/src/features/labyrinth-echo/game-logic.ts
+++ b/src/features/labyrinth-echo/game-logic.ts
@@ -1,0 +1,252 @@
+// @ts-nocheck
+/**
+ * 迷宮の残響 - ゲームロジック（純粋関数）
+ *
+ * LabyrinthEchoGame.tsx §4-§5 から抽出した状態非依存のロジック。
+ * テスト容易性と再利用性のために分離。
+ */
+
+// ── 契約（DbC） ──────────────────────────────────────
+
+/** Design-by-Contract assertion — throws on violation */
+export const invariant = (cond, ctx, detail = "") => {
+  if (!cond) {
+    const msg = `[迷宮の残響] Invariant violation in ${ctx}${detail ? `: ${detail}` : ""}`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+};
+
+// ── ゲーム設定 ────────────────────────────────────────
+
+export const CFG = Object.freeze({
+  EVENTS_PER_FLOOR: 3,
+  MAX_FLOOR: 5,
+  BASE_HP: 55,
+  BASE_MN: 35,
+  BASE_INF: 5,
+  BOSS_EVENT_ID: "e030",
+});
+
+export const DIFFICULTY = Object.freeze([
+  { id: "easy",   name: "探索者", sub: "初心者向け", color: "#4ade80", icon: "🌿",
+    desc: "体力・精神にゆとりがあり、迷宮の侵蝕も穏やか。物語を楽しみたい方に。",
+    hpMod: 12, mnMod: 8, drainMod: 0, dmgMult: 0.8, kpDeath: 1, kpWin: 2 },
+  { id: "normal", name: "挑戦者", sub: "標準難度",   color: "#818cf8", icon: "⚔",
+    desc: "均衡の取れた難易度。判断力と運の両方が試される。",
+    hpMod: 0,  mnMod: 0,  drainMod: -1, dmgMult: 1, kpDeath: 1, kpWin: 3 },
+  { id: "hard",   name: "求道者", sub: "上級者向け", color: "#f59e0b", icon: "🔥",
+    desc: "初期値が低く侵蝕が激しい。知識と経験を総動員しなければ生還は困難。",
+    hpMod: -15, mnMod: -12, drainMod: -3, dmgMult: 1.35, kpDeath: 2, kpWin: 5 },
+  { id: "abyss",  name: "修羅",   sub: "最高難度",   color: "#ef4444", icon: "💀",
+    desc: "全てが致命的。一つの判断ミスが死に直結する。真の強者のみが挑む領域。",
+    hpMod: -25, mnMod: -20, drainMod: -5, dmgMult: 1.8, kpDeath: 3, kpWin: 8 },
+]);
+
+export const STATUS_META = Object.freeze({
+  "負傷": { colors: ["#f87171", "rgba(248,113,113,0.08)", "rgba(248,113,113,0.18)"], tick: null },
+  "混乱": { colors: ["#c084fc", "rgba(192,132,252,0.08)", "rgba(192,132,252,0.18)"], tick: null },
+  "出血": { colors: ["#fb7185", "rgba(251,113,133,0.08)", "rgba(251,113,133,0.18)"], tick: { hp: -5, mn: 0 } },
+  "恐怖": { colors: ["#a78bfa", "rgba(167,139,250,0.08)", "rgba(167,139,250,0.18)"], tick: { hp: 0, mn: -4 } },
+  "呪い": { colors: ["#fb923c", "rgba(251,146,60,0.08)",  "rgba(251,146,60,0.18)"],  tick: null },
+});
+
+export const UNLOCKS = Object.freeze([
+  // ── 基本（BASIC: total cost ~130, always available） ──
+  { id: "u1",  name: "探索者の直感", desc: "初期情報値 +3",          cost: 3, icon: "◈",  cat: "basic", fx: { infoBonus: 3 } },
+  { id: "u2",  name: "鋼の心臓",     desc: "初期HP +5",             cost: 3, icon: "♥",  cat: "basic", fx: { hpBonus: 5 } },
+  { id: "u3",  name: "冷静沈着",     desc: "初期精神力 +4",         cost: 3, icon: "◎",  cat: "basic", fx: { mentalBonus: 4 } },
+  { id: "u4",  name: "古文書の知識", desc: "情報取得量 +10%",       cost: 6, icon: "✧",  cat: "basic", fx: { infoMult: 1.1 } },
+  { id: "u5",  name: "回復体質",     desc: "回復効果 +12%",         cost: 6, icon: "✦",  cat: "basic", fx: { healMult: 1.12 } },
+  { id: "u6",  name: "危機察知",     desc: "HP低下時、条件判定が緩和", cost: 8, icon: "⚡", cat: "basic", fx: { dangerSense: true } },
+  { id: "u7",  name: "精神防壁",     desc: "精神ダメージ -8%",      cost: 6, icon: "◉",  cat: "basic", fx: { mnReduce: 0.92 } },
+  { id: "u8",  name: "止血の知識",   desc: "出血ダメージ半減",       cost: 4, icon: "❋",  cat: "basic", fx: { bleedReduce: true } },
+  { id: "u9",  name: "鉄の体躯",     desc: "初期HP +8",             cost: 5, icon: "♦",  cat: "basic", fx: { hpBonus: 8 } },
+  { id: "u10", name: "瞑想の心得",   desc: "初期精神力 +6",         cost: 5, icon: "☯",  cat: "basic", fx: { mentalBonus: 6 } },
+  { id: "u11", name: "博識",         desc: "初期情報値 +5",         cost: 5, icon: "📖", cat: "basic", fx: { infoBonus: 5 } },
+  { id: "u12", name: "不屈の意志",   desc: "精神ドレイン無効化",     cost: 10, icon: "☀",  cat: "basic", fx: { drainImmune: true } },
+  { id: "u13", name: "頑強な肉体",   desc: "HPダメージ -5%",        cost: 8, icon: "🛡",  cat: "basic", fx: { hpReduce: 0.95 } },
+  { id: "u14", name: "迷宮の記憶",   desc: "情報取得量 +15%",       cost: 8, icon: "🔮", cat: "basic", fx: { infoMult: 1.15 } },
+  { id: "u15", name: "生存本能",     desc: "初期HP +12",            cost: 8, icon: "💪", cat: "basic", fx: { hpBonus: 12 } },
+  { id: "u16", name: "深淵の耐性",   desc: "初期精神力 +8",         cost: 7, icon: "🌙", cat: "basic", fx: { mentalBonus: 8 } },
+  { id: "u17", name: "解読者の目",   desc: "初期情報値 +6",         cost: 7, icon: "👁",  cat: "basic", fx: { infoBonus: 6 } },
+  { id: "u18", name: "応急手当",     desc: "回復効果 +15%（重複可）", cost: 8, icon: "💊", cat: "basic", fx: { healMult: 1.15 } },
+  { id: "u19", name: "鋼の精神",     desc: "精神ダメージ -12%（重複可）", cost: 10, icon: "🧠", cat: "basic", fx: { mnReduce: 0.88 } },
+  { id: "u20", name: "不死身の体",   desc: "HPダメージ -8%（重複可）",   cost: 10, icon: "⛊",  cat: "basic", fx: { hpReduce: 0.92 } },
+  // ── 特別（SPECIAL: 修羅クリア必須、高コスト） ──
+  { id: "u21", name: "二度目の命",   desc: "HP/精神が0になった時、一度だけ半分回復して復活", cost: 35, icon: "🔄", cat: "special", gate: "abyss", fx: { secondLife: true } },
+  { id: "u22", name: "呪い耐性",     desc: "呪い状態異常を完全無効化",   cost: 18, icon: "🛡",  cat: "special", gate: "abyss", fx: { curseImmune: true } },
+  { id: "u23", name: "連鎖の記憶",   desc: "連続イベントの発生確率が上昇", cost: 15, icon: "🔗", cat: "special", gate: "abyss", fx: { chainBoost: true } },
+  { id: "u24", name: "交渉術",       desc: "遭遇イベントの精神条件が緩和", cost: 18, icon: "🤝", cat: "special", gate: "abyss", fx: { negotiator: true } },
+  { id: "u25", name: "第六感",       desc: "精神低下時、精神条件判定を緩和", cost: 22, icon: "👁‍🗨", cat: "special", gate: "abyss", fx: { mentalSense: true } },
+  { id: "u26", name: "歴戦の傷",     desc: "初期HP +12、初期精神力 +10", cost: 28, icon: "⚔",  cat: "special", gate: "abyss", fx: { hpBonus: 12, mentalBonus: 10 } },
+  { id: "u27", name: "叡智の結晶",   desc: "初期情報値 +6、情報取得量 +10%", cost: 25, icon: "💎", cat: "special", gate: "abyss", fx: { infoBonus: 6, infoMult: 1.1 } },
+  { id: "u28", name: "全ダメージ軽減",desc: "HPダメージ -5%、精神ダメージ -5%", cost: 25, icon: "🌀", cat: "special", gate: "abyss", fx: { hpReduce: 0.95, mnReduce: 0.95 } },
+  { id: "u29", name: "迷宮の寵児",   desc: "全初期ステータス +5",    cost: 40, icon: "✨", cat: "special", gate: "abyss", fx: { hpBonus: 5, mentalBonus: 5, infoBonus: 5 } },
+  { id: "u30", name: "完全回復",     desc: "回復効果 +20%（重複可）", cost: 22, icon: "💚", cat: "special", gate: "abyss", fx: { healMult: 1.2 } },
+  // ── 難易度クリア報酬（TROPHY: 勲章的な微効果） ──
+  { id: "u31", name: "探索者の証",   desc: "全初期ステータス +1",    cost: 0, icon: "🌿", cat: "trophy", req: "easy",   fx: { hpBonus: 1, mentalBonus: 1, infoBonus: 1 } },
+  { id: "u32", name: "挑戦者の証",   desc: "回復効果 +5%、情報取得量 +5%", cost: 0, icon: "⚔",  cat: "trophy", req: "normal", fx: { healMult: 1.05, infoMult: 1.05 } },
+  { id: "u33", name: "求道者の証",   desc: "全ステータス +2、HPダメージ -2%", cost: 0, icon: "🔥", cat: "trophy", req: "hard",   fx: { hpBonus: 2, mentalBonus: 2, infoBonus: 2, hpReduce: 0.98 } },
+  { id: "u34", name: "修羅の証",     desc: "全ステータス +3、全ダメージ -3%", cost: 0, icon: "💀", cat: "trophy", req: "abyss", fx: { hpBonus: 3, mentalBonus: 3, infoBonus: 3, hpReduce: 0.97, mnReduce: 0.97 } },
+  { id: "u35", name: "完全制覇の印", desc: "全ステータス +5、回復 +8%、情報 +8%", cost: 0, icon: "👑", cat: "trophy", req: "abyss_perfect", fx: { hpBonus: 5, mentalBonus: 5, infoBonus: 5, healMult: 1.08, infoMult: 1.08 } },
+  // ── 実績解放（ACHIEVEMENT: 条件厳格化、微効果） ──
+  { id: "u36", name: "百戦錬磨",     desc: "全初期ステータス +2",    cost: 0, icon: "🏅", cat: "achieve", achReq: (m) => m.runs >= 20,   achDesc: "20回探索する", fx: { hpBonus: 2, mentalBonus: 2, infoBonus: 2 } },
+  { id: "u37", name: "生還の達人",   desc: "回復効果 +8%、精神ダメージ -3%", cost: 0, icon: "🏆", cat: "achieve", achReq: (m) => m.escapes >= 8, achDesc: "8回生還する", fx: { healMult: 1.08, mnReduce: 0.97 } },
+  { id: "u38", name: "博覧強記",     desc: "初期情報値 +3、情報取得量 +8%", cost: 0, icon: "📚", cat: "achieve", achReq: (m) => m.totalEvents >= 80, achDesc: "累計80イベントをクリアする", fx: { infoBonus: 3, infoMult: 1.08 } },
+  { id: "u39", name: "死線を越えて", desc: "全ダメージ -3%",          cost: 0, icon: "☠",  cat: "achieve", achReq: (m) => (m.totalDeaths ?? 0) >= 15, achDesc: "15回死亡する", fx: { hpReduce: 0.97, mnReduce: 0.97 } },
+  { id: "u40", name: "エンディングコレクター", desc: "全初期ステータス +3", cost: 0, icon: "🎭", cat: "achieve", achReq: (m) => (m.endings?.length ?? 0) >= 8, achDesc: "8種類のEDを見る", fx: { hpBonus: 3, mentalBonus: 3, infoBonus: 3 } },
+]);
+
+// ── 純粋ゲームロジック ────────────────────────────────
+
+export const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+export const rand  = (a, b) => Math.floor(Math.random() * (b - a + 1)) + a;
+export const shuffle = (arr) => {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [a[i], a[j]] = [a[j], a[i]]; }
+  return a;
+};
+
+/** FX key classification for merge strategy */
+export const FX_MULT = new Set(["infoMult", "healMult", "mnReduce", "hpReduce"]);
+export const FX_BOOL = new Set(["dangerSense", "bleedReduce", "drainImmune", "curseImmune", "secondLife", "chainBoost", "negotiator", "mentalSense"]);
+export const FX_DEFAULTS = Object.freeze({ hpBonus: 0, mentalBonus: 0, infoBonus: 0, infoMult: 1, healMult: 1, dangerSense: false, mnReduce: 1, bleedReduce: false, drainImmune: false, hpReduce: 1, curseImmune: false, secondLife: false, chainBoost: false, negotiator: false, mentalSense: false });
+
+/**
+ * Merge all unlock effects into a single FX object.
+ * @pre  each id in unlockIds exists in UNLOCKS
+ * @post returned object has every key in FX_DEFAULTS
+ */
+export const computeFx = (unlockIds) => {
+  const fx = { ...FX_DEFAULTS };
+  for (const uid of unlockIds) {
+    const def = UNLOCKS.find(u => u.id === uid);
+    if (!def?.fx) continue;
+    for (const [k, v] of Object.entries(def.fx)) {
+      if (FX_MULT.has(k))      fx[k] *= v;
+      else if (FX_BOOL.has(k)) fx[k] = v;
+      else                      fx[k] += v;
+    }
+  }
+  return fx;
+};
+
+/**
+ * Create initial player state for a new run.
+ * @pre  diff != null && fx != null
+ * @post hp > 0 && mn > 0
+ */
+export const createPlayer = (diff, fx) => {
+  invariant(diff != null, "createPlayer", "diff is required");
+  invariant(fx != null, "createPlayer", "fx is required");
+  const hp = CFG.BASE_HP + fx.hpBonus + diff.hpMod;
+  const mn = CFG.BASE_MN + fx.mentalBonus + diff.mnMod;
+  return { hp, maxHp: hp, mn, maxMn: mn, inf: CFG.BASE_INF + fx.infoBonus, st: [] };
+};
+
+/**
+ * Evaluate a condition string against player state.
+ * @param cond — "default" | "status:X" | "hp>N" | "mn>N" | "inf>N"
+ */
+export const evalCond = (cond, player, fx) => {
+  if (cond === "default") return true;
+  if (cond.startsWith("status:")) return player.st.includes(cond.slice(7));
+  if (cond.startsWith("hp>")) {
+    const t = parseInt(cond.slice(3), 10);
+    return ((fx.dangerSense && player.hp < 30) ? player.hp + 20 : player.hp) > t;
+  }
+  if (cond.startsWith("hp<"))  return player.hp  < parseInt(cond.slice(3), 10);
+  if (cond.startsWith("mn>")) {
+    const t = parseInt(cond.slice(3), 10);
+    let mn = player.mn;
+    if (fx.negotiator)  mn += 8;  // 交渉術
+    if (fx.mentalSense && player.mn < 25) mn += 15; // 第六感
+    return mn > t;
+  }
+  if (cond.startsWith("mn<"))  return player.mn  < parseInt(cond.slice(3), 10);
+  if (cond.startsWith("inf>")) return player.inf > parseInt(cond.slice(4), 10);
+  if (cond.startsWith("inf<")) return player.inf < parseInt(cond.slice(4), 10);
+  console.warn(`[evalCond] Unknown format: "${cond}"`);
+  return true;
+};
+
+/**
+ * Resolve which outcome applies for a choice.
+ * @pre choice.o is a non-empty array
+ */
+export const resolveOutcome = (choice, player, fx) => {
+  invariant(choice?.o?.length > 0, "resolveOutcome", "choice must have outcomes");
+  for (const o of choice.o) {
+    if (o.c !== "default" && evalCond(o.c, player, fx)) return o;
+  }
+  return choice.o.find(o => o.c === "default") ?? choice.o[0];
+};
+
+/**
+ * Apply fx/diff modifiers to raw outcome values. Pure.
+ * @returns { hp, mn, inf }
+ */
+export const applyModifiers = (outcome, fx, diff, playerStatuses) => {
+  let hp = outcome.hp ?? 0, mn = outcome.mn ?? 0, inf = outcome.inf ?? 0;
+  if (hp > 0) hp = Math.round(hp * fx.healMult);
+  if (hp < 0) hp = Math.round(hp * fx.hpReduce);
+  if (diff?.dmgMult !== 1) {
+    if (hp < 0) hp = Math.round(hp * diff.dmgMult);
+    if (mn < 0) mn = Math.round(mn * diff.dmgMult);
+  }
+  if (inf > 0) inf = Math.round(inf * fx.infoMult);
+  if (mn < 0)  mn = Math.round(mn * fx.mnReduce);
+  if (playerStatuses.includes("呪い") && inf > 0) inf = Math.round(inf * 0.5);
+  return { hp, mn, inf };
+};
+
+/**
+ * Apply stat changes + status flag to player. Pure.
+ */
+export const applyToPlayer = (player, { hp, mn, inf }, flag) => {
+  let sts = [...player.st];
+  if (flag?.startsWith("add:"))    { const s = flag.slice(4); if (!sts.includes(s)) sts.push(s); }
+  if (flag?.startsWith("remove:")) { sts = sts.filter(s => s !== flag.slice(7)); }
+  return {
+    ...player,
+    hp:  clamp(player.hp + hp, 0, player.maxHp),
+    mn:  clamp(player.mn + mn, 0, player.maxMn),
+    inf: Math.max(0, player.inf + inf),
+    st:  sts,
+  };
+};
+
+/**
+ * Compute per-turn drain (labyrinth + status ticks). Pure.
+ * @returns { player, drain: {hp,mn}|null }
+ */
+export const computeDrain = (player, fx, diff) => {
+  const base = diff ? diff.drainMod : -1;
+  let hpD = 0, mnD = fx.drainImmune ? 0 : base;
+  for (const s of player.st) {
+    const tick = STATUS_META[s]?.tick;
+    if (!tick) continue;
+    let h = tick.hp;
+    const m = tick.mn;
+    if (s === "出血" && fx.bleedReduce) h = Math.round(h * 0.5);
+    hpD += h; mnD += m;
+  }
+  if (hpD === 0 && mnD === 0) return { player, drain: null };
+  return {
+    player: { ...player, hp: clamp(player.hp + hpD, 0, player.maxHp), mn: clamp(player.mn + mnD, 0, player.maxMn) },
+    drain: { hp: hpD, mn: mnD },
+  };
+};
+
+/** Classify impact for audio/visual feedback */
+export const classifyImpact = (hp, mn) => {
+  if (hp < -15) return "bigDmg";
+  if (hp < 0 || mn < -10) return "dmg";
+  if (hp > 0) return "heal";
+  return null;
+};
+
+/** Overall progress 0-100 */
+export const computeProgress = (floor, step) =>
+  Math.min(100, ((floor - 1) * CFG.EVENTS_PER_FLOOR + step) / (CFG.MAX_FLOOR * CFG.EVENTS_PER_FLOOR) * 100);


### PR DESCRIPTION
## Summary
- テスト不足の4ゲーム（Agile Quiz Sugoroku, Labyrinth Echo, Air Hockey, Keys & Arms）にテストを追加
- 各ゲームの純粋関数を別ファイルに抽出し、元ファイルはインポートに変更（関数コード自体は未変更）
- テスト合計約197件を追加し、全973テストがパスすることを確認

## 変更内容

### Phase 1: Agile Quiz Sugoroku（テスト90件追加）
- `game-logic.ts` に7つの純粋関数（shuffle, average, percentage, clamp, pickQuestion, makeEvents, createSprintSummary）を抽出
- `useGame.ts` はインポートに変更
- テスト3ファイル新規作成（game-logic / constants / questions）

### Phase 2: Labyrinth Echo（テスト58件追加）
- `game-logic.ts` に§4-§5の純粋関数・定数（computeFx, createPlayer, evalCond 等）を抽出
- `LabyrinthEchoGame.tsx` はインポートに変更
- テスト2ファイル新規作成（game-logic / storage）

### Phase 3: Air Hockey（テスト24件追加）
- `items.test.ts`, `entities.test.ts` を新規作成
- `Physics.test.ts` に reflectOffSurface / applyFriction テストを追加

### Phase 4: Keys & Arms（テスト25件追加）
- `difficulty.ts` に Difficulty オブジェクトを抽出
- `engine.ts` はインポートに変更
- テスト1ファイル新規作成（difficulty）

## Test plan
- [x] `npx jest --no-coverage` で全973テストがパスすることを確認
- [x] 抽出元ファイルの動作が変わっていないことを既存テストで確認
- [ ] `npx jest --coverage` でカバレッジ向上を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)