### PR TITLE
chore: AI ツール固有の設定ファイルを gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ lint_output.txt
 
 ## claude
 .claude
+
+## AI tools (ユーザー固有の設定)
+.codex/
+.gemini/
+.mcp.json
+/AGENTS.md


### PR DESCRIPTION
## 概要
各ユーザーが独自に設定する AI ツール関連ファイルを `.gitignore` に追加し、リポジトリに含まれないようにします。

## 変更内容
- `.codex/` を gitignore に追加
- `.gemini/` を gitignore に追加
- `.mcp.json` を gitignore に追加
- `/AGENTS.md`（ルートのみ）を gitignore に追加

## テスト方法
- [ ] `git status` で上記ファイルが untracked に表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)