### PR TITLE
feat: 落ち物シューティングのスコア保存修正と難易度パラメータ完全実装

### DIFF
--- a/.docs/fs-20260225-01/plan.md
+++ b/.docs/fs-20260225-01/plan.md
@@ -1,0 +1,139 @@
+# Falldown Shooter ブラッシュアップ 実装計画
+
+## 概要
+
+Falldown Shooter（落ち物シューティング）の品質向上・機能追加を5フェーズで実施する。
+
+---
+
+## Phase 1: テスト基盤強化
+
+### 1-1. コンポーネント単体テスト追加
+- `__tests__/components/` ディレクトリに8ファイル作成
+  - `CellView.test.tsx` — Props 描画、パワーアップアイコン表示
+  - `BulletView.test.tsx` — 通常弾/貫通弾/下方弾の描画差異
+  - `PlayerShip.test.tsx` — SVG 描画、座標計算
+  - `StatusBar.test.tsx` — ステージ/ライン/スコア表示
+  - `SkillGauge.test.tsx` — ゲージ表示、100%時のスキルボタン、onUseSkill コールバック
+  - `PowerUpIndicator.test.tsx` — バッジ表示/非表示
+  - `Effects.test.tsx` — レーザー/爆発/ブラストの可視性制御
+  - `Overlays.test.tsx` — 各スクリーン表示、ボタンクリック、デモスライド切替
+
+### 1-2. カスタムフックテスト追加
+- `__tests__/hooks.test.ts`
+  - `useInterval` — enabled 切替、delay 変更時リセット
+  - `useKeyboard` — キー発火、enabled=false 時の無視、repeat キー無視
+  - `useIdleTimer` — タイムアウト発火、リセット動作
+
+### 1-3. 統合テスト追加
+- `__tests__/integration.test.tsx`
+  - ゲーム開始→プレイ→ゲームオーバーのフロー
+  - スキルチャージ→発動フロー
+  - パワーアップ取得→効果適用→消滅フロー
+  - ステージクリア→次ステージフロー
+
+---
+
+## Phase 2: コード品質改善
+
+### 2-1. エラーハンドリング強化
+- `audio.ts` — AudioContext suspended 時の resume()、未対応環境の警告
+- `score-storage.ts` — QuotaExceededError 対応、古いスコア自動クリーンアップ
+- `__tests__/audio.test.ts` 新規作成
+
+### 2-2. メインコンポーネント分割（450行→200行以下）
+- カスタムフック6個を `hooks/` ディレクトリに作成
+  - `use-game-state.ts` — stateRef、updateState、forceUpdate、初期状態管理
+  - `use-game-flow.ts` — startStage、goToTitle、resetGame、nextStage
+  - `use-game-controls.ts` — moveLeft、moveRight、fire
+  - `use-skill-system.ts` — skillCharge、activateSkill
+  - `use-power-up.ts` — powers、handlePowerUp、handlePowerExpire
+  - `use-game-loop.ts` — 4つの useInterval 統合
+- `FalldownShooterGame.tsx` をフック呼出 + JSX レンダリングのみに
+
+### 2-3. マジックナンバー定数化
+- `constants.ts` に CONFIG の effect/timing/fireworks セクション追加
+- 各コンポーネントの数値リテラルを定数参照に置換
+
+### 2-4. React.memo 最適化
+- 全プレゼンテーショナルコンポーネントに React.memo + displayName 追加
+
+---
+
+## Phase 3: 新機能追加
+
+### 3-1. ポーズ機能
+- `types.ts` — GameStatus に `'paused'` 追加
+- `hooks.ts` — Escape/P キーでポーズトグル
+- `components/PauseOverlay.tsx` — ポーズ画面 UI
+- 全 useInterval の enabled 条件に `status !== 'paused'` 追加
+- UI にポーズボタン（⏸）追加
+
+### 3-2. 難易度設定（Easy/Normal/Hard）
+- `difficulty.ts` — 難易度定義（spawn/fall/score 倍率、パワーアップ出現率）
+- `components/DifficultySelector.tsx` — 難易度選択 UI
+- `types.ts` — Difficulty 型、GameState に difficulty 追加
+- `constants.ts` — 難易度別パラメータ
+- スタート画面に難易度セレクター追加
+
+### 3-3. ランキング機能
+- `components/RankingOverlay.tsx` — トップ10表示（難易度別）
+- `Overlays.tsx` — スタート/ゲームオーバー/エンディング画面にランキングリンク追加
+- 既存 `score-storage.ts` の `getScores()` を活用
+
+---
+
+## Phase 4: UX/UI 改善
+
+### 4-1. アクセシビリティ強化
+- ARIA Live Region 追加（スコア更新: polite、ステージ変更: assertive）
+- スキルゲージに aria-valuenow / aria-valuemax
+- 全ボタンに aria-label
+- オーバーレイ表示時のフォーカストラップ
+
+### 4-2. レスポンシブ対応
+- `hooks/use-responsive-size.ts` — ウィンドウサイズに応じたセルサイズ動的計算
+- `FallingShooterPage.styles.ts` — min(100vw - 2rem, 固定幅) に変更
+- タッチ操作の改善（コントロールボタンサイズ拡大）
+
+### 4-3. Overlay DRY 改善
+- `Overlays.tsx` — GameOverScreen / EndingScreen の共通部分を ScoreOverlay に抽出
+
+---
+
+## Phase 5: 検証・仕上げ
+
+### 5-1. 未使用依存の調査・削除
+- `tone`, `jotai` のプロジェクト全体使用状況を検索 → 未使用なら報告
+
+### 5-2. テスト・カバレッジ確認
+- `npm test -- --coverage` 実行
+- 新規コード 80% 以上、ロジック層 90% 以上、UI 層 70% 以上
+
+### 5-3. README 更新
+- 新機能（ポーズ、難易度、ランキング）、ファイル構造、テスト方法を反映
+
+---
+
+## Phase 6: スコア保存修正 & 難易度パラメータ完全実装
+
+### 6-1. スコア保存に difficulty を渡す
+- `use-game-loop.ts` — `saveScore` に `difficulty` を追加（保存キーと取得キーの不一致を解消）
+- `use-game-loop.ts` — ステージクリア・エンディング到達時にも `saveScore` を追加
+- `use-game-flow.ts` — `getHighScore` に `difficulty` を渡し、`UseGameFlowParams` に `difficulty` を追加
+- `FalldownShooterGame.tsx` — `useGameFlow` に `difficulty` を渡す
+
+### 6-2. scoreMultiplier の適用
+- `use-game-loop.ts` — 弾衝突スコアに `Math.round(result.score * scoreMultiplier)` を適用
+- `use-game-loop.ts` — ラインクリアスコアに `Math.round(cleared * CONFIG.score.line * state.stage * scoreMultiplier)` を適用
+
+### 6-3. powerUpChance の適用
+- `block.ts` — `Block.create` に第3引数 `powerUpChance` を追加（デフォルト値で後方互換）
+- `use-game-loop.ts` — ブロック生成時に `powerUpChance` を渡す
+
+### 6-4. skillChargeMultiplier の適用
+- `use-skill-system.ts` — `UseSkillSystemParams` に `skillChargeMultiplier` を追加、チャージ計算に乗算
+- `FalldownShooterGame.tsx` — `useSkillSystem` に `DIFFICULTIES[difficulty].skillChargeMultiplier` を渡す
+
+### 6-5. Object.assign ミューテーションによるスコア二重加算バグの修正
+- `use-game-loop.ts` — `finalScore` 変数を導入し、`updateState` と `saveScore` で同一の値を使用

--- a/.docs/fs-20260225-01/spec.md
+++ b/.docs/fs-20260225-01/spec.md
@@ -1,0 +1,304 @@
+# Falldown Shooter ブラッシュアップ 仕様書
+
+## 新機能仕様
+
+---
+
+### 1. ポーズ機能
+
+#### 概要
+ゲームプレイ中に一時停止できる機能。
+
+#### 操作
+- **Escape キー** または **P キー**: ポーズ ON/OFF トグル
+- **ポーズボタン（⏸）**: ヘッダーに配置、タップでトグル
+
+#### 動作仕様
+- ポーズ中はすべてのゲームループ（スポーン、弾移動、ブロック落下、タイマー）を停止
+- ポーズ画面を表示（半透明オーバーレイ）
+- 再開ボタンまたは同じキーで復帰
+- ポーズ中のキーボード操作（移動・射撃・スキル）は無効化
+
+#### UI設計
+```
+┌──────────────────────┐
+│                      │
+│     ⏸ PAUSED         │
+│                      │
+│   [▶ Resume]         │
+│   [🏠 Title]         │
+│                      │
+└──────────────────────┘
+```
+
+#### 型定義
+```typescript
+// types.ts に追加
+export type GameStatus = 'idle' | 'playing' | 'paused' | 'clear' | 'over' | 'ending';
+```
+
+---
+
+### 2. 難易度設定
+
+#### 概要
+Easy / Normal / Hard の3段階で難易度を選択できる機能。
+
+#### 難易度パラメータ
+
+| パラメータ | Easy | Normal | Hard |
+|-----------|------|--------|------|
+| スポーン間隔倍率 | 1.5x | 1.0x | 0.7x |
+| 落下速度倍率 | 1.3x | 1.0x | 0.8x |
+| スコア倍率 | 0.8x | 1.0x | 1.5x |
+| パワーアップ出現率 | 20% | 15% | 10% |
+| スキルチャージレート | 1.2x | 1.0x | 0.8x |
+
+#### UI設計
+スタート画面に難易度セレクターを追加:
+```
+┌──────────────────────┐
+│  落ち物シューティング    │
+│     ← → Space        │
+│                      │
+│   [Easy] [Normal] [Hard] │
+│                      │
+│     [Start]          │
+└──────────────────────┘
+```
+
+#### 型定義
+```typescript
+// types.ts に追加
+export type Difficulty = 'easy' | 'normal' | 'hard';
+
+export interface DifficultyConfig {
+  label: string;
+  color: string;
+  spawnMultiplier: number;
+  fallMultiplier: number;
+  scoreMultiplier: number;
+  powerUpChance: number;
+  skillChargeMultiplier: number;
+}
+```
+
+#### データ保存
+- スコア保存時に difficulty を含める
+- ランキングは難易度別に分離
+- ストレージキー: `game_score_falling-shooter_<difficulty>`（例: `game_score_falling-shooter_normal`）
+
+#### 難易度パラメータの適用箇所（実装済み）
+
+| パラメータ | 適用箇所 | 適用方法 |
+|-----------|---------|---------|
+| `spawnMultiplier` | `use-game-loop.ts` → `GameLogic.getSpawnInterval()` | スポーン間隔の計算に使用 |
+| `fallMultiplier` | `use-game-loop.ts` → `GameLogic.getFallSpeed()` | 落下速度の計算に使用 |
+| `scoreMultiplier` | `use-game-loop.ts` → 弾衝突・ライン消去スコア | `Math.round(score * scoreMultiplier)` |
+| `powerUpChance` | `block.ts` → `Block.create()` 第3引数 | `Math.random() < powerUpChance` で判定 |
+| `skillChargeMultiplier` | `use-skill-system.ts` → チャージ計算 | `chargeGain * skillChargeMultiplier` |
+
+#### スコア保存タイミング（実装済み）
+
+| タイミング | 保存内容 |
+|-----------|---------|
+| ゲームオーバー | `saveScore('falling-shooter', finalScore, difficulty)` |
+| ステージクリア | `saveScore('falling-shooter', finalScore, difficulty)` |
+| エンディング到達 | `saveScore('falling-shooter', finalScore, difficulty)` |
+
+※ `finalScore` は `updateState` 前に計算し、`Object.assign` によるミューテーションでの二重加算を回避
+
+---
+
+### 3. ランキング機能
+
+#### 概要
+難易度別のトップ10スコアを表示する機能。
+
+#### 表示場所
+- スタート画面: 「ランキング」ボタン
+- ゲームオーバー画面: スコア下部にランキングリンク
+- エンディング画面: スコア下部にランキングリンク
+
+#### UI設計
+```
+┌──────────────────────┐
+│   🏆 ランキング        │
+│                      │
+│ [Easy] [Normal] [Hard] │
+│                      │
+│  1. 12,500  2025/02/25 │
+│  2. 10,200  2025/02/24 │
+│  3.  8,800  2025/02/23 │
+│  ...                 │
+│ 10.  1,200  2025/02/20 │
+│                      │
+│     [Close]          │
+└──────────────────────┘
+```
+
+#### データソース
+- 既存の `score-storage.ts` の `getScores()` を使用
+- `getScores('falling-shooter', 10, difficulty)` でトップ10取得
+
+---
+
+## コンポーネント分割仕様
+
+### カスタムフック一覧
+
+#### `use-game-state.ts`
+```typescript
+interface UseGameStateReturn {
+  state: GameState;
+  stateRef: React.MutableRefObject<GameState>;
+  updateState: (changes: Partial<GameState>) => void;
+  resetState: (stage: number, score: number) => void;
+}
+```
+
+#### `use-game-flow.ts`
+```typescript
+interface UseGameFlowParams {
+  difficulty: Difficulty;  // 難易度（ハイスコア取得に使用）
+  // ... 他のパラメータ
+}
+
+interface UseGameFlowReturn {
+  status: GameStatus;
+  setStatus: (status: GameStatus) => void;
+  highScore: number;
+  startStage: (num: number, score?: number) => void;
+  goToTitle: () => void;
+  resetGame: () => void;
+  nextStage: () => void;
+  loadHighScore: () => void;
+}
+```
+
+#### `use-game-controls.ts`
+```typescript
+interface UseGameControlsReturn {
+  playerX: number;
+  moveLeft: () => void;
+  moveRight: () => void;
+  fire: () => void;
+}
+```
+
+#### `use-skill-system.ts`
+```typescript
+interface UseSkillSystemParams {
+  gameState: UseGameStateReturn;
+  playerX: number;
+  isPlaying: boolean;
+  soundEnabled: boolean;
+  skillChargeMultiplier: number;  // 難易度別チャージ速度倍率
+}
+
+interface UseSkillSystemReturn {
+  skillCharge: number;
+  setSkillCharge: (c: number | ((prev: number) => number)) => void;
+  activateSkill: (skill: SkillType) => void;
+  laserX: number | null;
+  setLaserX: (x: number | null) => void;
+  showBlast: boolean;
+  setShowBlast: (v: boolean) => void;
+}
+```
+
+#### `use-power-up.ts`
+```typescript
+interface UsePowerUpReturn {
+  powers: Powers;
+  explosions: ExplosionData[];
+  handlePowerUp: (type: PowerType, x: number, y: number) => void;
+  handlePowerExpire: (type: PowerType) => void;
+}
+```
+
+#### `use-game-loop.ts`
+```typescript
+interface UseGameLoopParams {
+  gameState: UseGameStateReturn;
+  isPlaying: boolean;
+  powers: { slow: boolean };
+  soundEnabled: boolean;
+  handlePowerUp: (type: PowerType, x: number, y: number) => void;
+  setStatus: (status: GameStatus) => void;
+  loadHighScore: () => void;
+  difficulty: Difficulty;  // 難易度（スコア倍率・パワーアップ確率・スコア保存に使用）
+}
+
+// 4つの useInterval を統合管理
+// difficulty から scoreMultiplier, powerUpChance を取得して適用
+const useGameLoop: (params: UseGameLoopParams) => void;
+```
+
+---
+
+## エラーハンドリング仕様
+
+### audio.ts
+- `AudioContext.state === 'suspended'` 時に `resume()` を呼出
+- `window.AudioContext` 未対応時は `console.warn` で警告
+- 各音声再生で try-catch（既存）を維持
+
+### score-storage.ts
+- `QuotaExceededError` 発生時に古いスコアを自動削除して再試行
+- 最大保存件数: 100件（超過分は古い順に削除）
+- クリーンアップ後も保存失敗時は `console.error` で警告
+
+---
+
+## React.memo 最適化対象
+
+| コンポーネント | 比較対象 Props |
+|--------------|---------------|
+| CellComponent | x, y, color, size, power |
+| BulletView | bullet.id, size |
+| PlayerShip | x, y, size |
+| StatusBar | stage, lines, linesNeeded, score |
+| SkillGauge | charge, onUseSkill |
+| PowerUpIndicator | powers |
+
+---
+
+## アクセシビリティ仕様
+
+### ARIA Live Region
+- スコア表示: `aria-live="polite"` — スコア更新通知
+- ステージ表示: `aria-live="assertive"` — ステージ変更通知
+
+### スキルゲージ
+- `role="progressbar"`
+- `aria-valuenow={charge}`
+- `aria-valuemax={100}`
+- `aria-label="スキルゲージ"`
+
+### ボタン
+- ポーズボタン: `aria-label="ゲームを一時停止"`
+- サウンドボタン: `aria-label="サウンドの切り替え"`
+- ヘルプボタン: `aria-label="ヘルプを表示"`
+- コントロールボタン: `aria-label="左に移動"` / `aria-label="射撃"` / `aria-label="右に移動"`
+
+### フォーカストラップ
+- オーバーレイ表示中は Tab キーでオーバーレイ内の要素のみフォーカス
+
+---
+
+## レスポンシブ仕様
+
+### セルサイズ計算
+```typescript
+// 画面幅に応じてセルサイズを動的計算
+const cellSize = Math.floor(Math.min(
+  (windowWidth - 32) / CONFIG.grid.width,  // 左右パディング 16px ずつ
+  CONFIG.grid.cellSize                       // 最大30px
+));
+```
+
+### ブレークポイント
+- 360px 未満: セルサイズ自動縮小
+- 360px ～ 768px: 標準サイズ
+- 768px 以上: 標準サイズ（デスクトップ）

--- a/.docs/fs-20260225-01/tasks.md
+++ b/.docs/fs-20260225-01/tasks.md
@@ -1,0 +1,86 @@
+# Falldown Shooter ブラッシュアップ タスクチェックリスト
+
+## Phase 1: テスト基盤強化
+
+- [x] 1-1a. CellView.test.tsx 作成
+- [x] 1-1b. BulletView.test.tsx 作成
+- [x] 1-1c. PlayerShip.test.tsx 作成
+- [x] 1-1d. StatusBar.test.tsx 作成
+- [x] 1-1e. SkillGauge.test.tsx 作成
+- [x] 1-1f. PowerUpIndicator.test.tsx 作成
+- [x] 1-1g. Effects.test.tsx 作成
+- [x] 1-1h. Overlays.test.tsx 作成
+- [x] 1-2. hooks.test.ts 作成（useInterval, useKeyboard, useIdleTimer）
+- [x] 1-3. integration.test.tsx 作成（ゲームフロー統合テスト）
+- [x] Phase 1 テスト実行・確認（18 suites, 154 tests PASS）
+
+## Phase 2: コード品質改善
+
+- [x] 2-1a. audio.ts エラーハンドリング強化（suspended resume, 未対応警告）
+- [x] 2-1b. score-storage.ts QuotaExceededError 対応（自動クリーンアップ、MAX_SCORES=100）
+- [x] 2-1c. audio.test.ts 作成
+- [x] 2-2a. use-game-state.ts 作成
+- [x] 2-2b. use-game-flow.ts 作成
+- [x] 2-2c. use-game-controls.ts 作成
+- [x] 2-2d. use-skill-system.ts 作成
+- [x] 2-2e. use-power-up.ts 作成
+- [x] 2-2f. use-game-loop.ts 作成
+- [x] 2-2g. FalldownShooterGame.tsx リファクタリング（179行、フック＋GameBoard/GameOverlays抽出）
+- [x] 2-3. マジックナンバー定数化（EFFECT定数追加、Effects.tsx/Overlays.tsx置換）
+- [x] 2-4. React.memo 最適化（CellComponent, BulletView, PlayerShip, StatusBar, SkillGauge, PowerUpIndicator）
+- [x] Phase 2 テスト実行・確認（全パス）
+
+## Phase 3: 新機能追加
+
+- [x] 3-1a. types.ts に GameStatus='paused' と Difficulty 型追加
+- [x] 3-1b. hooks.ts に Escape/P キーハンドラー追加
+- [x] 3-1c. PauseOverlay.tsx 作成
+- [x] 3-1d. ゲームコンポーネントにポーズ機能統合
+- [x] 3-2a. difficulty.ts 作成（難易度パラメータ定義）
+- [x] 3-2b. DifficultySelector.tsx 作成
+- [x] 3-2c. スタート画面に難易度セレクター統合
+- [x] 3-3a. RankingOverlay.tsx 作成
+- [x] 3-3b. Overlays.tsx にランキングリンク追加（ScoreOverlay共通化含む）
+- [x] Phase 3 テスト実行・確認（全パス）
+
+## Phase 4: UX/UI 改善
+
+- [x] 4-1a. ARIA Live Region 追加（スコア: polite、ステージ: assertive）
+- [x] 4-1b. スキルゲージに ARIA 属性追加（role, aria-valuenow, aria-valuemax, aria-label）
+- [x] 4-1c. 全ボタンに aria-label 追加
+- [x] 4-2a. use-responsive-size.ts 作成
+- [x] 4-2b. FallingShooterPage.styles.ts レスポンシブ対応（max-width, min-height追加）
+- [x] 4-2c. FalldownShooterGame.tsx に useResponsiveSize フック統合
+- [x] 4-3. Overlay DRY 改善（ScoreOverlay共通コンポーネント抽出）
+- [x] Phase 4 テスト実行・確認（全パス）
+
+## Phase 5: 検証・仕上げ
+
+- [x] 5-1. 未使用依存の調査（tone: agile-quiz-sugorokuで使用、jotai: 多数のhooksで使用 → 削除不可）
+- [x] 5-2. テストカバレッジ確認（Stmts 65.56%, Lines 68.01%, コンポーネント層 86.18%）
+- [x] 5-3. ビルド確認（webpack compiled successfully）
+- [x] 5-4. TypeScript 型チェック（falldown-shooter エラー 0）
+- [x] 5-5. 検証・修正完了（18 suites, 154 tests PASS、FalldownShooterGame.tsx 179行）
+
+## 追加対応
+
+- [x] GameBoard.tsx 抽出（ゲーム盤面描画の専用コンポーネント化）
+- [x] GameOverlays.tsx 抽出（オーバーレイ描画の専用コンポーネント化）
+- [x] 統合テスト拡充（ポーズ機能・難易度選択・ランキング表示のフローテスト +8件）
+
+## Phase 6: スコア保存修正 & 難易度パラメータ完全実装
+
+- [x] 6-1a. use-game-loop.ts — saveScore に difficulty を追加（ゲームオーバー時）
+- [x] 6-1b. use-game-loop.ts — ステージクリア・エンディング到達時にもスコア保存を追加
+- [x] 6-1c. use-game-flow.ts — getHighScore に difficulty を渡す（UseGameFlowParams に追加）
+- [x] 6-1d. FalldownShooterGame.tsx — useGameFlow に difficulty を渡す
+- [x] 6-2a. use-game-loop.ts — 弾衝突スコアに scoreMultiplier 適用
+- [x] 6-2b. use-game-loop.ts — ラインクリアスコアに scoreMultiplier 適用
+- [x] 6-3a. block.ts — Block.create に powerUpChance パラメータ追加（デフォルト値で後方互換）
+- [x] 6-3b. use-game-loop.ts — Block.create 呼出時に powerUpChance を渡す
+- [x] 6-4a. use-skill-system.ts — UseSkillSystemParams に skillChargeMultiplier 追加・チャージ計算に適用
+- [x] 6-4b. use-skill-system.ts — useEffect 依存配列に skillChargeMultiplier 追加
+- [x] 6-4c. FalldownShooterGame.tsx — useSkillSystem に DIFFICULTIES[difficulty].skillChargeMultiplier を渡す
+- [x] 6-5. use-game-loop.ts — finalScore 変数導入（Object.assign ミューテーションによるスコア二重加算バグ修正）
+- [x] Phase 6 テスト実行・確認（18 suites, 158 tests PASS）
+- [x] README.md 更新（新機能・ファイル構成・テスト方法の反映）

--- a/src/features/falldown-shooter/FalldownShooterGame.tsx
+++ b/src/features/falldown-shooter/FalldownShooterGame.tsx
@@ -1,381 +1,148 @@
 // 落ち物シューティング メインゲームコンポーネント
 
-// 注: このファイルではパフォーマンス最適化のため、ref経由でゲーム状態を管理しています
-// ゲームループでの高頻度更新に対応するための意図的な設計パターンです
-
-import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { clamp } from '../../utils/math-utils';
-import { saveScore, getHighScore } from '../../utils/score-storage';
-
-import type {
-  GameState,
-  GameStatus,
-  PowerType,
-  SkillType,
-  BulletData,
-  ExplosionData,
-  Powers,
-} from './types';
+import React, { useState, useCallback } from 'react';
+import type { Difficulty, GameStatus } from './types';
 import { CONFIG } from './constants';
-import { uid } from './utils';
-import { Audio } from './audio';
-import { Grid } from './grid';
-import { Block } from './block';
-import { Bullet } from './bullet';
-import { GameLogic } from './game-logic';
-import { Stage } from './stage';
-import { useInterval, useKeyboard, useIdleTimer } from './hooks';
+import { DIFFICULTIES } from './difficulty';
+import { useKeyboard, useIdleTimer } from './hooks';
 
-import { CellComponent } from './components/CellView';
-import { BulletView } from './components/BulletView';
-import { PlayerShip } from './components/PlayerShip';
+import { useGameState } from './hooks/use-game-state';
+import { useGameFlow } from './hooks/use-game-flow';
+import { useGameControls } from './hooks/use-game-controls';
+import { useSkillSystem } from './hooks/use-skill-system';
+import { usePowerUp } from './hooks/use-power-up';
+import { useGameLoop } from './hooks/use-game-loop';
+import { useResponsiveSize } from './hooks/use-responsive-size';
+
 import { SkillGauge } from './components/SkillGauge';
 import { PowerUpIndicator } from './components/PowerUpIndicator';
 import { StatusBar } from './components/StatusBar';
-import { LaserEffectComponent, ExplosionEffectComponent, BlastEffectComponent } from './components/Effects';
-import {
-  StartScreen,
-  ClearScreen,
-  GameOverScreen,
-  EndingScreen,
-  DemoScreen,
-} from './components/Overlays';
+import { DemoScreen } from './components/Overlays';
+import { GameOverlays } from './components/GameOverlays';
+import { GameBoard } from './components/GameBoard';
+import { RankingOverlay } from './components/RankingOverlay';
 
 import {
   PageContainer,
   Header,
   Title,
   IconButton,
-  GameArea,
   ControlsContainer,
   ControlBtn,
-  DangerLine,
 } from '../../pages/FallingShooterPage.styles';
 
 export const FalldownShooterGame: React.FC = () => {
-  const { width: W, height: H, cellSize: SZ } = CONFIG.grid;
+  const SZ = useResponsiveSize();
 
-  // State
-  const stateRef = useRef<GameState>(Stage.create(1, 0, W, H));
-  const spawnTimeRef = useRef<number>(0);
-  const prevScoreRef = useRef<number>(0);
-
-  const [, forceUpdate] = useState<number>(0);
-  const [playerX, setPlayerX] = useState<number>(Math.floor(W / 2));
-  const [status, setStatus] = useState<GameStatus>('idle');
-  const [canFire, setCanFire] = useState<boolean>(true);
-  const [powers, setPowers] = useState<Powers>({
-    triple: false,
-    pierce: false,
-    slow: false,
-    downshot: false,
-  });
-  const [explosions, setExplosions] = useState<ExplosionData[]>([]);
-  const [laserX, setLaserX] = useState<number | null>(null);
-  const [showBlast, setShowBlast] = useState<boolean>(false);
   const [soundEnabled, setSoundEnabled] = useState<boolean>(true);
   const [showDemo, setShowDemo] = useState<boolean>(false);
+  const [showRanking, setShowRanking] = useState<boolean>(false);
+  const [difficulty, setDifficulty] = useState<Difficulty>('normal');
+  const [status, setStatus] = useState<GameStatus>('idle');
 
-  const [skillCharge, setSkillCharge] = useState<number>(0);
-  const [highScore, setHighScore] = useState<number>(0);
-
-  // パフォーマンス最適化のため、ref経由で状態を管理（ゲームループでの高頻度更新に対応）
-  const state = stateRef.current;
   const isPlaying = status === 'playing';
+  const isPaused = status === 'paused';
   const isIdle = status === 'idle';
 
-  // Helpers
-  const updateState = useCallback((changes: Partial<GameState>) => {
-    Object.assign(stateRef.current, changes);
-    forceUpdate(n => n + 1);
-  }, []);
+  // カスタムフック
+  const gameState = useGameState();
+  const { state } = gameState;
 
-  const playSound = useCallback(
-    (sound: () => void) => {
-      if (soundEnabled) sound();
-    },
-    [soundEnabled]
-  );
+  const powerUp = usePowerUp({ gameState, soundEnabled });
+  const { powers, explosions, handlePowerUp } = powerUp;
 
-  const loadHighScore = useCallback(() => {
-    getHighScore('falling-shooter').then(setHighScore);
-  }, []);
+  const controls = useGameControls({ gameState, powers, soundEnabled });
+  const { playerX, moveLeft, moveRight, fire } = controls;
 
-  useEffect(() => {
-    loadHighScore();
-  }, [loadHighScore]);
-
-  // スキルチャージエフェクト
-  useEffect(() => {
-    if (!isPlaying) return;
-    const scoreDiff = state.score - prevScoreRef.current;
-    if (scoreDiff > 0) {
-      const chargeGain = (scoreDiff / CONFIG.skill.chargeRate) * 100;
-      setSkillCharge(c => {
-        const newCharge = Math.min(CONFIG.skill.maxCharge, c + chargeGain);
-        if (c < 100 && newCharge >= 100) playSound(Audio.charge);
-        return newCharge;
-      });
-    }
-    prevScoreRef.current = state.score;
-  }, [state.score, isPlaying, playSound]);
-
-  // パワーアップハンドラー
-  const handlePowerExpire = useCallback((type: PowerType) => {
-    setPowers(p => ({ ...p, [type]: false }));
-  }, []);
-
-  const handlePowerUp = useCallback(
-    (type: PowerType, x: number, y: number) => {
-      if (type === 'bomb') {
-        playSound(Audio.bomb);
-        setExplosions(e => [...e, { id: uid(), x, y }]);
-        setTimeout(() => {
-          const st = stateRef.current;
-          const result = GameLogic.applyExplosion(x, y, st.blocks, st.grid, W, H);
-          updateState({
-            blocks: result.blocks,
-            grid: result.grid,
-            score: st.score + result.score,
-          });
-        }, 0);
-      } else {
-        playSound(Audio.power);
-        setPowers(p => ({ ...p, [type]: true }));
-        setTimeout(() => handlePowerExpire(type), CONFIG.powerUp.duration[type]);
-      }
-    },
-    [playSound, updateState, handlePowerExpire, W, H]
-  );
-
-  // スキルハンドラー
-  const activateSkill = useCallback(
-    (skillType: SkillType) => {
-      if (skillCharge < CONFIG.skill.maxCharge) return;
-
-      playSound(Audio.skill);
-      setSkillCharge(0);
-
-      const st = stateRef.current;
-
-      switch (skillType) {
-        case 'laser': {
-          setLaserX(playerX);
-          setTimeout(() => setLaserX(null), 300);
-          const result = GameLogic.applyLaserColumn(playerX, st.blocks, st.grid);
-          updateState({ blocks: result.blocks, grid: result.grid, score: st.score + result.score });
-          break;
-        }
-        case 'blast': {
-          setShowBlast(true);
-          setTimeout(() => setShowBlast(false), 400);
-          const result = GameLogic.applyBlastAll(st.blocks);
-          updateState({ blocks: result.blocks, score: st.score + result.score });
-          break;
-        }
-        case 'clear': {
-          const result = GameLogic.applyClearBottom(st.grid);
-          if (result.cleared) {
-            const newPlayerY = GameLogic.calculatePlayerY(result.grid);
-            updateState({ grid: result.grid, score: st.score + result.score, playerY: newPlayerY });
-          }
-          break;
-        }
-      }
-    },
-    [skillCharge, playerX, playSound, updateState]
-  );
-
-  // ゲームフローハンドラー
-  const startStage = useCallback(
-    (num: number, score: number = 0) => {
-      stateRef.current = Stage.create(num, score, W, H);
-      prevScoreRef.current = score;
-      setPlayerX(Math.floor(W / 2));
-      setCanFire(true);
-      setPowers({ triple: false, pierce: false, slow: false, downshot: false });
-      setExplosions([]);
-      setLaserX(null);
-      setShowBlast(false);
-      spawnTimeRef.current = 0;
-      setStatus('playing');
-      setShowDemo(false);
-      forceUpdate(n => n + 1);
-    },
-    [W, H]
-  );
-
-  const goToTitle = useCallback(() => {
-    stateRef.current = Stage.create(1, 0, W, H);
-    prevScoreRef.current = 0;
-    setPlayerX(Math.floor(W / 2));
-    setPowers({ triple: false, pierce: false, slow: false, downshot: false });
-    setExplosions([]);
-    setSkillCharge(0);
-    setStatus('idle');
-    forceUpdate(n => n + 1);
-  }, [W, H]);
-
-  const resetGame = useCallback(() => {
-    setSkillCharge(0);
-    startStage(1, 0);
-  }, [startStage]);
-
-  const nextStage = useCallback(() => {
-    playSound(Audio.win);
-    startStage(state.stage + 1, state.score);
-  }, [startStage, state.stage, state.score, playSound]);
-
-  // 操作
-  const moveLeft = useCallback(() => setPlayerX(x => clamp(x - 1, 0, W - 1)), [W]);
-  const moveRight = useCallback(() => setPlayerX(x => clamp(x + 1, 0, W - 1)), [W]);
-
-  const fire = useCallback(() => {
-    if (!canFire) return;
-    playSound(Audio.shoot);
-    const y = stateRef.current.playerY - 1;
-
-    let newBullets: BulletData[];
-    if (powers.triple && powers.downshot) {
-      newBullets = Bullet.createSpreadWithDownshot(playerX, y, powers.pierce);
-    } else if (powers.triple) {
-      newBullets = Bullet.createSpread(playerX, y, powers.pierce);
-    } else if (powers.downshot) {
-      newBullets = Bullet.createWithDownshot(playerX, y, powers.pierce);
-    } else {
-      newBullets = [Bullet.create(playerX, y, 0, -1, powers.pierce)];
-    }
-
-    updateState({ bullets: [...stateRef.current.bullets, ...newBullets] });
-    setCanFire(false);
-    setTimeout(() => setCanFire(true), CONFIG.timing.bullet.cooldown);
-  }, [canFire, playerX, powers, playSound, updateState]);
-
-  // Hooks
-  useIdleTimer(CONFIG.demo.idleTimeout, () => setShowDemo(true), isIdle && !showDemo);
-
-  useKeyboard(isPlaying, {
-    left: moveLeft,
-    right: moveRight,
-    fire,
-    skill1: () => activateSkill('laser'),
-    skill2: () => activateSkill('blast'),
-    skill3: () => activateSkill('clear'),
+  const skill = useSkillSystem({
+    gameState,
+    playerX,
+    isPlaying,
+    soundEnabled,
+    skillChargeMultiplier: DIFFICULTIES[difficulty].skillChargeMultiplier,
   });
 
-  // ゲームループ
-  useInterval(() => updateState({ time: state.time + 1 }), 1000, isPlaying);
+  const flow = useGameFlow({
+    difficulty,
+    gameState,
+    status,
+    setStatus,
+    setPlayerX: controls.setPlayerX,
+    setPowers: powerUp.setPowers,
+    setExplosions: powerUp.setExplosions,
+    setLaserX: skill.setLaserX,
+    setShowBlast: skill.setShowBlast,
+    setSkillCharge: skill.setSkillCharge,
+    setShowDemo,
+    setCanFire: controls.setCanFire,
+    soundEnabled,
+    spawnTimeRef: { current: 0 } as React.MutableRefObject<number>,
+    prevScoreRef: { current: 0 } as React.MutableRefObject<number>,
+  });
 
-  useInterval(
-    () => {
-      const now = Date.now();
-      const spawnInterval = GameLogic.getSpawnInterval(state.time, state.stage);
+  const { resetGame, goToTitle, nextStage } = flow;
 
-      if (now - spawnTimeRef.current > spawnInterval) {
-        if (GameLogic.canSpawnBlock(state.blocks)) {
-          updateState({ blocks: [...state.blocks, Block.create(W, state.blocks)] });
-          spawnTimeRef.current = now;
-        }
-      }
-    },
-    100,
-    isPlaying
-  );
+  // ポーズトグル
+  const togglePause = useCallback(() => {
+    if (status === 'playing') {
+      setStatus('paused');
+    } else if (status === 'paused') {
+      setStatus('playing');
+    }
+  }, [status, setStatus]);
 
-  useInterval(
-    () => {
-      if (!state.bullets.length) return;
+  // ゲームループ（ポーズ中は停止）
+  useGameLoop({
+    gameState,
+    isPlaying: isPlaying && !isPaused,
+    powers,
+    soundEnabled,
+    handlePowerUp,
+    setStatus,
+    loadHighScore: flow.loadHighScore,
+    difficulty,
+  });
 
-      const result = GameLogic.processBullets(
-        state.bullets,
-        state.blocks,
-        state.grid,
-        W,
-        H,
-        handlePowerUp
-      );
+  // キーボード操作（プレイ中またはポーズ中）
+  useKeyboard(isPlaying || isPaused, {
+    left: isPlaying ? moveLeft : () => {},
+    right: isPlaying ? moveRight : () => {},
+    fire: isPlaying ? fire : () => {},
+    skill1: isPlaying ? () => skill.activateSkill('laser') : () => {},
+    skill2: isPlaying ? () => skill.activateSkill('blast') : () => {},
+    skill3: isPlaying ? () => skill.activateSkill('clear') : () => {},
+    pause: togglePause,
+  });
 
-      if (result.hitCount > 0) playSound(Audio.hit);
+  // アイドルタイマー
+  useIdleTimer(CONFIG.demo.idleTimeout, () => setShowDemo(true), isIdle && !showDemo);
 
-      updateState({
-        bullets: result.bullets,
-        blocks: result.blocks,
-        grid: result.grid,
-        score: state.score + result.score,
-      });
-
-      result.pendingBombs.forEach(({ x, y }) => handlePowerUp('bomb', x, y));
-    },
-    CONFIG.timing.bullet.speed,
-    isPlaying
-  );
-
-  useInterval(
-    () => {
-      if (!state.blocks.length) return;
-
-      const { falling, landing } = GameLogic.processBlockFalling(state.blocks, state.grid, H);
-
-      if (!landing.length) {
-        updateState({ blocks: falling });
-        return;
-      }
-
-      playSound(Audio.land);
-
-      const gridWithLanded = Block.placeOnGrid(landing, state.grid);
-      const { grid: clearedGrid, cleared } = Grid.clearFullLines(gridWithLanded);
-
-      if (cleared > 0) playSound(Audio.line);
-
-      const newLines = state.lines + cleared;
-      const newPlayerY = GameLogic.calculatePlayerY(clearedGrid);
-      const lineScore = cleared * CONFIG.score.line * state.stage;
-
-      updateState({
-        blocks: falling,
-        grid: clearedGrid,
-        playerY: newPlayerY,
-        score: state.score + lineScore,
-        lines: newLines,
-      });
-
-      if (newLines >= state.linesNeeded) {
-        setStatus(Stage.isFinal(state.stage) ? 'ending' : 'clear');
-        return;
-      }
-
-      if (GameLogic.isGameOver(clearedGrid)) {
-        playSound(Audio.over);
-        saveScore('falling-shooter', state.score)
-          .then(() => loadHighScore())
-          .catch(err => console.error(err));
-        setStatus('over');
-      }
-    },
-    GameLogic.getFallSpeed(state.time, state.stage, powers.slow),
-    isPlaying
-  );
-
-  // Render
   return (
     <PageContainer>
       {showDemo && <DemoScreen onDismiss={() => setShowDemo(false)} />}
+      {showRanking && <RankingOverlay onClose={() => setShowRanking(false)} />}
 
       <Header>
         <Title>落ち物シューティング</Title>
         <div
           style={{ fontSize: '0.9rem', color: '#fbbf24', marginLeft: 'auto', marginRight: '1rem' }}
         >
-          High Score: {highScore}
+          High Score: {flow.highScore}
         </div>
-        <IconButton onClick={() => setSoundEnabled(s => !s)}>
+        {isPlaying && (
+          <IconButton onClick={togglePause} aria-label="ゲームを一時停止">
+            ⏸
+          </IconButton>
+        )}
+        <IconButton onClick={() => setSoundEnabled(s => !s)} aria-label="サウンドの切り替え">
           {soundEnabled ? '🔊' : '🔇'}
         </IconButton>
-        <IconButton onClick={() => setShowDemo(true)}>❓</IconButton>
+        <IconButton onClick={() => setShowDemo(true)} aria-label="ヘルプを表示">
+          ❓
+        </IconButton>
       </Header>
 
-      <SkillGauge charge={skillCharge} onUseSkill={activateSkill} />
+      <SkillGauge charge={skill.skillCharge} onUseSkill={skill.activateSkill} />
       <PowerUpIndicator powers={powers} />
       <StatusBar
         stage={state.stage}
@@ -385,65 +152,35 @@ export const FalldownShooterGame: React.FC = () => {
       />
 
       <div style={{ position: 'relative' }}>
-        {status === 'idle' && <StartScreen onStart={resetGame} />}
-        {status === 'clear' && <ClearScreen stage={state.stage} onNext={nextStage} />}
-        {status === 'over' && (
-          <GameOverScreen score={state.score} onRetry={resetGame} onTitle={goToTitle} />
-        )}
-        {status === 'ending' && (
-          <EndingScreen score={state.score} onRetry={resetGame} onTitle={goToTitle} />
-        )}
+        <GameOverlays
+          status={status}
+          stage={state.stage}
+          score={state.score}
+          difficulty={difficulty}
+          onDifficultyChange={setDifficulty}
+          onStart={resetGame}
+          onResume={togglePause}
+          onTitle={goToTitle}
+          onNext={nextStage}
+          onRanking={() => setShowRanking(true)}
+        />
 
-        <GameArea
-          $width={W * SZ}
-          $height={H * SZ}
-          role="region"
-          aria-label="シューティングパズルゲーム画面"
-          tabIndex={0}
-        >
-          {state.grid.map((row, y) =>
-            row.map(
-              (color, x) =>
-                color && <CellComponent key={`g${x}${y}`} x={x} y={y} color={color} size={SZ} />
-            )
-          )}
-
-          {state.blocks.map(block =>
-            Block.getCells(block).map(
-              (cell, i) =>
-                cell.y >= 0 && (
-                  <CellComponent
-                    key={`b${block.id}${i}`}
-                    x={cell.x}
-                    y={cell.y}
-                    color={block.color}
-                    size={SZ}
-                    power={i === 0 ? block.power : null}
-                  />
-                )
-            )
-          )}
-
-          {state.bullets.map(b => (
-            <BulletView key={b.id} bullet={b} size={SZ} />
-          ))}
-          {explosions.map(e => (
-            <ExplosionEffectComponent key={e.id} x={e.x} y={e.y} size={SZ} />
-          ))}
-          {laserX !== null && <LaserEffectComponent x={laserX} size={SZ} height={H} />}
-          <BlastEffectComponent visible={showBlast} />
-          <PlayerShip x={playerX} y={state.playerY} size={SZ} />
-
-          <DangerLine $top={SZ * CONFIG.dangerLine} />
-        </GameArea>
+        <GameBoard
+          state={state}
+          playerX={playerX}
+          cellSize={SZ}
+          explosions={explosions}
+          laserX={skill.laserX}
+          showBlast={skill.showBlast}
+        />
       </div>
 
       <ControlsContainer>
-        <ControlBtn onClick={moveLeft}>←</ControlBtn>
-        <ControlBtn onClick={fire} $variant="fire">
+        <ControlBtn onClick={moveLeft} aria-label="左に移動">←</ControlBtn>
+        <ControlBtn onClick={fire} $variant="fire" aria-label="射撃">
           🎯
         </ControlBtn>
-        <ControlBtn onClick={moveRight}>→</ControlBtn>
+        <ControlBtn onClick={moveRight} aria-label="右に移動">→</ControlBtn>
       </ControlsContainer>
     </PageContainer>
   );

--- a/src/features/falldown-shooter/README.md
+++ b/src/features/falldown-shooter/README.md
@@ -5,61 +5,127 @@
 上から落ちてくるブロックを弾で撃って消すシューティングゲーム。
 ステージが進むと難易度が上昇し、パワーアップアイテムやスキルを駆使して高得点を目指す。
 
+## 機能
+
+- **ステージ制**: ライン消去で進行、最終ステージクリアでエンディング
+- **難易度選択**: Easy / Normal / Hard の3段階（スコア倍率・落下速度・パワーアップ確率が変化）
+- **ポーズ機能**: ゲーム中に一時停止可能（Escape / P キー）
+- **ランキング**: 難易度別トップ10スコアを表示
+- **パワーアップ**: トリプルショット、貫通弾、ダウンショット、スロー、爆弾
+- **スキルシステム**: 3種類のスキル（レーザー / ブラスト / クリア）
+
 ## 操作方法
 
-- **矢印キー左/右**: 移動
-- **スペース**: 射撃
-- **Z / X / C**: スキル発動
-- **モバイル**: タッチボタン操作
+| 操作 | キー | 説明 |
+|------|------|------|
+| 移動 | ← → | 左右移動 |
+| 射撃 | Space | 弾を発射 |
+| スキル | Z / X / C | レーザー / ブラスト / クリア |
+| ポーズ | Escape / P | 一時停止トグル |
+| モバイル | タッチボタン | 画面下部のコントロールボタン |
 
-## 技術詳細
+## 難易度パラメータ
 
-### ファイル構成
+| パラメータ | Easy | Normal | Hard |
+|-----------|------|--------|------|
+| スポーン間隔倍率 | 1.5x（遅い） | 1.0x | 0.7x（速い） |
+| 落下速度倍率 | 1.3x（遅い） | 1.0x | 0.8x（速い） |
+| スコア倍率 | 0.8x | 1.0x | 1.5x |
+| パワーアップ出現率 | 20% | 15% | 10% |
+| スキルチャージ速度 | 1.2x（速い） | 1.0x | 0.8x（遅い） |
+
+## ファイル構成
 
 ```
 src/features/falldown-shooter/
-  types.ts              # 型定義
-  constants.ts          # ゲーム設定定数
+  types.ts              # 型定義（GameState, Difficulty, Powers 等）
+  constants.ts          # ゲーム設定定数（CONFIG）
+  difficulty.ts         # 難易度定義（DIFFICULTIES）
   block.ts              # ブロック生成・管理
   bullet.ts             # 弾管理
   grid.ts               # グリッド管理
   stage.ts              # ステージ進行
-  utils.ts              # ユーティリティ関数
   collision.ts          # 衝突判定
   game-logic.ts         # ゲームロジック（純粋関数）
-  audio.ts              # 効果音生成
-  hooks.ts              # カスタムフック
+  audio.ts              # 効果音生成（Web Audio API）
+  utils.ts              # ユーティリティ関数
+  hooks.ts              # 共通カスタムフック（useInterval, useKeyboard, useIdleTimer）
   FalldownShooterGame.tsx  # メインゲームコンポーネント
   index.ts              # barrel export
-  components/
+
+  hooks/                # ゲーム専用カスタムフック
+    use-game-state.ts   # ゲーム状態管理（stateRef, updateState）
+    use-game-flow.ts    # ゲームフロー（startStage, goToTitle, resetGame, nextStage, loadHighScore）
+    use-game-controls.ts # 操作（moveLeft, moveRight, fire）
+    use-game-loop.ts    # ゲームループ（4つのuseInterval統合、スコア保存、難易度パラメータ適用）
+    use-skill-system.ts # スキルシステム（チャージ、発動、skillChargeMultiplier適用）
+    use-power-up.ts     # パワーアップ管理
+    use-responsive-size.ts # レスポンシブセルサイズ計算
+    index.ts            # barrel export
+
+  components/           # UIコンポーネント（すべてReact.memo適用）
     BulletView.tsx      # 弾描画
     CellView.tsx        # セル描画
-    Effects.tsx         # エフェクト
-    Overlays.tsx        # オーバーレイ
-    PlayerShip.tsx      # プレイヤー描画
-    PowerUpIndicator.tsx # パワーアップ表示
-    SkillGauge.tsx      # スキルゲージ
-    StatusBar.tsx       # ステータスバー
-  __tests__/            # ユニットテスト
-    block.test.ts
-    bullet.test.ts
-    collision.test.ts
-    game-logic.test.ts
-    grid.test.ts
-    stage.test.ts
-    utils.test.ts
-src/pages/FallingShooterPage.tsx  # ページコンポーネント（薄いラッパー）
+    Effects.tsx         # エフェクト（レーザー、爆発、ブラスト）
+    Overlays.tsx        # オーバーレイ（スタート、クリア、ゲームオーバー、エンディング、デモ）
+    PlayerShip.tsx      # プレイヤー描画（SVG）
+    PowerUpIndicator.tsx # パワーアップ状態表示
+    SkillGauge.tsx      # スキルゲージ（ARIA対応）
+    StatusBar.tsx       # ステータスバー（ステージ、ライン、スコア）
+    DifficultySelector.tsx # 難易度選択UI
+    GameBoard.tsx       # ゲーム盤面描画
+    GameOverlays.tsx    # オーバーレイ統合管理
+    PauseOverlay.tsx    # ポーズ画面
+    RankingOverlay.tsx  # ランキング表示（難易度別タブ）
+
+  __tests__/            # テスト
+    block.test.ts       # ブロックロジック
+    bullet.test.ts      # 弾ロジック
+    collision.test.ts   # 衝突判定
+    game-logic.test.ts  # ゲームロジック
+    grid.test.ts        # グリッドロジック
+    stage.test.ts       # ステージ進行
+    utils.test.ts       # ユーティリティ
+    audio.test.ts       # 音声エラーハンドリング
+    hooks.test.ts       # カスタムフック（useInterval, useKeyboard, useIdleTimer）
+    integration.test.tsx # 統合テスト（ゲームフロー、ポーズ、難易度、ランキング）
+    components/         # コンポーネントテスト
+      BulletView.test.tsx
+      CellView.test.tsx
+      Effects.test.tsx
+      Overlays.test.tsx
+      PlayerShip.test.tsx
+      PowerUpIndicator.test.tsx
+      SkillGauge.test.tsx
+      StatusBar.test.tsx
+
+src/pages/FallingShooterPage.tsx        # ページコンポーネント（薄いラッパー）
+src/pages/FallingShooterPage.styles.ts  # スタイル定義（レスポンシブ対応）
+src/utils/score-storage.ts             # スコア保存・取得（難易度別キー対応）
 ```
 
-### 状態管理
+## 状態管理
 
-- React Hooks（`useState`, `useRef`, `useCallback`）
-- カスタムフックによるゲーム状態管理
-- パフォーマンス最適化のため `useRef` でゲーム状態管理
+- React Hooks（`useState`, `useRef`, `useCallback`）によるゲーム状態管理
+- `useRef` でゲームループの高頻度更新に対応（`Object.assign` によるミューテーション）
+- カスタムフックへの分離でメインコンポーネントを約180行に維持
 
-### 使用技術
+## 使用技術
 
 - **CSS Animation**: レーザー、爆発、デンジャーラインエフェクト
-- **Web Audio API**: 効果音生成
-- **スキルゲージシステム**: 3種類のスキル（Z/X/C）
-- **パワーアップ**: トリプルショット、貫通弾、爆弾など
+- **Web Audio API**: 効果音生成（AudioContext suspended 対応）
+- **localStorage**: スコア保存（難易度別キー、QuotaExceededError 対応）
+- **React.memo**: 全プレゼンテーショナルコンポーネントのレンダリング最適化
+- **ARIA**: スキルゲージ、ボタンラベル、ライブリージョンによるアクセシビリティ対応
+
+## テスト実行
+
+```bash
+# falldown-shooter のテストのみ実行
+npx jest --testPathPatterns='falldown-shooter' --no-coverage
+
+# カバレッジ付き
+npx jest --testPathPatterns='falldown-shooter' --coverage
+```
+
+**テスト構成**: 18テストスイート / 158テスト

--- a/src/features/falldown-shooter/__tests__/audio.test.ts
+++ b/src/features/falldown-shooter/__tests__/audio.test.ts
@@ -1,0 +1,104 @@
+// Audio モジュールのテスト
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('Audio', () => {
+  let mockOscillator: Record<string, any>;
+  let mockGain: Record<string, any>;
+  let mockAudioContext: Record<string, any>;
+
+  beforeEach(() => {
+    // AudioContext のモックを設定
+    mockOscillator = {
+      connect: jest.fn(),
+      start: jest.fn(),
+      stop: jest.fn(),
+      type: '',
+      frequency: { value: 0 },
+    };
+
+    mockGain = {
+      connect: jest.fn(),
+      gain: {
+        setValueAtTime: jest.fn(),
+        exponentialRampToValueAtTime: jest.fn(),
+      },
+    };
+
+    mockAudioContext = {
+      createOscillator: jest.fn(() => mockOscillator),
+      createGain: jest.fn(() => mockGain),
+      currentTime: 0,
+      destination: {},
+      state: 'running',
+      resume: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // window.AudioContext を設定
+    Object.defineProperty(window, 'AudioContext', {
+      value: jest.fn(() => mockAudioContext),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('shoot が音を再生すること', async () => {
+    // モジュールを新しくインポート（シングルトンリセット）
+    const { Audio } = await import('../audio');
+    Audio.shoot();
+    expect(mockAudioContext.createOscillator).toHaveBeenCalled();
+    expect(mockOscillator.start).toHaveBeenCalled();
+  });
+
+  test('hit が音を再生すること', async () => {
+    const { Audio } = await import('../audio');
+    Audio.hit();
+    expect(mockOscillator.start).toHaveBeenCalled();
+  });
+
+  test('land が音を再生すること', async () => {
+    const { Audio } = await import('../audio');
+    Audio.land();
+    expect(mockOscillator.start).toHaveBeenCalled();
+  });
+
+  test('bomb が音を再生すること', async () => {
+    const { Audio } = await import('../audio');
+    Audio.bomb();
+    expect(mockOscillator.start).toHaveBeenCalled();
+  });
+
+  test('AudioContext 未対応の場合に警告を出すこと', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    Object.defineProperty(window, 'AudioContext', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    // webkitAudioContext も未定義に
+    const win = window as unknown as Record<string, unknown>;
+    delete win.webkitAudioContext;
+
+    const { Audio } = await import('../audio');
+    Audio.shoot();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Web Audio API')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  test('suspended 状態で resume が呼ばれること', async () => {
+    mockAudioContext.state = 'suspended';
+    const { Audio } = await import('../audio');
+    Audio.shoot();
+    expect(mockAudioContext.resume).toHaveBeenCalled();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/BulletView.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/BulletView.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BulletView } from '../../components/BulletView';
+import type { BulletData } from '../../types';
+
+const makeBullet = (overrides: Partial<BulletData> = {}): BulletData => ({
+  id: 'test-bullet',
+  x: 5,
+  y: 10,
+  dx: 0,
+  dy: -1,
+  pierce: false,
+  ...overrides,
+});
+
+describe('BulletView', () => {
+  test('通常弾を描画すること', () => {
+    const { container } = render(
+      <BulletView bullet={makeBullet()} size={30} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('貫通弾の場合に描画されること', () => {
+    const { container } = render(
+      <BulletView bullet={makeBullet({ pierce: true })} size={30} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('下方弾の場合に描画されること', () => {
+    const { container } = render(
+      <BulletView bullet={makeBullet({ dy: 1 })} size={30} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('異なるサイズで描画されること', () => {
+    const { container: container1 } = render(
+      <BulletView bullet={makeBullet()} size={20} />
+    );
+    const { container: container2 } = render(
+      <BulletView bullet={makeBullet()} size={40} />
+    );
+    expect(container1.firstChild).toBeInTheDocument();
+    expect(container2.firstChild).toBeInTheDocument();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/CellView.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/CellView.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CellComponent } from '../../components/CellView';
+import { POWER_TYPES } from '../../constants';
+
+describe('CellComponent', () => {
+  describe('基本描画', () => {
+    test('指定された色でセルを描画すること', () => {
+      const { container } = render(
+        <CellComponent x={2} y={3} color="#FF6B6B" size={30} />
+      );
+      const cell = container.firstChild as HTMLElement;
+      expect(cell).toBeInTheDocument();
+    });
+
+    test('パワーアップなしの場合アイコンを表示しないこと', () => {
+      const { container } = render(
+        <CellComponent x={0} y={0} color="#FF6B6B" size={30} />
+      );
+      expect(container.textContent).toBe('');
+    });
+  });
+
+  describe('パワーアップ表示', () => {
+    test('tripleパワーアップのアイコンを表示すること', () => {
+      const { container } = render(
+        <CellComponent x={0} y={0} color="#FF6B6B" size={30} power="triple" />
+      );
+      expect(container.textContent).toBe(POWER_TYPES.triple.icon);
+    });
+
+    test('bombパワーアップのアイコンを表示すること', () => {
+      const { container } = render(
+        <CellComponent x={0} y={0} color="#FF6B6B" size={30} power="bomb" />
+      );
+      expect(container.textContent).toBe(POWER_TYPES.bomb.icon);
+    });
+
+    test('pierceパワーアップのアイコンを表示すること', () => {
+      const { container } = render(
+        <CellComponent x={0} y={0} color="#FF6B6B" size={30} power="pierce" />
+      );
+      expect(container.textContent).toBe(POWER_TYPES.pierce.icon);
+    });
+
+    test('power=null の場合アイコンを表示しないこと', () => {
+      const { container } = render(
+        <CellComponent x={0} y={0} color="#FF6B6B" size={30} power={null} />
+      );
+      expect(container.textContent).toBe('');
+    });
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/Effects.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/Effects.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import {
+  LaserEffectComponent,
+  ExplosionEffectComponent,
+  BlastEffectComponent,
+} from '../../components/Effects';
+
+// setTimeout をモック化
+jest.useFakeTimers();
+
+describe('LaserEffectComponent', () => {
+  test('初期表示されること', () => {
+    const { container } = render(
+      <LaserEffectComponent x={5} size={30} height={18} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('300ms後に非表示になること', () => {
+    const { container } = render(
+      <LaserEffectComponent x={5} size={30} height={18} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('ExplosionEffectComponent', () => {
+  test('初期表示されること', () => {
+    const { container } = render(
+      <ExplosionEffectComponent x={3} y={5} size={30} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('250ms後に非表示になること', () => {
+    const { container } = render(
+      <ExplosionEffectComponent x={3} y={5} size={30} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('BlastEffectComponent', () => {
+  test('visible=trueの場合表示されること', () => {
+    const { container } = render(<BlastEffectComponent visible={true} />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('visible=falseの場合表示されないこと', () => {
+    const { container } = render(<BlastEffectComponent visible={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/Overlays.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/Overlays.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+  StartScreen,
+  ClearScreen,
+  GameOverScreen,
+  EndingScreen,
+  DemoScreen,
+} from '../../components/Overlays';
+import { DEMO_SLIDES } from '../../constants';
+
+// ShareButton のモック（外部依存を分離）
+jest.mock('../../../../components/molecules/ShareButton', () => ({
+  ShareButton: () => <button data-testid="share-button">Share</button>,
+}));
+
+jest.useFakeTimers();
+
+describe('StartScreen', () => {
+  const defaultProps = {
+    onStart: jest.fn(),
+    difficulty: 'normal' as const,
+    onDifficultyChange: jest.fn(),
+    onRanking: jest.fn(),
+  };
+
+  test('タイトルを表示すること', () => {
+    render(<StartScreen {...defaultProps} />);
+    expect(screen.getByText('落ち物シューティング')).toBeInTheDocument();
+  });
+
+  test('操作説明を表示すること', () => {
+    render(<StartScreen {...defaultProps} />);
+    expect(screen.getByText('← → Space')).toBeInTheDocument();
+  });
+
+  test('Startボタンクリック時にonStartが呼ばれること', () => {
+    const onStart = jest.fn();
+    render(<StartScreen {...defaultProps} onStart={onStart} />);
+    fireEvent.click(screen.getByText('Start'));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  test('難易度セレクターが表示されること', () => {
+    render(<StartScreen {...defaultProps} />);
+    expect(screen.getByText('Easy')).toBeInTheDocument();
+    expect(screen.getByText('Normal')).toBeInTheDocument();
+    expect(screen.getByText('Hard')).toBeInTheDocument();
+  });
+
+  test('ランキングボタンが表示されること', () => {
+    render(<StartScreen {...defaultProps} />);
+    expect(screen.getByText('🏆')).toBeInTheDocument();
+  });
+});
+
+describe('ClearScreen', () => {
+  test('ステージクリアメッセージを表示すること', () => {
+    render(<ClearScreen stage={2} onNext={jest.fn()} />);
+    expect(screen.getByText(/Stage 2 Clear/)).toBeInTheDocument();
+  });
+
+  test('Nextボタンクリック時にonNextが呼ばれること', () => {
+    const onNext = jest.fn();
+    render(<ClearScreen stage={1} onNext={onNext} />);
+    fireEvent.click(screen.getByText('Next'));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GameOverScreen', () => {
+  test('Game Overタイトルを表示すること', () => {
+    render(<GameOverScreen score={500} onRetry={jest.fn()} onTitle={jest.fn()} />);
+    expect(screen.getByText('Game Over')).toBeInTheDocument();
+  });
+
+  test('スコアを表示すること', () => {
+    render(<GameOverScreen score={1500} onRetry={jest.fn()} onTitle={jest.fn()} />);
+    expect(screen.getByText('Score: 1500')).toBeInTheDocument();
+  });
+
+  test('Retryボタンクリック時にonRetryが呼ばれること', () => {
+    const onRetry = jest.fn();
+    render(<GameOverScreen score={0} onRetry={onRetry} onTitle={jest.fn()} />);
+    fireEvent.click(screen.getByText('Retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test('Titleボタンクリック時にonTitleが呼ばれること', () => {
+    const onTitle = jest.fn();
+    render(<GameOverScreen score={0} onRetry={jest.fn()} onTitle={onTitle} />);
+    fireEvent.click(screen.getByText('Title'));
+    expect(onTitle).toHaveBeenCalledTimes(1);
+  });
+
+  test('ランキングボタンが表示されること', () => {
+    render(
+      <GameOverScreen score={0} onRetry={jest.fn()} onTitle={jest.fn()} onRanking={jest.fn()} />
+    );
+    expect(screen.getByText('🏆')).toBeInTheDocument();
+  });
+});
+
+describe('EndingScreen', () => {
+  test('クリアメッセージを表示すること', () => {
+    render(<EndingScreen score={3000} onRetry={jest.fn()} onTitle={jest.fn()} />);
+    expect(screen.getByText(/Clear/)).toBeInTheDocument();
+  });
+
+  test('スコアを表示すること', () => {
+    render(<EndingScreen score={3000} onRetry={jest.fn()} onTitle={jest.fn()} />);
+    expect(screen.getByText('Score: 3000')).toBeInTheDocument();
+  });
+
+  test('Againボタンクリック時にonRetryが呼ばれること', () => {
+    const onRetry = jest.fn();
+    render(<EndingScreen score={0} onRetry={onRetry} onTitle={jest.fn()} />);
+    fireEvent.click(screen.getByText('Again'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test('Titleボタンクリック時にonTitleが呼ばれること', () => {
+    const onTitle = jest.fn();
+    render(<EndingScreen score={0} onRetry={jest.fn()} onTitle={onTitle} />);
+    fireEvent.click(screen.getByText('Title'));
+    expect(onTitle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DemoScreen', () => {
+  test('最初のスライドタイトルを表示すること', () => {
+    render(<DemoScreen onDismiss={jest.fn()} />);
+    expect(screen.getByText(DEMO_SLIDES[0].title)).toBeInTheDocument();
+  });
+
+  test('スライドドットが表示されること', () => {
+    const { container } = render(<DemoScreen onDismiss={jest.fn()} />);
+    // ドットの数がスライド数と一致
+    const dots = container.querySelectorAll('div > div > div');
+    // DemoDot はスライド数分存在するはず
+    expect(dots.length).toBeGreaterThan(0);
+  });
+
+  test('クリック時にonDismissが呼ばれること', () => {
+    const onDismiss = jest.fn();
+    const { container } = render(<DemoScreen onDismiss={onDismiss} />);
+    // DemoContainer をクリック
+    const demoContainer = container.firstChild as HTMLElement;
+    fireEvent.click(demoContainer);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  test('スライドが自動的に切り替わること', () => {
+    render(<DemoScreen onDismiss={jest.fn()} />);
+    expect(screen.getByText(DEMO_SLIDES[0].title)).toBeInTheDocument();
+
+    // スライド間隔分進める
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(screen.getByText(DEMO_SLIDES[1].title)).toBeInTheDocument();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/PlayerShip.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/PlayerShip.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PlayerShip } from '../../components/PlayerShip';
+
+describe('PlayerShip', () => {
+  test('SVGを含むコンポーネントが描画されること', () => {
+    const { container } = render(
+      <PlayerShip x={5} y={16} size={30} />
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  test('ポリゴンが描画されること', () => {
+    const { container } = render(
+      <PlayerShip x={5} y={16} size={30} />
+    );
+    const polygon = container.querySelector('polygon');
+    expect(polygon).toBeInTheDocument();
+    expect(polygon?.getAttribute('fill')).toBe('#0FF');
+  });
+
+  test('異なる座標で描画されること', () => {
+    const { container: c1 } = render(<PlayerShip x={0} y={0} size={30} />);
+    const { container: c2 } = render(<PlayerShip x={11} y={17} size={30} />);
+    expect(c1.firstChild).toBeInTheDocument();
+    expect(c2.firstChild).toBeInTheDocument();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/PowerUpIndicator.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/PowerUpIndicator.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PowerUpIndicator } from '../../components/PowerUpIndicator';
+import { POWER_TYPES } from '../../constants';
+import type { Powers } from '../../types';
+
+const defaultPowers: Powers = {
+  triple: false,
+  pierce: false,
+  slow: false,
+  downshot: false,
+};
+
+describe('PowerUpIndicator', () => {
+  test('全パワーが無効の場合何も表示しないこと', () => {
+    const { container } = render(<PowerUpIndicator powers={defaultPowers} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('tripleが有効の場合バッジを表示すること', () => {
+    const powers: Powers = { ...defaultPowers, triple: true };
+    render(<PowerUpIndicator powers={powers} />);
+    expect(screen.getByText(POWER_TYPES.triple.icon)).toBeInTheDocument();
+  });
+
+  test('pierceが有効の場合バッジを表示すること', () => {
+    const powers: Powers = { ...defaultPowers, pierce: true };
+    render(<PowerUpIndicator powers={powers} />);
+    expect(screen.getByText(POWER_TYPES.pierce.icon)).toBeInTheDocument();
+  });
+
+  test('slowが有効の場合バッジを表示すること', () => {
+    const powers: Powers = { ...defaultPowers, slow: true };
+    render(<PowerUpIndicator powers={powers} />);
+    expect(screen.getByText(POWER_TYPES.slow.icon)).toBeInTheDocument();
+  });
+
+  test('downshotが有効の場合バッジを表示すること', () => {
+    const powers: Powers = { ...defaultPowers, downshot: true };
+    render(<PowerUpIndicator powers={powers} />);
+    expect(screen.getByText(POWER_TYPES.downshot.icon)).toBeInTheDocument();
+  });
+
+  test('複数のパワーが有効の場合すべてのバッジを表示すること', () => {
+    const powers: Powers = { triple: true, pierce: true, slow: false, downshot: true };
+    render(<PowerUpIndicator powers={powers} />);
+    expect(screen.getByText(POWER_TYPES.triple.icon)).toBeInTheDocument();
+    expect(screen.getByText(POWER_TYPES.pierce.icon)).toBeInTheDocument();
+    expect(screen.getByText(POWER_TYPES.downshot.icon)).toBeInTheDocument();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/SkillGauge.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/SkillGauge.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SkillGauge } from '../../components/SkillGauge';
+import { SKILLS } from '../../constants';
+import type { SkillType } from '../../types';
+
+describe('SkillGauge', () => {
+  const mockOnUseSkill = jest.fn();
+
+  beforeEach(() => {
+    mockOnUseSkill.mockClear();
+  });
+
+  describe('ゲージ表示', () => {
+    test('チャージ率をパーセント表示すること', () => {
+      render(<SkillGauge charge={50} onUseSkill={mockOnUseSkill} />);
+      expect(screen.getByText('50%')).toBeInTheDocument();
+    });
+
+    test('小数値を切り捨てて表示すること', () => {
+      render(<SkillGauge charge={33.7} onUseSkill={mockOnUseSkill} />);
+      expect(screen.getByText('33%')).toBeInTheDocument();
+    });
+
+    test('0%の場合も表示すること', () => {
+      render(<SkillGauge charge={0} onUseSkill={mockOnUseSkill} />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+    });
+  });
+
+  describe('スキルボタン', () => {
+    test('チャージ100%未満の場合スキルボタンを表示しないこと', () => {
+      render(<SkillGauge charge={99} onUseSkill={mockOnUseSkill} />);
+      const skillKeys = Object.values(SKILLS).map(s => s.key);
+      skillKeys.forEach(key => {
+        expect(screen.queryByText(key)).not.toBeInTheDocument();
+      });
+    });
+
+    test('チャージ100%の場合3つのスキルボタンを表示すること', () => {
+      render(<SkillGauge charge={100} onUseSkill={mockOnUseSkill} />);
+      expect(screen.getByText(SKILLS.laser.icon)).toBeInTheDocument();
+      expect(screen.getByText(SKILLS.blast.icon)).toBeInTheDocument();
+      expect(screen.getByText(SKILLS.clear.icon)).toBeInTheDocument();
+    });
+
+    test('スキルボタンクリック時にonUseSkillが呼ばれること', () => {
+      render(<SkillGauge charge={100} onUseSkill={mockOnUseSkill} />);
+
+      // laser ボタンを探してクリック
+      const laserButton = screen.getByTitle(`${SKILLS.laser.name}: ${SKILLS.laser.desc}`);
+      fireEvent.click(laserButton);
+      expect(mockOnUseSkill).toHaveBeenCalledWith('laser');
+    });
+
+    test('各スキルボタンが正しいスキルタイプで呼ばれること', () => {
+      render(<SkillGauge charge={100} onUseSkill={mockOnUseSkill} />);
+
+      const skillTypes: SkillType[] = ['laser', 'blast', 'clear'];
+      skillTypes.forEach(skillType => {
+        const button = screen.getByTitle(
+          `${SKILLS[skillType].name}: ${SKILLS[skillType].desc}`
+        );
+        fireEvent.click(button);
+        expect(mockOnUseSkill).toHaveBeenCalledWith(skillType);
+      });
+    });
+  });
+});

--- a/src/features/falldown-shooter/__tests__/components/StatusBar.test.tsx
+++ b/src/features/falldown-shooter/__tests__/components/StatusBar.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { StatusBar } from '../../components/StatusBar';
+
+describe('StatusBar', () => {
+  test('ステージ番号を表示すること', () => {
+    render(<StatusBar stage={2} lines={1} linesNeeded={4} score={500} />);
+    expect(screen.getByText('ST2')).toBeInTheDocument();
+  });
+
+  test('ラインクリア進捗を表示すること', () => {
+    render(<StatusBar stage={1} lines={1} linesNeeded={2} score={100} />);
+    expect(screen.getByText('1/2')).toBeInTheDocument();
+  });
+
+  test('スコアを表示すること', () => {
+    render(<StatusBar stage={1} lines={0} linesNeeded={1} score={1250} />);
+    expect(screen.getByText('1250')).toBeInTheDocument();
+  });
+
+  test('全ての値が0の場合も正しく表示すること', () => {
+    render(<StatusBar stage={1} lines={0} linesNeeded={1} score={0} />);
+    expect(screen.getByText('ST1')).toBeInTheDocument();
+    expect(screen.getByText('0/1')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/src/features/falldown-shooter/__tests__/game-logic.test.ts
+++ b/src/features/falldown-shooter/__tests__/game-logic.test.ts
@@ -116,6 +116,34 @@ describe('GameLogic', () => {
       const slow = GameLogic.getFallSpeed(0, 0, true);
       expect(slow).toBe(normal * 2);
     });
+
+    test('spawnMultiplierでスポーン間隔が変化すること', () => {
+      const base = GameLogic.getSpawnInterval(0, 0);
+      expect(GameLogic.getSpawnInterval(0, 0, 1.5)).toBe(base * 1.5);
+      expect(GameLogic.getSpawnInterval(0, 0, 0.7)).toBeCloseTo(base * 0.7);
+    });
+
+    test('fallMultiplierで落下速度が変化すること', () => {
+      const base = GameLogic.getFallSpeed(0, 0, false);
+      expect(GameLogic.getFallSpeed(0, 0, false, 1.3)).toBeCloseTo(base * 1.3);
+      expect(GameLogic.getFallSpeed(0, 0, false, 0.8)).toBeCloseTo(base * 0.8);
+    });
+
+    test('slowモードとfallMultiplierが同時に適用されること', () => {
+      const base = GameLogic.getFallSpeed(0, 0, false);
+      const multiplier = 1.3;
+      expect(GameLogic.getFallSpeed(0, 0, true, multiplier)).toBeCloseTo(base * 2 * multiplier);
+    });
+
+    test('倍率省略時はデフォルト値1.0が適用されること', () => {
+      const withDefault = GameLogic.getSpawnInterval(5, 1);
+      const withExplicit = GameLogic.getSpawnInterval(5, 1, 1.0);
+      expect(withDefault).toBe(withExplicit);
+
+      const fallDefault = GameLogic.getFallSpeed(5, 1, false);
+      const fallExplicit = GameLogic.getFallSpeed(5, 1, false, 1.0);
+      expect(fallDefault).toBe(fallExplicit);
+    });
   });
 
   describe('applyLaserColumn', () => {

--- a/src/features/falldown-shooter/__tests__/hooks.test.ts
+++ b/src/features/falldown-shooter/__tests__/hooks.test.ts
@@ -1,0 +1,232 @@
+import { renderHook, act } from '@testing-library/react';
+import { useInterval, useKeyboard, useIdleTimer } from '../hooks';
+import type { KeyboardHandlers } from '../types';
+
+// フェイクタイマーを使用
+jest.useFakeTimers();
+
+describe('useInterval', () => {
+  test('enabled=true の場合コールバックが定期的に呼ばれること', () => {
+    const callback = jest.fn();
+    renderHook(() => useInterval(callback, 100, true));
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  test('enabled=false の場合コールバックが呼ばれないこと', () => {
+    const callback = jest.fn();
+    renderHook(() => useInterval(callback, 100, false));
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('enabled を true→false に変更するとコールバックが停止すること', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useInterval(callback, 100, enabled),
+      { initialProps: { enabled: true } }
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    rerender({ enabled: false });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    // 停止後は呼ばれない
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  test('delay 変更時にインターバルがリセットされること', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      ({ delay }) => useInterval(callback, delay, true),
+      { initialProps: { delay: 100 } }
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    callback.mockClear();
+    rerender({ delay: 200 });
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useKeyboard', () => {
+  const createHandlers = (): KeyboardHandlers => ({
+    left: jest.fn(),
+    right: jest.fn(),
+    fire: jest.fn(),
+    skill1: jest.fn(),
+    skill2: jest.fn(),
+    skill3: jest.fn(),
+  });
+
+  test('ArrowLeft キーで left ハンドラーが呼ばれること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    });
+
+    expect(handlers.left).toHaveBeenCalledTimes(1);
+  });
+
+  test('ArrowRight キーで right ハンドラーが呼ばれること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    });
+
+    expect(handlers.right).toHaveBeenCalledTimes(1);
+  });
+
+  test('スペースキーで fire ハンドラーが呼ばれること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    });
+
+    expect(handlers.fire).toHaveBeenCalledTimes(1);
+  });
+
+  test('ArrowUp キーで fire ハンドラーが呼ばれること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    });
+
+    expect(handlers.fire).toHaveBeenCalledTimes(1);
+  });
+
+  test('1,2,3 キーでスキルハンドラーが呼ばれること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '2' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }));
+    });
+
+    expect(handlers.skill1).toHaveBeenCalledTimes(1);
+    expect(handlers.skill2).toHaveBeenCalledTimes(1);
+    expect(handlers.skill3).toHaveBeenCalledTimes(1);
+  });
+
+  test('enabled=false の場合キーイベントが無視されること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(false, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    });
+
+    expect(handlers.left).not.toHaveBeenCalled();
+    expect(handlers.fire).not.toHaveBeenCalled();
+  });
+
+  test('repeat キーイベントが無視されること', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', repeat: true }));
+    });
+
+    expect(handlers.left).not.toHaveBeenCalled();
+  });
+
+  test('未登録キーは何もしないこと', () => {
+    const handlers = createHandlers();
+    renderHook(() => useKeyboard(true, handlers));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+
+    // どのハンドラーも呼ばれない
+    Object.values(handlers).forEach(h => {
+      expect(h).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('useIdleTimer', () => {
+  test('タイムアウト後に onIdle が呼ばれること', () => {
+    const onIdle = jest.fn();
+    renderHook(() => useIdleTimer(3000, onIdle, true));
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  test('enabled=false の場合 onIdle が呼ばれないこと', () => {
+    const onIdle = jest.fn();
+    renderHook(() => useIdleTimer(3000, onIdle, false));
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  test('reset を呼ぶとタイマーがリセットされること', () => {
+    const onIdle = jest.fn();
+    const { result } = renderHook(() => useIdleTimer(3000, onIdle, true));
+
+    // 2秒経過
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // リセット
+    act(() => {
+      result.current();
+    });
+
+    // さらに2秒（リセットから計2秒なので発火しない）
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // さらに1秒（リセットから計3秒で発火）
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/falldown-shooter/__tests__/integration.test.tsx
+++ b/src/features/falldown-shooter/__tests__/integration.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { FalldownShooterGame } from '../FalldownShooterGame';
+
+// ShareButton のモック
+jest.mock('../../../components/molecules/ShareButton', () => ({
+  ShareButton: () => <button data-testid="share-button">Share</button>,
+}));
+
+// Audio のモック
+jest.mock('../audio', () => ({
+  Audio: {
+    shoot: jest.fn(),
+    hit: jest.fn(),
+    land: jest.fn(),
+    line: jest.fn(),
+    power: jest.fn(),
+    bomb: jest.fn(),
+    over: jest.fn(),
+    win: jest.fn(),
+    skill: jest.fn(),
+    charge: jest.fn(),
+  },
+}));
+
+// score-storage のモック
+jest.mock('../../../utils/score-storage', () => ({
+  saveScore: jest.fn().mockResolvedValue(undefined),
+  getHighScore: jest.fn().mockResolvedValue(0),
+  getScores: jest.fn().mockResolvedValue([]),
+}));
+
+jest.useFakeTimers();
+
+describe('FalldownShooterGame 統合テスト', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('ゲーム開始フロー', () => {
+    test('初期状態でスタート画面が表示されること', () => {
+      render(<FalldownShooterGame />);
+      expect(screen.getByText('Start')).toBeInTheDocument();
+    });
+
+    test('Startボタンクリックでゲームが開始されること', async () => {
+      render(<FalldownShooterGame />);
+      fireEvent.click(screen.getByText('Start'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Start')).not.toBeInTheDocument();
+      });
+    });
+
+    test('ゲーム開始後にステータスバーが表示されること', async () => {
+      render(<FalldownShooterGame />);
+      fireEvent.click(screen.getByText('Start'));
+
+      await waitFor(() => {
+        expect(screen.getByText('ST1')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('UI要素', () => {
+    test('サウンドトグルボタンが動作すること', () => {
+      render(<FalldownShooterGame />);
+
+      // 初期状態: サウンド ON
+      expect(screen.getByText('🔊')).toBeInTheDocument();
+
+      // クリックで OFF
+      fireEvent.click(screen.getByText('🔊'));
+      expect(screen.getByText('🔇')).toBeInTheDocument();
+
+      // 再クリックで ON
+      fireEvent.click(screen.getByText('🔇'));
+      expect(screen.getByText('🔊')).toBeInTheDocument();
+    });
+
+    test('ヘルプボタンクリックでデモ画面が表示されること', () => {
+      render(<FalldownShooterGame />);
+      fireEvent.click(screen.getByText('❓'));
+      // デモ画面のコンテンツが表示される
+      expect(screen.getByText('🎮 遊び方')).toBeInTheDocument();
+    });
+
+    test('コントロールボタンが表示されること', () => {
+      render(<FalldownShooterGame />);
+      expect(screen.getByText('←')).toBeInTheDocument();
+      expect(screen.getByText('🎯')).toBeInTheDocument();
+      expect(screen.getByText('→')).toBeInTheDocument();
+    });
+
+    test('難易度セレクターが表示されること', () => {
+      render(<FalldownShooterGame />);
+      expect(screen.getByText('Easy')).toBeInTheDocument();
+      expect(screen.getByText('Normal')).toBeInTheDocument();
+      expect(screen.getByText('Hard')).toBeInTheDocument();
+    });
+  });
+
+  describe('スキルゲージ', () => {
+    test('初期状態で0%が表示されること', () => {
+      render(<FalldownShooterGame />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+    });
+  });
+
+  describe('ハイスコア表示', () => {
+    test('ハイスコアが表示されること', async () => {
+      render(<FalldownShooterGame />);
+      await waitFor(() => {
+        expect(screen.getByText(/High Score/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('デモ画面', () => {
+    test('アイドル状態でデモが自動表示されること', () => {
+      render(<FalldownShooterGame />);
+
+      // 8秒アイドル
+      act(() => {
+        jest.advanceTimersByTime(8000);
+      });
+
+      expect(screen.getByText('🎮 遊び方')).toBeInTheDocument();
+    });
+
+    test('デモ画面クリックで閉じること', () => {
+      render(<FalldownShooterGame />);
+
+      // デモを表示
+      fireEvent.click(screen.getByText('❓'));
+      expect(screen.getByText('🎮 遊び方')).toBeInTheDocument();
+
+      // デモコンテナをクリック（DemoContainerのonClick）
+      const demoTitle = screen.getByText('🎮 遊び方');
+      // 親のDemoContainer要素をクリック
+      fireEvent.click(demoTitle.closest('div')!.parentElement!.parentElement!);
+    });
+  });
+
+  describe('ポーズ機能', () => {
+    test('ゲーム中にEscapeキーでポーズ画面が表示されること', async () => {
+      render(<FalldownShooterGame />);
+
+      // ゲームを開始
+      fireEvent.click(screen.getByText('Start'));
+      await waitFor(() => {
+        expect(screen.queryByText('Start')).not.toBeInTheDocument();
+      });
+
+      // Escapeキーでポーズ
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Escape' });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/PAUSED/)).toBeInTheDocument();
+      });
+    });
+
+    test('ポーズ中にResumeボタンでゲームが再開されること', async () => {
+      render(<FalldownShooterGame />);
+
+      // ゲームを開始
+      fireEvent.click(screen.getByText('Start'));
+      await waitFor(() => {
+        expect(screen.queryByText('Start')).not.toBeInTheDocument();
+      });
+
+      // Escapeキーでポーズ
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Escape' });
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/PAUSED/)).toBeInTheDocument();
+      });
+
+      // Resumeボタンでゲーム再開
+      fireEvent.click(screen.getByText(/Resume/));
+      await waitFor(() => {
+        expect(screen.queryByText(/PAUSED/)).not.toBeInTheDocument();
+      });
+    });
+
+    test('ポーズ中にTitleボタンでタイトルに戻ること', async () => {
+      render(<FalldownShooterGame />);
+
+      // ゲームを開始
+      fireEvent.click(screen.getByText('Start'));
+      await waitFor(() => {
+        expect(screen.queryByText('Start')).not.toBeInTheDocument();
+      });
+
+      // Escapeキーでポーズ
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Escape' });
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/PAUSED/)).toBeInTheDocument();
+      });
+
+      // Titleボタンでタイトルに戻る
+      fireEvent.click(screen.getByText(/Title/));
+      await waitFor(() => {
+        expect(screen.getByText('Start')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('難易度選択', () => {
+    test('難易度を変更できること', () => {
+      render(<FalldownShooterGame />);
+
+      // 初期状態: Normal が選択されている
+      const normalBtn = screen.getByText('Normal');
+      expect(normalBtn).toBeInTheDocument();
+
+      // Easy に変更
+      fireEvent.click(screen.getByText('Easy'));
+
+      // Easy が選択状態に（ボタンが存在し続けること）
+      expect(screen.getByText('Easy')).toBeInTheDocument();
+    });
+
+    test('Hard を選択してゲームを開始できること', async () => {
+      render(<FalldownShooterGame />);
+
+      // Hard に変更
+      fireEvent.click(screen.getByText('Hard'));
+
+      // ゲームを開始
+      fireEvent.click(screen.getByText('Start'));
+      await waitFor(() => {
+        expect(screen.queryByText('Start')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('ランキング機能', () => {
+    test('スタート画面からランキングを表示できること', async () => {
+      render(<FalldownShooterGame />);
+
+      // ランキングボタン（🏆）をクリック
+      const trophyButtons = screen.getAllByText('🏆');
+      fireEvent.click(trophyButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/ランキング/)).toBeInTheDocument();
+      });
+    });
+
+    test('ランキング画面でCloseボタンで閉じられること', async () => {
+      render(<FalldownShooterGame />);
+
+      // ランキング画面を開く
+      const trophyButtons = screen.getAllByText('🏆');
+      fireEvent.click(trophyButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/ランキング/)).toBeInTheDocument();
+      });
+
+      // Closeボタンで閉じる
+      fireEvent.click(screen.getByText('Close'));
+      await waitFor(() => {
+        expect(screen.queryByText(/ランキング/)).not.toBeInTheDocument();
+      });
+    });
+
+    test('スコアがない場合にメッセージが表示されること', async () => {
+      render(<FalldownShooterGame />);
+
+      // ランキング画面を開く
+      const trophyButtons = screen.getAllByText('🏆');
+      fireEvent.click(trophyButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('スコアがありません')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/features/falldown-shooter/block.ts
+++ b/src/features/falldown-shooter/block.ts
@@ -38,10 +38,10 @@ export const Block = {
       power: i === 0 ? block.power : null,
     })),
 
-  create: (gridWidth: number, existingBlocks: BlockData[] = []): BlockData => {
+  create: (gridWidth: number, existingBlocks: BlockData[] = [], powerUpChance: number = CONFIG.powerUp.chance): BlockData => {
     const shape = pick(BLOCK_SHAPES);
     const power =
-      Math.random() < CONFIG.powerUp.chance ? pick(Object.keys(POWER_TYPES) as PowerType[]) : null;
+      Math.random() < powerUpChance ? pick(Object.keys(POWER_TYPES) as PowerType[]) : null;
     const shapeWidth = shape[0].length;
     const shapeHeight = shape.length;
 

--- a/src/features/falldown-shooter/components/BulletView.tsx
+++ b/src/features/falldown-shooter/components/BulletView.tsx
@@ -9,7 +9,7 @@ interface BulletViewProps {
   size: number;
 }
 
-export const BulletView: React.FC<BulletViewProps> = ({ bullet, size }) => {
+export const BulletView: React.FC<BulletViewProps> = React.memo(({ bullet, size }) => {
   const isDownshot = bullet.dy > 0;
   return (
     <BulletWrapper
@@ -21,4 +21,5 @@ export const BulletView: React.FC<BulletViewProps> = ({ bullet, size }) => {
       $downshot={isDownshot}
     />
   );
-};
+});
+BulletView.displayName = 'BulletView';

--- a/src/features/falldown-shooter/components/CellView.tsx
+++ b/src/features/falldown-shooter/components/CellView.tsx
@@ -13,11 +13,12 @@ interface CellProps {
   power?: PowerType | null;
 }
 
-export const CellComponent: React.FC<CellProps> = ({ x, y, color, size, power }) => {
+export const CellComponent: React.FC<CellProps> = React.memo(({ x, y, color, size, power }) => {
   const p = power ? POWER_TYPES[power] : null;
   return (
     <CellWrapper $x={x} $y={y} $size={size} $color={p?.color || color} $hasPower={!!p}>
       {p?.icon}
     </CellWrapper>
   );
-};
+});
+CellComponent.displayName = 'CellComponent';

--- a/src/features/falldown-shooter/components/DifficultySelector.tsx
+++ b/src/features/falldown-shooter/components/DifficultySelector.tsx
@@ -1,0 +1,57 @@
+// 難易度選択コンポーネント
+
+import React from 'react';
+import styled from 'styled-components';
+import type { Difficulty } from '../types';
+import { DIFFICULTIES, DIFFICULTY_ORDER } from '../difficulty';
+
+interface DifficultySelectorProps {
+  selected: Difficulty;
+  onSelect: (difficulty: Difficulty) => void;
+}
+
+const Container = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+`;
+
+const DifficultyBtn = styled.button<{ $color: string; $isSelected: boolean }>`
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: white;
+  border: 2px solid ${props => (props.$isSelected ? 'white' : 'transparent')};
+  cursor: pointer;
+  background-color: ${props => props.$color};
+  opacity: ${props => (props.$isSelected ? 1 : 0.6)};
+  transition: all 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+export const DifficultySelector: React.FC<DifficultySelectorProps> = ({
+  selected,
+  onSelect,
+}) => (
+  <Container>
+    {DIFFICULTY_ORDER.map(key => {
+      const config = DIFFICULTIES[key];
+      return (
+        <DifficultyBtn
+          key={key}
+          $color={config.color}
+          $isSelected={selected === key}
+          onClick={() => onSelect(key)}
+          aria-label={`難易度: ${config.label}`}
+          aria-pressed={selected === key}
+        >
+          {config.label}
+        </DifficultyBtn>
+      );
+    })}
+  </Container>
+);

--- a/src/features/falldown-shooter/components/Effects.tsx
+++ b/src/features/falldown-shooter/components/Effects.tsx
@@ -1,6 +1,7 @@
 // エフェクトコンポーネント群
 
 import React, { useState, useEffect } from 'react';
+import { EFFECT } from '../constants';
 import { Laser, Explosion, Blast } from '../../../pages/FallingShooterPage.styles';
 
 export const LaserEffectComponent: React.FC<{ x: number; size: number; height: number }> = ({
@@ -10,7 +11,7 @@ export const LaserEffectComponent: React.FC<{ x: number; size: number; height: n
 }) => {
   const [visible, setVisible] = useState(true);
   useEffect(() => {
-    setTimeout(() => setVisible(false), 300);
+    setTimeout(() => setVisible(false), EFFECT.laser.duration);
   }, []);
   return visible ? <Laser $x={x} $size={size} $height={height} /> : null;
 };
@@ -22,7 +23,7 @@ export const ExplosionEffectComponent: React.FC<{ x: number; y: number; size: nu
 }) => {
   const [visible, setVisible] = useState(true);
   useEffect(() => {
-    setTimeout(() => setVisible(false), 250);
+    setTimeout(() => setVisible(false), EFFECT.explosion.duration);
   }, []);
   return visible ? <Explosion $x={x} $y={y} $size={size} /> : null;
 };

--- a/src/features/falldown-shooter/components/GameBoard.tsx
+++ b/src/features/falldown-shooter/components/GameBoard.tsx
@@ -1,0 +1,77 @@
+// ゲーム盤面描画コンポーネント
+
+import React from 'react';
+import type { GameState } from '../types';
+import { CONFIG } from '../constants';
+import { Block } from '../block';
+import { CellComponent } from './CellView';
+import { BulletView } from './BulletView';
+import { PlayerShip } from './PlayerShip';
+import { LaserEffectComponent, ExplosionEffectComponent, BlastEffectComponent } from './Effects';
+import { GameArea, DangerLine } from '../../../pages/FallingShooterPage.styles';
+
+interface GameBoardProps {
+  state: GameState;
+  playerX: number;
+  cellSize: number;
+  explosions: { id: string; x: number; y: number }[];
+  laserX: number | null;
+  showBlast: boolean;
+}
+
+/** グリッド・ブロック・弾丸・エフェクト・プレイヤーを描画する */
+export const GameBoard: React.FC<GameBoardProps> = ({
+  state,
+  playerX,
+  cellSize: SZ,
+  explosions,
+  laserX,
+  showBlast,
+}) => {
+  const { width: W, height: H } = CONFIG.grid;
+
+  return (
+    <GameArea
+      $width={W * SZ}
+      $height={H * SZ}
+      role="region"
+      aria-label="シューティングパズルゲーム画面"
+      tabIndex={0}
+    >
+      {state.grid.map((row, y) =>
+        row.map(
+          (color, x) =>
+            color && <CellComponent key={`g${x}${y}`} x={x} y={y} color={color} size={SZ} />
+        )
+      )}
+
+      {state.blocks.map(block =>
+        Block.getCells(block).map(
+          (cell, i) =>
+            cell.y >= 0 && (
+              <CellComponent
+                key={`b${block.id}${i}`}
+                x={cell.x}
+                y={cell.y}
+                color={block.color}
+                size={SZ}
+                power={i === 0 ? block.power : null}
+              />
+            )
+        )
+      )}
+
+      {state.bullets.map(b => (
+        <BulletView key={b.id} bullet={b} size={SZ} />
+      ))}
+      {explosions.map(e => (
+        <ExplosionEffectComponent key={e.id} x={e.x} y={e.y} size={SZ} />
+      ))}
+      {laserX !== null && <LaserEffectComponent x={laserX} size={SZ} height={H} />}
+      <BlastEffectComponent visible={showBlast} />
+      <PlayerShip x={playerX} y={state.playerY} size={SZ} />
+
+      <DangerLine $top={SZ * CONFIG.dangerLine} />
+    </GameArea>
+  );
+};

--- a/src/features/falldown-shooter/components/GameOverlays.tsx
+++ b/src/features/falldown-shooter/components/GameOverlays.tsx
@@ -1,0 +1,67 @@
+// ゲームオーバーレイ管理コンポーネント
+
+import React from 'react';
+import type { GameStatus, Difficulty } from '../types';
+import {
+  StartScreen,
+  ClearScreen,
+  GameOverScreen,
+  EndingScreen,
+} from './Overlays';
+import { PauseOverlay } from './PauseOverlay';
+
+interface GameOverlaysProps {
+  status: GameStatus;
+  stage: number;
+  score: number;
+  difficulty: Difficulty;
+  onDifficultyChange: (d: Difficulty) => void;
+  onStart: () => void;
+  onResume: () => void;
+  onTitle: () => void;
+  onNext: () => void;
+  onRanking: () => void;
+}
+
+/** ステータスに応じたオーバーレイを描画する */
+export const GameOverlays: React.FC<GameOverlaysProps> = ({
+  status,
+  stage,
+  score,
+  difficulty,
+  onDifficultyChange,
+  onStart,
+  onResume,
+  onTitle,
+  onNext,
+  onRanking,
+}) => (
+  <>
+    {status === 'idle' && (
+      <StartScreen
+        onStart={onStart}
+        difficulty={difficulty}
+        onDifficultyChange={onDifficultyChange}
+        onRanking={onRanking}
+      />
+    )}
+    {status === 'paused' && <PauseOverlay onResume={onResume} onTitle={onTitle} />}
+    {status === 'clear' && <ClearScreen stage={stage} onNext={onNext} />}
+    {status === 'over' && (
+      <GameOverScreen
+        score={score}
+        onRetry={onStart}
+        onTitle={onTitle}
+        onRanking={onRanking}
+      />
+    )}
+    {status === 'ending' && (
+      <EndingScreen
+        score={score}
+        onRetry={onStart}
+        onTitle={onTitle}
+        onRanking={onRanking}
+      />
+    )}
+  </>
+);

--- a/src/features/falldown-shooter/components/PauseOverlay.tsx
+++ b/src/features/falldown-shooter/components/PauseOverlay.tsx
@@ -1,0 +1,30 @@
+// ポーズ画面コンポーネント
+
+import React from 'react';
+import {
+  OverlayContainer,
+  OverlayContent,
+  OverlayTitle,
+  OverlayText,
+  Button,
+} from '../../../pages/FallingShooterPage.styles';
+
+interface PauseOverlayProps {
+  onResume: () => void;
+  onTitle: () => void;
+}
+
+export const PauseOverlay: React.FC<PauseOverlayProps> = ({ onResume, onTitle }) => (
+  <OverlayContainer>
+    <OverlayContent>
+      <OverlayTitle $color="#fbbf24">⏸ PAUSED</OverlayTitle>
+      <OverlayText>Esc / P キーで再開</OverlayText>
+      <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+        <Button onClick={onResume}>▶ Resume</Button>
+        <Button onClick={onTitle} $variant="secondary">
+          🏠 Title
+        </Button>
+      </div>
+    </OverlayContent>
+  </OverlayContainer>
+);

--- a/src/features/falldown-shooter/components/PlayerShip.tsx
+++ b/src/features/falldown-shooter/components/PlayerShip.tsx
@@ -9,10 +9,11 @@ interface PlayerShipProps {
   size: number;
 }
 
-export const PlayerShip: React.FC<PlayerShipProps> = ({ x, y, size }) => (
+export const PlayerShip: React.FC<PlayerShipProps> = React.memo(({ x, y, size }) => (
   <PlayerWrapper $x={x} $y={y} $size={size}>
     <svg viewBox="0 0 40 40" style={{ filter: 'drop-shadow(0 0 4px cyan)' }}>
       <polygon points="20,4 36,36 20,28 4,36" fill="#0FF" stroke="#FFF" strokeWidth="2" />
     </svg>
   </PlayerWrapper>
-);
+));
+PlayerShip.displayName = 'PlayerShip';

--- a/src/features/falldown-shooter/components/PowerUpIndicator.tsx
+++ b/src/features/falldown-shooter/components/PowerUpIndicator.tsx
@@ -5,7 +5,7 @@ import type { Powers, PowerType } from '../types';
 import { POWER_TYPES } from '../constants';
 import { PowerIndicator, PowerBadge } from '../../../pages/FallingShooterPage.styles';
 
-export const PowerUpIndicator: React.FC<{ powers: Powers }> = ({ powers }) => {
+export const PowerUpIndicator: React.FC<{ powers: Powers }> = React.memo(({ powers }) => {
   const active = (Object.entries(powers) as [PowerType, boolean][]).filter(
     ([k, v]) => v && k !== 'bomb'
   );
@@ -19,4 +19,5 @@ export const PowerUpIndicator: React.FC<{ powers: Powers }> = ({ powers }) => {
       ))}
     </PowerIndicator>
   );
-};
+});
+PowerUpIndicator.displayName = 'PowerUpIndicator';

--- a/src/features/falldown-shooter/components/RankingOverlay.tsx
+++ b/src/features/falldown-shooter/components/RankingOverlay.tsx
@@ -1,0 +1,123 @@
+// ランキング表示コンポーネント
+
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import type { Difficulty } from '../types';
+import { DIFFICULTIES, DIFFICULTY_ORDER } from '../difficulty';
+import { getScores, type ScoreRecord } from '../../../utils/score-storage';
+import {
+  RankingContainer,
+  OverlayContent,
+  OverlayTitle,
+  Button,
+} from '../../../pages/FallingShooterPage.styles';
+
+interface RankingOverlayProps {
+  onClose: () => void;
+}
+
+const RANKING_LIMIT = 10;
+
+const RankingList = styled.div`
+  margin: 0.75rem 0;
+  text-align: left;
+`;
+
+const RankingRow = styled.div<{ $isFirst: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  color: ${props => (props.$isFirst ? '#facc15' : '#d1d5db')};
+  border-bottom: 1px solid #374151;
+`;
+
+const RankNumber = styled.span`
+  width: 1.5rem;
+  text-align: right;
+  margin-right: 0.5rem;
+`;
+
+const TabContainer = styled.div`
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+  justify-content: center;
+`;
+
+const Tab = styled.button<{ $color: string; $isActive: boolean }>`
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+  border: none;
+  cursor: pointer;
+  background-color: ${props => props.$color};
+  opacity: ${props => (props.$isActive ? 1 : 0.5)};
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+/** 日付をフォーマットする */
+const formatDate = (timestamp: number): string => {
+  const d = new Date(timestamp);
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${month}/${day}`;
+};
+
+export const RankingOverlay: React.FC<RankingOverlayProps> = ({ onClose }) => {
+  const [tab, setTab] = useState<Difficulty>('normal');
+  const [scores, setScores] = useState<ScoreRecord[]>([]);
+
+  useEffect(() => {
+    getScores('falling-shooter', RANKING_LIMIT, tab).then(setScores);
+  }, [tab]);
+
+  return (
+    <RankingContainer>
+      <OverlayContent>
+        <OverlayTitle $color="#facc15">🏆 ランキング</OverlayTitle>
+
+        <TabContainer>
+          {DIFFICULTY_ORDER.map(key => (
+            <Tab
+              key={key}
+              $color={DIFFICULTIES[key].color}
+              $isActive={tab === key}
+              onClick={() => setTab(key)}
+            >
+              {DIFFICULTIES[key].label}
+            </Tab>
+          ))}
+        </TabContainer>
+
+        <RankingList>
+          {scores.length === 0 && (
+            <p style={{ color: '#6b7280', fontSize: '0.8rem', textAlign: 'center' }}>
+              スコアがありません
+            </p>
+          )}
+          {scores.map((record, i) => (
+            <RankingRow key={`${record.timestamp}-${i}`} $isFirst={i === 0}>
+              <span>
+                <RankNumber>{i + 1}.</RankNumber>
+                {record.score.toLocaleString()}
+              </span>
+              <span style={{ fontSize: '0.7rem', color: '#9ca3af' }}>
+                {formatDate(record.timestamp)}
+              </span>
+            </RankingRow>
+          ))}
+        </RankingList>
+
+        <Button onClick={onClose} $variant="secondary">
+          Close
+        </Button>
+      </OverlayContent>
+    </RankingContainer>
+  );
+};

--- a/src/features/falldown-shooter/components/SkillGauge.tsx
+++ b/src/features/falldown-shooter/components/SkillGauge.tsx
@@ -16,12 +16,17 @@ interface SkillGaugeProps {
   onUseSkill: (skill: SkillType) => void;
 }
 
-export const SkillGauge: React.FC<SkillGaugeProps> = ({ charge, onUseSkill }) => {
+export const SkillGauge: React.FC<SkillGaugeProps> = React.memo(({ charge, onUseSkill }) => {
   const isFull = charge >= CONFIG.skill.maxCharge;
   return (
     <SkillGaugeContainer>
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <GaugeBar>
+        <GaugeBar
+          role="progressbar"
+          aria-valuenow={Math.floor(charge)}
+          aria-valuemax={100}
+          aria-label="スキルゲージ"
+        >
           <GaugeFill $width={charge} $isFull={isFull} />
         </GaugeBar>
         <span style={{ fontSize: '0.875rem', fontWeight: 'bold' }}>{Math.floor(charge)}%</span>
@@ -34,6 +39,7 @@ export const SkillGauge: React.FC<SkillGaugeProps> = ({ charge, onUseSkill }) =>
               onClick={() => onUseSkill(key)}
               $color={skill.color}
               title={`${skill.name}: ${skill.desc}`}
+              aria-label={`スキル: ${skill.name}`}
             >
               <span style={{ fontSize: '1.25rem' }}>{skill.icon}</span>
               <span style={{ fontSize: '0.75rem', marginLeft: '0.25rem' }}>{skill.key}</span>
@@ -43,4 +49,5 @@ export const SkillGauge: React.FC<SkillGaugeProps> = ({ charge, onUseSkill }) =>
       )}
     </SkillGaugeContainer>
   );
-};
+});
+SkillGauge.displayName = 'SkillGauge';

--- a/src/features/falldown-shooter/components/StatusBar.tsx
+++ b/src/features/falldown-shooter/components/StatusBar.tsx
@@ -8,12 +8,13 @@ export const StatusBar: React.FC<{
   lines: number;
   linesNeeded: number;
   score: number;
-}> = ({ stage, lines, linesNeeded, score }) => (
+}> = React.memo(({ stage, lines, linesNeeded, score }) => (
   <StatusBarContainer>
-    <StatusBadge $color="#9333ea">ST{stage}</StatusBadge>
+    <StatusBadge $color="#9333ea" aria-live="assertive">ST{stage}</StatusBadge>
     <StatusBadge $color="#16a34a">
       {lines}/{linesNeeded}
     </StatusBadge>
-    <StatusBadge $color="#2563eb">{score}</StatusBadge>
+    <StatusBadge $color="#2563eb" aria-live="polite">{score}</StatusBadge>
   </StatusBarContainer>
-);
+));
+StatusBar.displayName = 'StatusBar';

--- a/src/features/falldown-shooter/constants.ts
+++ b/src/features/falldown-shooter/constants.ts
@@ -69,6 +69,22 @@ export const SKILLS: Record<SkillType, SkillInfo> = {
   clear: { icon: '✨', name: 'ライン消去', desc: '最下段を消去', color: '#00CED1', key: '3' },
 };
 
+// エフェクト・タイミング定数
+export const EFFECT = {
+  laser: { duration: 300 },
+  explosion: { duration: 250 },
+  blast: { duration: 400 },
+  fireworks: {
+    count: 5,
+    particlesPerBurst: 12,
+    colors: ['#FF6B6B', '#4ECDC4', '#FFEAA7', '#FFD700'],
+    updateInterval: 50,
+    gravity: 0.06,
+    velocityScale: 0.4,
+    lifeLoss: 0.02,
+  },
+} as const;
+
 export const DEMO_SLIDES: DemoSlide[] = [
   {
     title: '🎮 遊び方',

--- a/src/features/falldown-shooter/difficulty.ts
+++ b/src/features/falldown-shooter/difficulty.ts
@@ -1,0 +1,35 @@
+// 落ち物シューティング 難易度定義
+
+import type { Difficulty, DifficultyConfig } from './types';
+
+export const DIFFICULTIES: Record<Difficulty, DifficultyConfig> = {
+  easy: {
+    label: 'Easy',
+    color: '#22c55e',
+    spawnMultiplier: 1.5,
+    fallMultiplier: 1.3,
+    scoreMultiplier: 0.8,
+    powerUpChance: 0.2,
+    skillChargeMultiplier: 1.2,
+  },
+  normal: {
+    label: 'Normal',
+    color: '#3b82f6',
+    spawnMultiplier: 1.0,
+    fallMultiplier: 1.0,
+    scoreMultiplier: 1.0,
+    powerUpChance: 0.15,
+    skillChargeMultiplier: 1.0,
+  },
+  hard: {
+    label: 'Hard',
+    color: '#ef4444',
+    spawnMultiplier: 0.7,
+    fallMultiplier: 0.8,
+    scoreMultiplier: 1.5,
+    powerUpChance: 0.1,
+    skillChargeMultiplier: 0.8,
+  },
+};
+
+export const DIFFICULTY_ORDER: Difficulty[] = ['easy', 'normal', 'hard'];

--- a/src/features/falldown-shooter/game-logic.ts
+++ b/src/features/falldown-shooter/game-logic.ts
@@ -174,8 +174,8 @@ export const GameLogic = {
     return blocksNearTop.length < 3;
   },
 
-  getSpawnInterval: (time: number, stage: number): number =>
-    calcTiming(CONFIG.timing.spawn, time, stage),
-  getFallSpeed: (time: number, stage: number, slow: boolean): number =>
-    calcTiming(CONFIG.timing.fall, time, stage) * (slow ? 2 : 1),
+  getSpawnInterval: (time: number, stage: number, spawnMultiplier = 1.0): number =>
+    calcTiming(CONFIG.timing.spawn, time, stage) * spawnMultiplier,
+  getFallSpeed: (time: number, stage: number, slow: boolean, fallMultiplier = 1.0): number =>
+    calcTiming(CONFIG.timing.fall, time, stage) * (slow ? 2 : 1) * fallMultiplier,
 };

--- a/src/features/falldown-shooter/hooks.ts
+++ b/src/features/falldown-shooter/hooks.ts
@@ -29,6 +29,7 @@ export const useKeyboard = (enabled: boolean, handlers: KeyboardHandlers): void 
       '1': handlers.skill1,
       '2': handlers.skill2,
       '3': handlers.skill3,
+      ...(handlers.pause ? { Escape: handlers.pause, p: handlers.pause, P: handlers.pause } : {}),
     };
 
     const handle = (e: KeyboardEvent) => {

--- a/src/features/falldown-shooter/hooks/index.ts
+++ b/src/features/falldown-shooter/hooks/index.ts
@@ -1,0 +1,14 @@
+// カスタムフック barrel export
+
+export { useGameState } from './use-game-state';
+export { useGameFlow } from './use-game-flow';
+export { useGameControls } from './use-game-controls';
+export { useSkillSystem } from './use-skill-system';
+export { usePowerUp } from './use-power-up';
+export { useGameLoop } from './use-game-loop';
+
+export type { UseGameStateReturn } from './use-game-state';
+export type { UseGameFlowReturn } from './use-game-flow';
+export type { UseGameControlsReturn } from './use-game-controls';
+export type { UseSkillSystemReturn } from './use-skill-system';
+export type { UsePowerUpReturn } from './use-power-up';

--- a/src/features/falldown-shooter/hooks/use-game-controls.ts
+++ b/src/features/falldown-shooter/hooks/use-game-controls.ts
@@ -1,0 +1,72 @@
+// ゲーム操作管理フック
+
+import { useState, useCallback } from 'react';
+import type { BulletData, Powers } from '../types';
+import type { UseGameStateReturn } from './use-game-state';
+import { CONFIG } from '../constants';
+import { Audio } from '../audio';
+import { Bullet } from '../bullet';
+import { clamp } from '../../../utils/math-utils';
+
+const { width: W } = CONFIG.grid;
+
+export interface UseGameControlsParams {
+  gameState: UseGameStateReturn;
+  powers: Powers;
+  soundEnabled: boolean;
+}
+
+export interface UseGameControlsReturn {
+  playerX: number;
+  setPlayerX: (x: number | ((prev: number) => number)) => void;
+  canFire: boolean;
+  setCanFire: (v: boolean) => void;
+  moveLeft: () => void;
+  moveRight: () => void;
+  fire: () => void;
+}
+
+export const useGameControls = ({
+  gameState,
+  powers,
+  soundEnabled,
+}: UseGameControlsParams): UseGameControlsReturn => {
+  const [playerX, setPlayerX] = useState<number>(Math.floor(W / 2));
+  const [canFire, setCanFire] = useState<boolean>(true);
+
+  const moveLeft = useCallback(() => setPlayerX(x => clamp(x - 1, 0, W - 1)), []);
+  const moveRight = useCallback(() => setPlayerX(x => clamp(x + 1, 0, W - 1)), []);
+
+  const fire = useCallback(() => {
+    if (!canFire) return;
+    if (soundEnabled) Audio.shoot();
+    const y = gameState.stateRef.current.playerY - 1;
+
+    let newBullets: BulletData[];
+    if (powers.triple && powers.downshot) {
+      newBullets = Bullet.createSpreadWithDownshot(playerX, y, powers.pierce);
+    } else if (powers.triple) {
+      newBullets = Bullet.createSpread(playerX, y, powers.pierce);
+    } else if (powers.downshot) {
+      newBullets = Bullet.createWithDownshot(playerX, y, powers.pierce);
+    } else {
+      newBullets = [Bullet.create(playerX, y, 0, -1, powers.pierce)];
+    }
+
+    gameState.updateState({
+      bullets: [...gameState.stateRef.current.bullets, ...newBullets],
+    });
+    setCanFire(false);
+    setTimeout(() => setCanFire(true), CONFIG.timing.bullet.cooldown);
+  }, [canFire, playerX, powers, soundEnabled, gameState]);
+
+  return {
+    playerX,
+    setPlayerX,
+    canFire,
+    setCanFire,
+    moveLeft,
+    moveRight,
+    fire,
+  };
+};

--- a/src/features/falldown-shooter/hooks/use-game-flow.ts
+++ b/src/features/falldown-shooter/hooks/use-game-flow.ts
@@ -1,0 +1,117 @@
+// ゲームフロー管理フック
+
+import { useState, useCallback, useEffect } from 'react';
+import type { Difficulty, GameStatus, Powers } from '../types';
+import type { UseGameStateReturn } from './use-game-state';
+import { CONFIG } from '../constants';
+import { Audio } from '../audio';
+import { getHighScore } from '../../../utils/score-storage';
+
+const { width: W } = CONFIG.grid;
+const DEFAULT_POWERS: Powers = { triple: false, pierce: false, slow: false, downshot: false };
+
+export interface UseGameFlowParams {
+  difficulty: Difficulty;
+  gameState: UseGameStateReturn;
+  status: GameStatus;
+  setStatus: (status: GameStatus) => void;
+  setPlayerX: (x: number | ((prev: number) => number)) => void;
+  setPowers: (p: Powers | ((prev: Powers) => Powers)) => void;
+  setExplosions: (e: React.SetStateAction<{ id: string; x: number; y: number }[]>) => void;
+  setLaserX: (x: number | null) => void;
+  setShowBlast: (v: boolean) => void;
+  setSkillCharge: (c: number | ((prev: number) => number)) => void;
+  setShowDemo: (v: boolean) => void;
+  setCanFire: (v: boolean) => void;
+  soundEnabled: boolean;
+  spawnTimeRef: React.MutableRefObject<number>;
+  prevScoreRef: React.MutableRefObject<number>;
+}
+
+export interface UseGameFlowReturn {
+  status: GameStatus;
+  setStatus: (status: GameStatus) => void;
+  highScore: number;
+  startStage: (num: number, score?: number) => void;
+  goToTitle: () => void;
+  resetGame: () => void;
+  nextStage: () => void;
+  loadHighScore: () => void;
+}
+
+export const useGameFlow = ({
+  difficulty,
+  gameState,
+  status,
+  setStatus,
+  setPlayerX,
+  setPowers,
+  setExplosions,
+  setLaserX,
+  setShowBlast,
+  setSkillCharge,
+  setShowDemo,
+  setCanFire,
+  soundEnabled,
+  spawnTimeRef,
+  prevScoreRef,
+}: UseGameFlowParams): UseGameFlowReturn => {
+  const [highScore, setHighScore] = useState<number>(0);
+
+  const loadHighScore = useCallback(() => {
+    getHighScore('falling-shooter', difficulty).then(setHighScore);
+  }, [difficulty]);
+
+  useEffect(() => {
+    loadHighScore();
+  }, [loadHighScore]);
+
+  const startStage = useCallback(
+    (num: number, score: number = 0) => {
+      gameState.resetState(num, score);
+      prevScoreRef.current = score;
+      setPlayerX(Math.floor(W / 2));
+      setCanFire(true);
+      setPowers(DEFAULT_POWERS);
+      setExplosions([]);
+      setLaserX(null);
+      setShowBlast(false);
+      spawnTimeRef.current = 0;
+      setStatus('playing');
+      setShowDemo(false);
+    },
+    [gameState, setPlayerX, setPowers, setExplosions, setLaserX, setShowBlast, setShowDemo, setCanFire, setStatus, spawnTimeRef, prevScoreRef]
+  );
+
+  const goToTitle = useCallback(() => {
+    gameState.resetState(1, 0);
+    prevScoreRef.current = 0;
+    setPlayerX(Math.floor(W / 2));
+    setPowers(DEFAULT_POWERS);
+    setExplosions([]);
+    setSkillCharge(0);
+    setStatus('idle');
+  }, [gameState, setPlayerX, setPowers, setExplosions, setSkillCharge, setStatus, prevScoreRef]);
+
+  const resetGame = useCallback(() => {
+    setSkillCharge(0);
+    startStage(1, 0);
+  }, [startStage, setSkillCharge]);
+
+  const nextStage = useCallback(() => {
+    const st = gameState.stateRef.current;
+    if (soundEnabled) Audio.win();
+    startStage(st.stage + 1, st.score);
+  }, [startStage, gameState, soundEnabled]);
+
+  return {
+    status,
+    setStatus,
+    highScore,
+    startStage,
+    goToTitle,
+    resetGame,
+    nextStage,
+    loadHighScore,
+  };
+};

--- a/src/features/falldown-shooter/hooks/use-game-loop.ts
+++ b/src/features/falldown-shooter/hooks/use-game-loop.ts
@@ -1,0 +1,156 @@
+// ゲームループ管理フック
+
+import { useRef } from 'react';
+import type { Difficulty, GameStatus, PowerType } from '../types';
+import type { UseGameStateReturn } from './use-game-state';
+import { CONFIG } from '../constants';
+import { DIFFICULTIES } from '../difficulty';
+import { Audio } from '../audio';
+import { Block } from '../block';
+import { Grid } from '../grid';
+import { GameLogic } from '../game-logic';
+import { Stage } from '../stage';
+import { useInterval } from '../hooks';
+import { saveScore } from '../../../utils/score-storage';
+
+const { width: W, height: H } = CONFIG.grid;
+
+export interface UseGameLoopParams {
+  gameState: UseGameStateReturn;
+  isPlaying: boolean;
+  powers: { slow: boolean };
+  soundEnabled: boolean;
+  handlePowerUp: (type: PowerType, x: number, y: number) => void;
+  setStatus: (status: GameStatus) => void;
+  loadHighScore: () => void;
+  difficulty: Difficulty;
+}
+
+export const useGameLoop = ({
+  gameState,
+  isPlaying,
+  powers,
+  soundEnabled,
+  handlePowerUp,
+  setStatus,
+  loadHighScore,
+  difficulty,
+}: UseGameLoopParams): void => {
+  const { spawnMultiplier, fallMultiplier, scoreMultiplier, powerUpChance } = DIFFICULTIES[difficulty];
+  const spawnTimeRef = useRef<number>(0);
+
+  // タイマー（1秒ごとに time を加算）
+  useInterval(
+    () => gameState.updateState({ time: gameState.stateRef.current.time + 1 }),
+    1000,
+    isPlaying
+  );
+
+  // ブロックスポーン
+  useInterval(
+    () => {
+      const state = gameState.stateRef.current;
+      const now = Date.now();
+      const spawnInterval = GameLogic.getSpawnInterval(state.time, state.stage, spawnMultiplier);
+
+      if (now - spawnTimeRef.current > spawnInterval) {
+        if (GameLogic.canSpawnBlock(state.blocks)) {
+          gameState.updateState({
+            blocks: [...state.blocks, Block.create(W, state.blocks, powerUpChance)],
+          });
+          spawnTimeRef.current = now;
+        }
+      }
+    },
+    100,
+    isPlaying
+  );
+
+  // 弾の処理と衝突判定
+  useInterval(
+    () => {
+      const state = gameState.stateRef.current;
+      if (!state.bullets.length) return;
+
+      const result = GameLogic.processBullets(
+        state.bullets,
+        state.blocks,
+        state.grid,
+        W,
+        H,
+        handlePowerUp
+      );
+
+      if (result.hitCount > 0 && soundEnabled) Audio.hit();
+
+      gameState.updateState({
+        bullets: result.bullets,
+        blocks: result.blocks,
+        grid: result.grid,
+        score: state.score + Math.round(result.score * scoreMultiplier),
+      });
+
+      result.pendingBombs.forEach(({ x, y }) => handlePowerUp('bomb', x, y));
+    },
+    CONFIG.timing.bullet.speed,
+    isPlaying
+  );
+
+  // ブロック落下
+  useInterval(
+    () => {
+      const state = gameState.stateRef.current;
+      if (!state.blocks.length) return;
+
+      const { falling, landing } = GameLogic.processBlockFalling(state.blocks, state.grid, H);
+
+      if (!landing.length) {
+        gameState.updateState({ blocks: falling });
+        return;
+      }
+
+      if (soundEnabled) Audio.land();
+
+      const gridWithLanded = Block.placeOnGrid(landing, state.grid);
+      const { grid: clearedGrid, cleared } = Grid.clearFullLines(gridWithLanded);
+
+      if (cleared > 0 && soundEnabled) Audio.line();
+
+      const newLines = state.lines + cleared;
+      const newPlayerY = GameLogic.calculatePlayerY(clearedGrid);
+      const lineScore = Math.round(cleared * CONFIG.score.line * state.stage * scoreMultiplier);
+      const finalScore = state.score + lineScore;
+
+      gameState.updateState({
+        blocks: falling,
+        grid: clearedGrid,
+        playerY: newPlayerY,
+        score: finalScore,
+        lines: newLines,
+      });
+
+      if (newLines >= state.linesNeeded) {
+        saveScore('falling-shooter', finalScore, difficulty)
+          .then(() => loadHighScore())
+          .catch(err => console.error(err));
+        setStatus(Stage.isFinal(state.stage) ? 'ending' : 'clear');
+        return;
+      }
+
+      if (GameLogic.isGameOver(clearedGrid)) {
+        if (soundEnabled) Audio.over();
+        saveScore('falling-shooter', finalScore, difficulty)
+          .then(() => loadHighScore())
+          .catch(err => console.error(err));
+        setStatus('over');
+      }
+    },
+    GameLogic.getFallSpeed(
+      gameState.stateRef.current.time,
+      gameState.stateRef.current.stage,
+      powers.slow,
+      fallMultiplier
+    ),
+    isPlaying
+  );
+};

--- a/src/features/falldown-shooter/hooks/use-game-state.ts
+++ b/src/features/falldown-shooter/hooks/use-game-state.ts
@@ -1,0 +1,37 @@
+// ゲーム状態管理フック
+
+import { useState, useCallback, useRef } from 'react';
+import type { GameState } from '../types';
+import { Stage } from '../stage';
+import { CONFIG } from '../constants';
+
+export interface UseGameStateReturn {
+  state: GameState;
+  stateRef: React.MutableRefObject<GameState>;
+  updateState: (changes: Partial<GameState>) => void;
+  resetState: (stage: number, score: number) => void;
+}
+
+const { width: W, height: H } = CONFIG.grid;
+
+export const useGameState = (): UseGameStateReturn => {
+  const stateRef = useRef<GameState>(Stage.create(1, 0, W, H));
+  const [, forceUpdate] = useState<number>(0);
+
+  const updateState = useCallback((changes: Partial<GameState>) => {
+    Object.assign(stateRef.current, changes);
+    forceUpdate(n => n + 1);
+  }, []);
+
+  const resetState = useCallback((stage: number, score: number) => {
+    stateRef.current = Stage.create(stage, score, W, H);
+    forceUpdate(n => n + 1);
+  }, []);
+
+  return {
+    state: stateRef.current,
+    stateRef,
+    updateState,
+    resetState,
+  };
+};

--- a/src/features/falldown-shooter/hooks/use-power-up.ts
+++ b/src/features/falldown-shooter/hooks/use-power-up.ts
@@ -1,0 +1,74 @@
+// パワーアップ管理フック
+
+import { useState, useCallback } from 'react';
+import type { PowerType, Powers, ExplosionData } from '../types';
+import type { UseGameStateReturn } from './use-game-state';
+import { CONFIG } from '../constants';
+import { Audio } from '../audio';
+import { GameLogic } from '../game-logic';
+import { uid } from '../utils';
+
+const { width: W, height: H } = CONFIG.grid;
+
+export interface UsePowerUpParams {
+  gameState: UseGameStateReturn;
+  soundEnabled: boolean;
+}
+
+export interface UsePowerUpReturn {
+  powers: Powers;
+  setPowers: (p: Powers | ((prev: Powers) => Powers)) => void;
+  explosions: ExplosionData[];
+  setExplosions: (e: React.SetStateAction<ExplosionData[]>) => void;
+  handlePowerUp: (type: PowerType, x: number, y: number) => void;
+  handlePowerExpire: (type: PowerType) => void;
+}
+
+export const usePowerUp = ({
+  gameState,
+  soundEnabled,
+}: UsePowerUpParams): UsePowerUpReturn => {
+  const [powers, setPowers] = useState<Powers>({
+    triple: false,
+    pierce: false,
+    slow: false,
+    downshot: false,
+  });
+  const [explosions, setExplosions] = useState<ExplosionData[]>([]);
+
+  const handlePowerExpire = useCallback((type: PowerType) => {
+    setPowers(p => ({ ...p, [type]: false }));
+  }, []);
+
+  const handlePowerUp = useCallback(
+    (type: PowerType, x: number, y: number) => {
+      if (type === 'bomb') {
+        if (soundEnabled) Audio.bomb();
+        setExplosions(e => [...e, { id: uid(), x, y }]);
+        setTimeout(() => {
+          const st = gameState.stateRef.current;
+          const result = GameLogic.applyExplosion(x, y, st.blocks, st.grid, W, H);
+          gameState.updateState({
+            blocks: result.blocks,
+            grid: result.grid,
+            score: st.score + result.score,
+          });
+        }, 0);
+      } else {
+        if (soundEnabled) Audio.power();
+        setPowers(p => ({ ...p, [type]: true }));
+        setTimeout(() => handlePowerExpire(type), CONFIG.powerUp.duration[type]);
+      }
+    },
+    [soundEnabled, gameState, handlePowerExpire]
+  );
+
+  return {
+    powers,
+    setPowers,
+    explosions,
+    setExplosions,
+    handlePowerUp,
+    handlePowerExpire,
+  };
+};

--- a/src/features/falldown-shooter/hooks/use-responsive-size.ts
+++ b/src/features/falldown-shooter/hooks/use-responsive-size.ts
@@ -1,0 +1,32 @@
+// レスポンシブセルサイズ計算フック
+
+import { useState, useEffect } from 'react';
+import { CONFIG } from '../constants';
+
+const PADDING = 32; // 左右パディング合計
+
+/** ウィンドウサイズに応じたセルサイズを計算する */
+const calculateCellSize = (windowWidth: number): number => {
+  const maxWidth = windowWidth - PADDING;
+  const calculated = Math.floor(maxWidth / CONFIG.grid.width);
+  return Math.min(calculated, CONFIG.grid.cellSize);
+};
+
+export const useResponsiveSize = (): number => {
+  const [cellSize, setCellSize] = useState<number>(() =>
+    typeof window !== 'undefined'
+      ? calculateCellSize(window.innerWidth)
+      : CONFIG.grid.cellSize
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setCellSize(calculateCellSize(window.innerWidth));
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return cellSize;
+};

--- a/src/features/falldown-shooter/hooks/use-skill-system.ts
+++ b/src/features/falldown-shooter/hooks/use-skill-system.ts
@@ -1,0 +1,113 @@
+// スキルシステム管理フック
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { SkillType } from '../types';
+import type { UseGameStateReturn } from './use-game-state';
+import { CONFIG } from '../constants';
+import { Audio } from '../audio';
+import { GameLogic } from '../game-logic';
+
+export interface UseSkillSystemParams {
+  gameState: UseGameStateReturn;
+  playerX: number;
+  isPlaying: boolean;
+  soundEnabled: boolean;
+  skillChargeMultiplier: number;
+}
+
+export interface UseSkillSystemReturn {
+  skillCharge: number;
+  setSkillCharge: (c: number | ((prev: number) => number)) => void;
+  activateSkill: (skill: SkillType) => void;
+  laserX: number | null;
+  setLaserX: (x: number | null) => void;
+  showBlast: boolean;
+  setShowBlast: (v: boolean) => void;
+}
+
+export const useSkillSystem = ({
+  gameState,
+  playerX,
+  isPlaying,
+  soundEnabled,
+  skillChargeMultiplier,
+}: UseSkillSystemParams): UseSkillSystemReturn => {
+  const [skillCharge, setSkillCharge] = useState<number>(0);
+  const [laserX, setLaserX] = useState<number | null>(null);
+  const [showBlast, setShowBlast] = useState<boolean>(false);
+  const prevScoreRef = useRef<number>(0);
+
+  // スキルチャージエフェクト
+  useEffect(() => {
+    if (!isPlaying) return;
+    const state = gameState.stateRef.current;
+    const scoreDiff = state.score - prevScoreRef.current;
+    if (scoreDiff > 0) {
+      const chargeGain = (scoreDiff / CONFIG.skill.chargeRate) * 100 * skillChargeMultiplier;
+      setSkillCharge(c => {
+        const newCharge = Math.min(CONFIG.skill.maxCharge, c + chargeGain);
+        if (c < 100 && newCharge >= 100 && soundEnabled) Audio.charge();
+        return newCharge;
+      });
+    }
+    prevScoreRef.current = state.score;
+  }, [gameState.stateRef.current.score, isPlaying, soundEnabled, gameState.stateRef, skillChargeMultiplier]);
+
+  const activateSkill = useCallback(
+    (skillType: SkillType) => {
+      if (skillCharge < CONFIG.skill.maxCharge) return;
+
+      if (soundEnabled) Audio.skill();
+      setSkillCharge(0);
+
+      const st = gameState.stateRef.current;
+
+      switch (skillType) {
+        case 'laser': {
+          setLaserX(playerX);
+          setTimeout(() => setLaserX(null), 300);
+          const result = GameLogic.applyLaserColumn(playerX, st.blocks, st.grid);
+          gameState.updateState({
+            blocks: result.blocks,
+            grid: result.grid,
+            score: st.score + result.score,
+          });
+          break;
+        }
+        case 'blast': {
+          setShowBlast(true);
+          setTimeout(() => setShowBlast(false), 400);
+          const result = GameLogic.applyBlastAll(st.blocks);
+          gameState.updateState({
+            blocks: result.blocks,
+            score: st.score + result.score,
+          });
+          break;
+        }
+        case 'clear': {
+          const result = GameLogic.applyClearBottom(st.grid);
+          if (result.cleared) {
+            const newPlayerY = GameLogic.calculatePlayerY(result.grid);
+            gameState.updateState({
+              grid: result.grid,
+              score: st.score + result.score,
+              playerY: newPlayerY,
+            });
+          }
+          break;
+        }
+      }
+    },
+    [skillCharge, playerX, soundEnabled, gameState]
+  );
+
+  return {
+    skillCharge,
+    setSkillCharge,
+    activateSkill,
+    laserX,
+    setLaserX,
+    showBlast,
+    setShowBlast,
+  };
+};

--- a/src/features/falldown-shooter/index.ts
+++ b/src/features/falldown-shooter/index.ts
@@ -18,6 +18,7 @@ export type {
   PowerType,
   SkillType,
   GameStatus,
+  Difficulty,
   OscillatorType,
   TimingConfig,
   Config,
@@ -34,4 +35,5 @@ export type {
   BulletProcessResult,
   DemoSlide,
   KeyboardHandlers,
+  DifficultyConfig,
 } from './types';

--- a/src/features/falldown-shooter/types.ts
+++ b/src/features/falldown-shooter/types.ts
@@ -2,7 +2,8 @@
 
 export type PowerType = 'triple' | 'pierce' | 'bomb' | 'slow' | 'downshot';
 export type SkillType = 'laser' | 'blast' | 'clear';
-export type GameStatus = 'idle' | 'playing' | 'clear' | 'over' | 'ending';
+export type GameStatus = 'idle' | 'playing' | 'paused' | 'clear' | 'over' | 'ending';
+export type Difficulty = 'easy' | 'normal' | 'hard';
 export type OscillatorType = 'sine' | 'square' | 'sawtooth' | 'triangle';
 
 export interface TimingConfig {
@@ -133,4 +134,15 @@ export interface KeyboardHandlers {
   skill1: () => void;
   skill2: () => void;
   skill3: () => void;
+  pause?: () => void;
+}
+
+export interface DifficultyConfig {
+  label: string;
+  color: string;
+  spawnMultiplier: number;
+  fallMultiplier: number;
+  scoreMultiplier: number;
+  powerUpChance: number;
+  skillChargeMultiplier: number;
 }

--- a/src/pages/FallingShooterPage.styles.ts
+++ b/src/pages/FallingShooterPage.styles.ts
@@ -48,6 +48,7 @@ export const GameArea = styled.div<{ $width: number; $height: number }>`
   overflow: hidden;
   width: ${props => props.$width}px;
   height: ${props => props.$height}px;
+  max-width: calc(100vw - 2rem);
 `;
 
 export const CellWrapper = styled.div<{
@@ -115,6 +116,16 @@ export const OverlayContainer = styled.div`
   background-color: rgba(0, 0, 0, 0.8);
 `;
 
+export const RankingContainer = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.85);
+`;
+
 export const OverlayContent = styled.div`
   padding: 1rem;
   border-radius: 0.5rem;
@@ -175,6 +186,7 @@ export const ControlBtn = styled.button<{ $variant?: 'fire' | 'default' }>`
   user-select: none;
   touch-action: manipulation;
   transition: transform 0.1s;
+  min-height: 48px;
 
   &:active {
     transform: scale(0.95);


### PR DESCRIPTION
## 概要
落ち物シューティング（falldown-shooter）のスコア保存バグ修正と、難易度パラメータの完全実装を行いました。
併せて、Phase 1〜5 で実施したリファクタリング・新機能追加・テスト拡充も含まれています。

## 変更内容

### スコア保存修正
- `saveScore` に `difficulty` を渡し、保存キー（`game_score_falling-shooter_normal` 等）と取得キーの不一致を解消
- ステージクリア・エンディング到達時にもスコア保存を追加（これまでゲームオーバー時のみだった）
- `Object.assign` によるミューテーションで発生していたスコア二重加算バグを `finalScore` 変数の導入で修正

### 難易度パラメータ完全実装
- `scoreMultiplier`: 弾衝突スコア・ラインクリアスコアに適用
- `powerUpChance`: `Block.create` に渡して難易度別パワーアップ出現率を実現
- `skillChargeMultiplier`: スキルチャージ計算に適用

### リファクタリング（Phase 2）
- メインコンポーネント（450行→180行）をカスタムフック6個 + UIコンポーネント2個に分離
- マジックナンバーの定数化、全プレゼンテーショナルコンポーネントに React.memo 適用

### 新機能追加（Phase 3）
- ポーズ機能（Escape / P キー）
- 難易度選択 UI（Easy / Normal / Hard）
- ランキング表示（難易度別トップ10）

### UX/UI 改善（Phase 4）
- ARIA 対応（ライブリージョン、ボタンラベル、スキルゲージ）
- レスポンシブ対応（セルサイズ動的計算）

### テスト拡充（Phase 1）
- コンポーネントテスト 8件、フックテスト、統合テスト追加
- **18 テストスイート / 158 テスト: すべて PASS**

## 変更対象ファイル（48ファイル）
- 新規: 25ファイル（カスタムフック7、コンポーネント5、テスト10、ドキュメント3）
- 変更: 23ファイル

## テスト方法
- [x] `npx jest --testPathPatterns='falldown-shooter' --no-coverage` で全テスト PASS
- [x] ゲームオーバー後、ランキングにスコアが表示されること
- [x] 難易度別タブで正しい難易度のスコアのみ表示されること
- [x] Easy / Hard で落下速度・スコア倍率・パワーアップ確率に差があること
- [x] ポーズ（Escape / P）でゲームが一時停止・再開すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)