### PR TITLE
refactor: Deep Sea Interceptor TDD リファクタリング

### DIFF
--- a/src/features/deep-sea-interceptor/__tests__/entities.test.ts
+++ b/src/features/deep-sea-interceptor/__tests__/entities.test.ts
@@ -1,4 +1,4 @@
-import { EntityFactory, randomChoice } from '../entities';
+import { EntityFactory, randomChoice, isBoss, isMidboss } from '../entities';
 
 describe('EntityFactory', () => {
   describe('bullet', () => {
@@ -115,5 +115,50 @@ describe('randomChoice', () => {
     const arr = ['a', 'b', 'c'];
     const result = randomChoice(arr);
     expect(arr).toContain(result);
+  });
+});
+
+describe('isBoss', () => {
+  test('boss タイプを正しく判定すること', () => {
+    const boss = EntityFactory.enemy('boss', 200, -60);
+    expect(isBoss(boss)).toBe(true);
+  });
+
+  test('boss1〜boss5 タイプを正しく判定すること', () => {
+    for (const type of ['boss1', 'boss2', 'boss3', 'boss4', 'boss5']) {
+      const enemy = EntityFactory.enemy(type, 200, -60);
+      expect(isBoss(enemy)).toBe(true);
+    }
+  });
+
+  test('通常の敵はボスではないこと', () => {
+    for (const type of ['basic', 'fast', 'shooter', 'tank']) {
+      const enemy = EntityFactory.enemy(type, 100, 50);
+      expect(isBoss(enemy)).toBe(false);
+    }
+  });
+
+  test('ミッドボスはボスではないこと', () => {
+    const midboss = EntityFactory.enemy('midboss1', 200, -60);
+    expect(isBoss(midboss)).toBe(false);
+  });
+});
+
+describe('isMidboss', () => {
+  test('midboss1〜midboss5 を正しく判定すること', () => {
+    for (const type of ['midboss1', 'midboss2', 'midboss3', 'midboss4', 'midboss5']) {
+      const enemy = EntityFactory.enemy(type, 200, -60);
+      expect(isMidboss(enemy)).toBe(true);
+    }
+  });
+
+  test('通常の敵はミッドボスではないこと', () => {
+    const enemy = EntityFactory.enemy('basic', 100, 50);
+    expect(isMidboss(enemy)).toBe(false);
+  });
+
+  test('ボスはミッドボスではないこと', () => {
+    const boss = EntityFactory.enemy('boss1', 200, -60);
+    expect(isMidboss(boss)).toBe(false);
   });
 });

--- a/src/features/deep-sea-interceptor/__tests__/game-logic-subfunctions.test.ts
+++ b/src/features/deep-sea-interceptor/__tests__/game-logic-subfunctions.test.ts
@@ -1,0 +1,328 @@
+import {
+  resolvePlayerInput,
+  updatePlayerPosition,
+  getMovementStrategy,
+  processBulletEnemyCollisions,
+  processItemCollection,
+  processPlayerDamage,
+  processGraze,
+  checkStageProgression,
+} from '../game-logic';
+import { EntityFactory, isBoss } from '../entities';
+import { MovementStrategies } from '../movement';
+import { buildGameState, buildUiState } from '../test-helpers';
+import { DifficultyConfig } from '../constants';
+
+describe('resolvePlayerInput', () => {
+  test('キーボード入力が優先されること', () => {
+    const keys = { ArrowLeft: true } as Record<string, boolean>;
+    const touchInput = { dx: 1, dy: 0 };
+    const result = resolvePlayerInput(keys, touchInput);
+    expect(result.dx).toBe(-1);
+  });
+
+  test('キーボード入力がない場合はタッチ入力にフォールバックすること', () => {
+    const keys = {} as Record<string, boolean>;
+    const touchInput = { dx: 0.5, dy: -0.3 };
+    const result = resolvePlayerInput(keys, touchInput);
+    expect(result.dx).toBe(0.5);
+    expect(result.dy).toBe(-0.3);
+  });
+
+  test('WASD入力も処理されること', () => {
+    const keys = { w: true, d: true } as Record<string, boolean>;
+    const result = resolvePlayerInput(keys, { dx: 0, dy: 0 });
+    expect(result.dx).toBe(1);
+    expect(result.dy).toBe(-1);
+  });
+
+  test('入力がなければ (0, 0) を返すこと', () => {
+    const keys = {} as Record<string, boolean>;
+    const result = resolvePlayerInput(keys, { dx: 0, dy: 0 });
+    expect(result.dx).toBe(0);
+    expect(result.dy).toBe(0);
+  });
+});
+
+describe('updatePlayerPosition', () => {
+  test('移動方向に応じて座標が変化すること', () => {
+    const result = updatePlayerPosition({ x: 200, y: 400 }, { dx: 1, dy: 0 }, 4);
+    expect(result.x).toBe(204);
+    expect(result.y).toBe(400);
+  });
+
+  test('左端でクランプされること', () => {
+    const result = updatePlayerPosition({ x: 5, y: 400 }, { dx: -1, dy: 0 }, 10);
+    expect(result.x).toBe(15);
+  });
+
+  test('右端でクランプされること', () => {
+    const result = updatePlayerPosition({ x: 395, y: 400 }, { dx: 1, dy: 0 }, 10);
+    expect(result.x).toBe(385);
+  });
+
+  test('上端でクランプされること', () => {
+    const result = updatePlayerPosition({ x: 200, y: 5 }, { dx: 0, dy: -1 }, 10);
+    expect(result.y).toBe(15);
+  });
+
+  test('下端でクランプされること', () => {
+    const result = updatePlayerPosition({ x: 200, y: 520 }, { dx: 0, dy: 1 }, 10);
+    expect(result.y).toBe(510);
+  });
+});
+
+describe('getMovementStrategy', () => {
+  test('ボスタイプにはboss戦略を返すこと', () => {
+    expect(getMovementStrategy('boss1', 0)).toBe(MovementStrategies.boss);
+    expect(getMovementStrategy('boss3', 1)).toBe(MovementStrategies.boss);
+  });
+
+  test('ミッドボスにはboss戦略を返すこと', () => {
+    expect(getMovementStrategy('midboss1', 0)).toBe(MovementStrategies.boss);
+    expect(getMovementStrategy('midboss3', 2)).toBe(MovementStrategies.boss);
+  });
+
+  test('通常敵パターン0にはstraight戦略を返すこと', () => {
+    expect(getMovementStrategy('basic', 0)).toBe(MovementStrategies.straight);
+  });
+
+  test('通常敵パターン1にはsine戦略を返すこと', () => {
+    expect(getMovementStrategy('basic', 1)).toBe(MovementStrategies.sine);
+  });
+
+  test('通常敵パターン2にはdrift戦略を返すこと', () => {
+    expect(getMovementStrategy('basic', 2)).toBe(MovementStrategies.drift);
+  });
+});
+
+describe('processBulletEnemyCollisions', () => {
+  test('弾と敵が衝突するとスコアが増加すること', () => {
+    const bullet = EntityFactory.bullet(100, 100);
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const diffConfig = DifficultyConfig['standard'];
+    const result = processBulletEnemyCollisions([bullet], [enemy], 0, diffConfig);
+    expect(result.scoreDelta).toBeGreaterThan(0);
+    expect(result.audioEvents).toContainEqual({ name: 'destroy' });
+  });
+
+  test('コンボが加算されること', () => {
+    const bullet = EntityFactory.bullet(100, 100);
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const diffConfig = DifficultyConfig['standard'];
+    const result = processBulletEnemyCollisions([bullet], [enemy], 0, diffConfig);
+    expect(result.comboState.combo).toBe(1);
+    expect(result.comboState.maxCombo).toBe(1);
+  });
+
+  test('ボス撃破で bossDefeated が true になること', () => {
+    const boss = EntityFactory.enemy('boss1', 100, 100, 1);
+    boss.hp = 1;
+    const bullet = EntityFactory.bullet(100, 100, { damage: 10 });
+    const diffConfig = DifficultyConfig['standard'];
+    const result = processBulletEnemyCollisions([bullet], [boss], 0, diffConfig);
+    expect(result.bossDefeated).toBe(true);
+    expect(result.screenShake).toBe(500);
+    expect(result.screenFlash).toBe(200);
+  });
+
+  test('貫通弾は衝突後も残ること', () => {
+    const bullet = EntityFactory.bullet(100, 100, { piercing: true, damage: 10 });
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const diffConfig = DifficultyConfig['standard'];
+    const result = processBulletEnemyCollisions([bullet], [enemy], 0, diffConfig);
+    expect(result.bullets.some(b => b.piercing)).toBe(true);
+  });
+
+  test('ミッドボス撃破で確定アイテムドロップすること', () => {
+    const midboss = EntityFactory.enemy('midboss1', 100, 100, 1);
+    midboss.hp = 1;
+    const bullet = EntityFactory.bullet(100, 100, { damage: 100 });
+    const diffConfig = DifficultyConfig['standard'];
+    const result = processBulletEnemyCollisions([bullet], [midboss], 0, diffConfig);
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.screenShake).toBe(200);
+  });
+});
+
+describe('processItemCollection', () => {
+  test('パワーアイテムでpower増加すること', () => {
+    const player = { x: 100, y: 100 };
+    const item = EntityFactory.item(100, 100, 'power');
+    const enemies: ReturnType<typeof EntityFactory.enemy>[] = [];
+    const result = processItemCollection(player, [item], buildUiState(), enemies, Date.now());
+    expect(result.uiChanges.power).toBe(2);
+    expect(result.audioEvents).toContainEqual({ name: 'item' });
+  });
+
+  test('シールドアイテムでshieldEndTime設定されること', () => {
+    const player = { x: 100, y: 100 };
+    const item = EntityFactory.item(100, 100, 'shield');
+    const enemies: ReturnType<typeof EntityFactory.enemy>[] = [];
+    const now = Date.now();
+    const result = processItemCollection(player, [item], buildUiState(), enemies, now);
+    expect(result.uiChanges.shieldEndTime).toBe(now + 8000);
+  });
+
+  test('ボムアイテムでボス以外の敵が全滅すること', () => {
+    const player = { x: 100, y: 100 };
+    const item = EntityFactory.item(100, 100, 'bomb');
+    const enemies = [
+      EntityFactory.enemy('basic', 200, 200),
+      EntityFactory.enemy('boss1', 200, 100, 1),
+    ];
+    const result = processItemCollection(player, [item], buildUiState(), enemies, Date.now());
+    // 通常敵のHPは0になるが、ボスは無傷
+    const basicEnemy = result.enemies.find(e => e.enemyType === 'basic');
+    const bossEnemy = result.enemies.find(e => e.enemyType === 'boss1');
+    expect(basicEnemy!.hp).toBe(0);
+    expect(bossEnemy!.hp).toBeGreaterThan(0);
+  });
+
+  test('ライフアイテムでlives増加すること', () => {
+    const player = { x: 100, y: 100 };
+    const item = EntityFactory.item(100, 100, 'life');
+    const enemies: ReturnType<typeof EntityFactory.enemy>[] = [];
+    const result = processItemCollection(player, [item], buildUiState({ lives: 2 }), enemies, Date.now());
+    expect(result.uiChanges.lives).toBe(3);
+  });
+
+  test('スピードアイテムでspeedLevel増加すること', () => {
+    const player = { x: 100, y: 100 };
+    const item = EntityFactory.item(100, 100, 'speed');
+    const enemies: ReturnType<typeof EntityFactory.enemy>[] = [];
+    const result = processItemCollection(player, [item], buildUiState(), enemies, Date.now());
+    expect(result.uiChanges.speedLevel).toBe(1);
+  });
+
+  test('収集されなかったアイテムは残ること', () => {
+    const player = { x: 100, y: 100 };
+    const farItem = EntityFactory.item(300, 300, 'power');
+    const enemies: ReturnType<typeof EntityFactory.enemy>[] = [];
+    const result = processItemCollection(player, [farItem], buildUiState(), enemies, Date.now());
+    expect(result.remainingItems).toHaveLength(1);
+  });
+});
+
+describe('processPlayerDamage', () => {
+  test('敵と衝突してライフが減ること', () => {
+    const player = { x: 100, y: 100 };
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const result = processPlayerDamage(player, [enemy], [], {
+      invincible: false,
+      invincibleEndTime: 0,
+      shieldEndTime: 0,
+      lives: 3,
+      combo: 5,
+    }, Date.now());
+    expect(result.hit).toBe(true);
+    expect(result.livesLost).toBe(1);
+    expect(result.comboReset).toBe(true);
+  });
+
+  test('無敵中はダメージを受けないこと', () => {
+    const player = { x: 100, y: 100 };
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const now = Date.now();
+    const result = processPlayerDamage(player, [enemy], [], {
+      invincible: true,
+      invincibleEndTime: now + 5000,
+      shieldEndTime: 0,
+      lives: 3,
+      combo: 0,
+    }, now);
+    expect(result.hit).toBe(false);
+  });
+
+  test('シールド中はダメージを受けないこと', () => {
+    const player = { x: 100, y: 100 };
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const now = Date.now();
+    const result = processPlayerDamage(player, [enemy], [], {
+      invincible: false,
+      invincibleEndTime: 0,
+      shieldEndTime: now + 5000,
+      lives: 3,
+      combo: 0,
+    }, now);
+    expect(result.hit).toBe(false);
+  });
+
+  test('ライフ0でゲームオーバーイベントが発生すること', () => {
+    const player = { x: 100, y: 100 };
+    const enemy = EntityFactory.enemy('basic', 100, 100);
+    const result = processPlayerDamage(player, [enemy], [], {
+      invincible: false,
+      invincibleEndTime: 0,
+      shieldEndTime: 0,
+      lives: 1,
+      combo: 0,
+    }, Date.now());
+    expect(result.event).toBe('gameover');
+  });
+
+  test('敵弾との衝突でもダメージを受けること', () => {
+    const player = { x: 100, y: 100 };
+    const enemyBullet = EntityFactory.enemyBullet(100, 100, { x: 0, y: 1 });
+    const result = processPlayerDamage(player, [], [enemyBullet], {
+      invincible: false,
+      invincibleEndTime: 0,
+      shieldEndTime: 0,
+      lives: 3,
+      combo: 0,
+    }, Date.now());
+    expect(result.hit).toBe(true);
+  });
+});
+
+describe('processGraze', () => {
+  test('グレイズ範囲内でスコアが加算されること', () => {
+    const player = { x: 100, y: 100 };
+    // グレイズ範囲: 衝突半径(8+4=12)の外側、グレイズ半径(8+16=24)の内側
+    // distance = 15 → hitRadius=12, grazeRadius=24 → グレイズ成功
+    const enemyBullet = EntityFactory.enemyBullet(115, 100, { x: 0, y: 1 });
+    const grazedIds = new Set<number>();
+    const now = Date.now();
+    const result = processGraze(player, [enemyBullet], grazedIds, 0, buildUiState(), now);
+    expect(result.grazeCount).toBe(1);
+    expect(result.scoreDelta).toBeGreaterThan(0);
+    expect(result.audioEvents).toContainEqual({ name: 'graze' });
+  });
+
+  test('既にグレイズ済みの弾は無視されること', () => {
+    const player = { x: 100, y: 100 };
+    const enemyBullet = EntityFactory.enemyBullet(115, 100, { x: 0, y: 1 });
+    const grazedIds = new Set<number>([enemyBullet.id]);
+    const now = Date.now();
+    const result = processGraze(player, [enemyBullet], grazedIds, 0, buildUiState(), now);
+    expect(result.grazeCount).toBe(0);
+  });
+});
+
+describe('checkStageProgression', () => {
+  test('ステージ1〜4のボス撃破でステージが進行すること', () => {
+    const now = Date.now();
+    const result = checkStageProgression(true, now - 3000, 2, 5000, 10, 5, now);
+    expect(result.event).toBe('stageCleared');
+    expect(result.nextStage).toBe(3);
+    expect(result.bonus).toBeGreaterThan(0);
+  });
+
+  test('ステージ5のボス撃破でエンディングイベントが発生すること', () => {
+    const now = Date.now();
+    const result = checkStageProgression(true, now - 3000, 5, 20000, 30, 10, now);
+    expect(result.event).toBe('ending');
+  });
+
+  test('ボス未撃破ではイベントなしであること', () => {
+    const now = Date.now();
+    const result = checkStageProgression(false, 0, 1, 1000, 0, 0, now);
+    expect(result.event).toBe('none');
+  });
+
+  test('ボス撃破後2秒以内はイベントなしであること', () => {
+    const now = Date.now();
+    const result = checkStageProgression(true, now - 500, 1, 1000, 0, 0, now);
+    expect(result.event).toBe('none');
+  });
+});

--- a/src/features/deep-sea-interceptor/__tests__/weapon.test.ts
+++ b/src/features/deep-sea-interceptor/__tests__/weapon.test.ts
@@ -1,0 +1,100 @@
+import { createBulletsForWeapon, createChargedShot } from '../weapon';
+
+describe('createBulletsForWeapon', () => {
+  describe('torpedo', () => {
+    test('power=1 で1発の弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'torpedo', 1, false);
+      expect(bullets).toHaveLength(1);
+      expect(bullets[0].weaponType).toBe('torpedo');
+    });
+
+    test('power=3 で2発の弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'torpedo', 3, false);
+      expect(bullets).toHaveLength(2);
+    });
+
+    test('power=4 で3発の弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'torpedo', 4, false);
+      expect(bullets).toHaveLength(3);
+    });
+
+    test('power=5 で4発の弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'torpedo', 5, false);
+      expect(bullets).toHaveLength(4);
+    });
+
+    test('hasSpread=true で3発の弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'torpedo', 1, true);
+      expect(bullets).toHaveLength(3);
+    });
+  });
+
+  describe('sonarWave', () => {
+    test('常に3発の弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'sonarWave', 1, false);
+      expect(bullets).toHaveLength(3);
+      expect(bullets[0].weaponType).toBe('sonarWave');
+    });
+
+    test('lifespan が設定されていること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'sonarWave', 1, false);
+      bullets.forEach(b => {
+        expect(b.lifespan).toBeDefined();
+        expect(b.lifespan).toBeGreaterThan(0);
+      });
+    });
+
+    test('power=5 で高い damage と lifespan を持つこと', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'sonarWave', 5, false);
+      expect(bullets[0].damage).toBe(2.5);
+      expect(bullets[0].lifespan).toBe(40);
+    });
+  });
+
+  describe('bioMissile', () => {
+    test('power=1 で1発のホーミング弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'bioMissile', 1, false);
+      expect(bullets).toHaveLength(1);
+      expect(bullets[0].homing).toBe(true);
+      expect(bullets[0].weaponType).toBe('bioMissile');
+    });
+
+    test('power=3 で2発のホーミング弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'bioMissile', 3, false);
+      expect(bullets).toHaveLength(2);
+    });
+
+    test('power=5 で3発のホーミング弾を生成すること', () => {
+      const bullets = createBulletsForWeapon(200, 300, 'bioMissile', 5, false);
+      expect(bullets).toHaveLength(3);
+    });
+  });
+});
+
+describe('createChargedShot', () => {
+  test('torpedo チャージショットは貫通弾であること', () => {
+    const bullets = createChargedShot(200, 300, 'torpedo');
+    expect(bullets).toHaveLength(1);
+    expect(bullets[0].charged).toBe(true);
+    expect(bullets[0].piercing).toBe(true);
+    expect(bullets[0].damage).toBe(5);
+  });
+
+  test('sonarWave チャージショットは8発の全方位弾であること', () => {
+    const bullets = createChargedShot(200, 300, 'sonarWave');
+    expect(bullets).toHaveLength(8);
+    bullets.forEach(b => {
+      expect(b.charged).toBe(true);
+      expect(b.weaponType).toBe('sonarWave');
+    });
+  });
+
+  test('bioMissile チャージショットは5発のホーミング弾であること', () => {
+    const bullets = createChargedShot(200, 300, 'bioMissile');
+    expect(bullets).toHaveLength(5);
+    bullets.forEach(b => {
+      expect(b.charged).toBe(true);
+      expect(b.homing).toBe(true);
+    });
+  });
+});

--- a/src/features/deep-sea-interceptor/entities.ts
+++ b/src/features/deep-sea-interceptor/entities.ts
@@ -4,7 +4,7 @@
 
 import { randomRange, randomInt as baseRandomInt } from '../../utils/math-utils';
 import { Config, EnemyConfig, ItemConfig } from './constants';
-import type { Bullet, Enemy, EnemyBullet, Item, Particle, Bubble, Position, ItemType, WeaponType } from './types';
+import type { Bullet, Enemy, EnemyBullet, Item, Particle, Bubble, Position, ItemType, WeaponType, EnemyType } from './types';
 
 // ユニークID生成
 const uniqueId = (() => {
@@ -21,6 +21,14 @@ export const resetIdCounter = () => {
 export function randomChoice<T>(arr: T[]): T {
   return arr[baseRandomInt(0, arr.length - 1)];
 }
+
+/** ボス判定（boss, boss1〜boss5） */
+export const isBoss = (e: { enemyType: EnemyType }): boolean =>
+  e.enemyType === 'boss' || (e.enemyType.startsWith('boss') && !e.enemyType.startsWith('midboss'));
+
+/** ミッドボス判定（midboss1〜midboss5） */
+export const isMidboss = (e: { enemyType: EnemyType }): boolean =>
+  e.enemyType.startsWith('midboss');
 
 /** エンティティファクトリ */
 export const EntityFactory = {
@@ -73,8 +81,8 @@ export const EntityFactory = {
   enemy: (type: string, x: number, y: number, stage = 1): Enemy => {
     const cfg = EnemyConfig[type];
     if (!cfg) throw new Error(`Invalid enemy type: ${type}`);
-    const isBoss = type === 'boss' || type.startsWith('boss');
-    const hp = isBoss ? cfg.hp + stage * 15 : cfg.hp;
+    const boss = type === 'boss' || (type.startsWith('boss') && !type.startsWith('midboss'));
+    const hp = boss ? cfg.hp + stage * 15 : cfg.hp;
     return {
       id: uniqueId(),
       x,
@@ -92,7 +100,7 @@ export const EntityFactory = {
       lastShotAt: 0,
       movementPattern: baseRandomInt(0, 2),
       angle: 0,
-      bossPhase: (type === 'boss' || type.startsWith('boss')) ? 1 : 0,
+      bossPhase: boss ? 1 : 0,
     };
   },
 

--- a/src/features/deep-sea-interceptor/test-helpers.ts
+++ b/src/features/deep-sea-interceptor/test-helpers.ts
@@ -1,0 +1,16 @@
+// ============================================================================
+// Deep Sea Interceptor - テストヘルパー
+// ============================================================================
+
+import { createInitialGameState, createInitialUiState } from './game-logic';
+import type { GameState, UiState } from './types';
+
+/** テスト用 GameState ファクトリ */
+export function buildGameState(overrides: Partial<GameState> = {}): GameState {
+  return { ...createInitialGameState(), ...overrides };
+}
+
+/** テスト用 UiState ファクトリ */
+export function buildUiState(overrides: Partial<UiState> = {}): UiState {
+  return { ...createInitialUiState(), ...overrides };
+}

--- a/src/features/deep-sea-interceptor/types.ts
+++ b/src/features/deep-sea-interceptor/types.ts
@@ -193,6 +193,9 @@ export interface SavedAchievementData {
   lastUpdated: number;
 }
 
+/** オーディオイベント（副作用分離用） */
+export type AudioEvent = { readonly name: string };
+
 /** 移動可能エンティティ */
 export type MovableEntity = Position & { speed: number };
 

--- a/src/features/deep-sea-interceptor/weapon.ts
+++ b/src/features/deep-sea-interceptor/weapon.ts
@@ -1,0 +1,136 @@
+// ============================================================================
+// Deep Sea Interceptor - 武器ロジック（純粋関数）
+// ============================================================================
+
+import { EntityFactory } from './entities';
+import type { Bullet, WeaponType } from './types';
+
+/** 武器タイプ別の射撃ロジック（純粋関数） */
+export function createBulletsForWeapon(
+  x: number,
+  y: number,
+  weaponType: WeaponType,
+  power: number,
+  hasSpread: boolean
+): Bullet[] {
+  const bullets: Bullet[] = [];
+
+  switch (weaponType) {
+    case 'torpedo': {
+      // トーピード: power レベルに応じた弾数
+      const angles = hasSpread
+        ? [-0.25, 0, 0.25]
+        : power >= 5
+          ? [-0.1, 0, 0.1, 0]
+          : power >= 4
+            ? [-0.1, 0, 0.1]
+            : power >= 3
+              ? [-0.1, 0.1]
+              : [0];
+      for (const a of angles) {
+        bullets.push(
+          EntityFactory.bullet(x, y - 12, {
+            angle: -Math.PI / 2 + a,
+            weaponType: 'torpedo',
+            damage: power >= 2 && a === 0 ? 1.5 : 1,
+          })
+        );
+      }
+      break;
+    }
+    case 'sonarWave': {
+      // ソナーウェーブ: 扇状3発、高火力・射程制限あり
+      const spreadAngle = power >= 5 ? 0.35 : power >= 3 ? 0.26 : 0.17;
+      const lifespan = power >= 5 ? 40 : power >= 3 ? 33 : 28;
+      const dmg = power >= 5 ? 2.5 : power >= 3 ? 2 : 1.5;
+      for (const a of [-spreadAngle, 0, spreadAngle]) {
+        bullets.push(
+          EntityFactory.bullet(x, y - 12, {
+            angle: -Math.PI / 2 + a,
+            weaponType: 'sonarWave',
+            speed: 8,
+            damage: dmg,
+            lifespan,
+          })
+        );
+      }
+      break;
+    }
+    case 'bioMissile': {
+      // バイオミサイル: ホーミング弾
+      const count = power >= 5 ? 3 : power >= 3 ? 2 : 1;
+      const dmg = 1;
+      for (let i = 0; i < count; i++) {
+        const offset = (i - (count - 1) / 2) * 0.2;
+        bullets.push(
+          EntityFactory.bullet(x, y - 12, {
+            angle: -Math.PI / 2 + offset,
+            weaponType: 'bioMissile',
+            speed: 7,
+            damage: dmg,
+            homing: true,
+          })
+        );
+      }
+      break;
+    }
+  }
+
+  return bullets;
+}
+
+/** 武器タイプ別チャージショット（純粋関数） */
+export function createChargedShot(
+  x: number,
+  y: number,
+  weaponType: WeaponType
+): Bullet[] {
+  const bullets: Bullet[] = [];
+
+  switch (weaponType) {
+    case 'torpedo':
+      bullets.push(
+        EntityFactory.bullet(x, y - 12, {
+          charged: true,
+          weaponType: 'torpedo',
+          piercing: true,
+          damage: 5,
+        })
+      );
+      break;
+    case 'sonarWave':
+      // 全方位8発パルス
+      for (let i = 0; i < 8; i++) {
+        const angle = (Math.PI * 2 * i) / 8;
+        bullets.push(
+          EntityFactory.bullet(x, y, {
+            charged: true,
+            weaponType: 'sonarWave',
+            angle,
+            speed: 7,
+            damage: 4,
+            lifespan: 32,
+          })
+        );
+      }
+      break;
+    case 'bioMissile':
+      // 追尾型拡散5発
+      for (let i = 0; i < 5; i++) {
+        const offset = (i - 2) * 0.3;
+        bullets.push(
+          EntityFactory.bullet(x, y - 12, {
+            charged: true,
+            weaponType: 'bioMissile',
+            angle: -Math.PI / 2 + offset,
+            speed: 8,
+            damage: 2,
+            homing: true,
+          })
+        );
+      }
+      break;
+  }
+
+  return bullets;
+}


### PR DESCRIPTION
## Summary
- `updateFrame()` 巨大モノリス（300行超）を TDD で段階的に純粋関数へ分解
- SOLID / DRY / 関数型原則（副作用分離）に基づくリファクタリング
- 武器ロジックを `weapon.ts` に抽出し `hooks.ts` から分離
- `isBoss()` / `isMidboss()` DRY ヘルパーで重複コードを解消
- `AudioEvent` パターンで副作用を関数末尾に集約

## 抽出した純粋関数（8個）
| 関数名 | 責務 |
|--------|------|
| `resolvePlayerInput` | 入力解決（キーボード優先、タッチフォールバック） |
| `updatePlayerPosition` | クランプ付き移動計算 |
| `getMovementStrategy` | 移動戦略のテーブルルックアップ |
| `processBulletEnemyCollisions` | 弾-敵衝突処理 |
| `processItemCollection` | アイテム収集処理 |
| `processPlayerDamage` | 被弾処理 |
| `processGraze` | グレイズ判定 |
| `checkStageProgression` | ステージ進行判定 |

## Test plan
- [x] 既存54テスト全パス（後方互換性確認）
- [x] 新規57テスト全パス（サブ関数の単体テスト）
- [x] 合計111テスト全パス
- [ ] ブラウザでのゲームプレイ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)