### PR TITLE
fix: 開発モードで runtimeChunk を無効化し HMR ループを防止

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,6 +13,10 @@ interface Configuration extends WebpackConfiguration {
   devServer?: WebpackDevServerConfiguration;
 }
 
+const isDev = process.argv.includes('--mode')
+  ? process.argv[process.argv.indexOf('--mode') + 1] !== 'production'
+  : true;
+
 const config: Configuration = {
   mode: 'development',
   devtool: process.env.NODE_ENV === 'production' ? false : 'source-map',
@@ -64,7 +68,7 @@ const config: Configuration = {
     splitChunks: {
       chunks: 'all',
     },
-    runtimeChunk: 'single',
+    runtimeChunk: isDev ? false : 'single',
   },
   performance: {
     maxAssetSize: 400000,
@@ -79,6 +83,9 @@ const config: Configuration = {
     hot: true,
     liveReload: false,
     historyApiFallback: true,
+    client: {
+      overlay: { errors: true, warnings: false },
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

- 開発モードで `runtimeChunk: "single"` が HMR と競合しリロードループを引き起こす問題を修正
- `isDev` フラグを導入し、開発モードでは `runtimeChunk` を無効化
- devServer の `client.overlay` でエラーのみ表示し、警告オーバーレイを抑制

## Changes

- `webpack.config.ts`: `isDev` 判定を追加、`runtimeChunk` を開発時 `false` に変更、`client.overlay` 設定を追加

## Test plan

- [x] `npm start` で開発サーバーを起動し、HMR が正常に動作しリロードループが発生しないことを確認
- [x] `npm run build` で本番ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)