### PR TITLE
feat: フッターに YouTube チャンネル「灯火の絵物語」のリンクを追加

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -78,6 +78,37 @@ describe('App フッター', () => {
         expect.stringContaining('gallery.niku9.click')
       );
     });
+
+    it('YouTube チャンネル「灯火の絵物語」へのリンクが表示される', () => {
+      const footer = renderFooter();
+      const youtubeLink = within(footer).getByRole('link', {
+        name: /灯火の絵物語/,
+      });
+
+      expect(youtubeLink).toBeInTheDocument();
+    });
+
+    it('YouTube リンクが新しいタブで開く設定になっている', () => {
+      const footer = renderFooter();
+      const youtubeLink = within(footer).getByRole('link', {
+        name: /灯火の絵物語/,
+      });
+
+      expect(youtubeLink).toHaveAttribute('target', '_blank');
+      expect(youtubeLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('YouTube リンクが youtube.com/@toukanoemonogatari を指す', () => {
+      const footer = renderFooter();
+      const youtubeLink = within(footer).getByRole('link', {
+        name: /灯火の絵物語/,
+      });
+
+      expect(youtubeLink).toHaveAttribute(
+        'href',
+        'https://www.youtube.com/@toukanoemonogatari'
+      );
+    });
   });
 
   describe('下段: コピーライト', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -388,6 +388,15 @@ const App: React.FC = () => {
               >
                 Gallery NIKU9 桜花-Click
               </SisterSiteLink>
+              {' ／ '}
+              <span aria-hidden="true">📺</span>{' '}
+              <SisterSiteLink
+                href="https://www.youtube.com/@toukanoemonogatari"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                灯火の絵物語
+              </SisterSiteLink>
             </SisterSiteRow>
             <CopyrightRow>&copy; 2026 niku9.click All Rights Reserved.</CopyrightRow>
           </Footer>


### PR DESCRIPTION
## 概要

サイト運営者の YouTube チャンネル「灯火の絵物語」へのリンクをフッターの姉妹サイト行に追加します。既存の Gallery NIKU9 と並列で、同じ運営者の別活動を緩く接続することが目的です。

## 変更内容

- `src/App.tsx`: `SisterSiteRow` 内に YouTube チャンネルへの外部リンクを並列追加（区切り `／`）
  - URL: `https://www.youtube.com/@toukanoemonogatari`
  - 表示テキスト: 灯火の絵物語
  - 📺 アイコンは `aria-hidden="true"` で装飾扱い、アクセシブル名はリンクテキストのみ
  - `target="_blank"` + `rel="noopener noreferrer"`（既存パターン踏襲）
- `src/App.test.tsx`: TDD で YouTube リンクのテスト 3 件を先行追加
  - リンク表示／新タブで開く設定／URL 一致

## 設計判断

- 「同一運営者の別活動」という既存の姉妹サイト枠と意図が一致するため、そこに同居
- 「YouTube は厳密にはサイトではない」が、ラベル変更は影響範囲が広く過剰設計と判断（YAGNI）
- 区切りに `／`（全角スラッシュ）を使い、視覚的な並列を表現
- 認知負荷を増やさないため、追加スタイル・追加コンポーネントは最小（既存 styled-components を再利用）

## テスト方法

- [x] `npm run typecheck` パス
- [x] `npm run lint:ci` パス（警告ゼロ）
- [x] `npm test`（`src/App.test.tsx`）14/14 パス
- [x] フルスイート: 7871/7872 パス
  - `src/features/air-hockey/__tests__/integration/obstacle.test.ts` で 1 件失敗を確認しましたが、本 PR と無関係の既存 flaky テストです（単独実行ではパス、main 状態でも同テストはパスを確認済）。
- [ ] 開発サーバーで実機ブラウザ確認（フッターのリンク表示・新タブ遷移）— レビュー時にお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)