### PR TITLE
chore: .gitignore に CLAUDE.md と GEMINI.md を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ lint_output.txt
 .gemini/
 .mcp.json
 /AGENTS.md
+/CLAUDE.md
+/GEMINI.md


### PR DESCRIPTION
## Summary
- AGENTS.md への symlink である CLAUDE.md と GEMINI.md を .gitignore に追加
- 各 CLI（Claude Code / Gemini CLI）が AGENTS.md を参照するためのローカルファイルであり、リポジトリに含める必要がない

## Test plan
- [ ] `.gitignore` の差分が CLAUDE.md と GEMINI.md の追加のみであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)