### PR TITLE
feat: Non-Brake Descent ゲームフィール刷新 P0+P1（タイムスケール基盤）

### DIFF
--- a/.docs/nbd-20260610-01/plan.md
+++ b/.docs/nbd-20260610-01/plan.md
@@ -1,0 +1,917 @@
+# Non-Brake Descent ゲームフィール刷新 実装計画（P0 + P1: タイムスケール基盤）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ゲームループにタイムスケール層（GameClock）を導入し、敵撃破ヒットストップ・ニアミス bullet-time・死亡時インパクト・`prefers-reduced-motion` 対応を、既存メカニクス無改変で実装する。
+
+**Architecture:** 既存の単一 `setInterval(1000/60)` ループ（`presentation/hooks/use-game-engine.ts`）は書き換えず、純粋ロジック `GameClock` をループ先頭のゲートとして挿入する。`shouldStepSim===false` の tick はシミュレーション本体をスキップ（＝完全停止＝ヒットストップ／間引き＝スローモー）。トリガーは衝突イベント箇所で `triggerHitstop` / `triggerSlowMo` を呼ぶだけ。
+
+**Tech Stack:** TypeScript / React 19 / Jotai / Jest 30 (+ SWC) / styled-components。テストは co-located（対象と同ディレクトリに `*.test.ts`）、AAA コメント + `正常系/異常系/境界値` の describe ネスト、日本語テスト名。
+
+**対象ディレクトリ:** `src/features/non-brake-descent/`（以下、パスはこの接頭辞を省略せず明記）
+
+**設計仕様の出典:** `.docs/nbd-20260610-01/spec.md`
+
+---
+
+## ファイル構成（本計画で作成・変更するファイル）
+
+| 種別 | パス | 責務 |
+|------|------|------|
+| 作成 | `src/features/non-brake-descent/application/game-loop/game-clock.ts` | タイムスケール純粋ロジック（hitstop/slowmo） |
+| 作成 | `src/features/non-brake-descent/application/game-loop/game-clock.test.ts` | GameClock の単体テスト |
+| 作成 | `src/features/non-brake-descent/application/game-loop/motion-scale.ts` | reduced-motion 係数の純粋ヘルパー |
+| 作成 | `src/features/non-brake-descent/application/game-loop/motion-scale.test.ts` | motion-scale の単体テスト |
+| 作成 | `src/features/non-brake-descent/presentation/hooks/use-reduced-motion.ts` | `prefers-reduced-motion` 監視フック |
+| 作成 | `src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts` | フックの単体テスト |
+| 変更 | `src/features/non-brake-descent/config.ts` | `juice` 数値セクションを追加 |
+| 変更 | `src/features/non-brake-descent/presentation/hooks/use-game-engine.ts` | クロックゲート配線・各トリガー・reduced-motion 適用 |
+
+---
+
+# Phase 0: タイムスケール基盤
+
+## Task 1: Config に juice 数値セクションを追加
+
+**Files:**
+- Modify: `src/features/non-brake-descent/config.ts`
+
+数値（ヒットストップ/スローモーのフレーム数）はマジックナンバーにせず Config に集約する（コーディング規約準拠）。
+
+- [ ] **Step 1: Config に juice セクションを追加**
+
+`src/features/non-brake-descent/config.ts` の `Config` オブジェクト末尾（`animation: {...},` の次の行）に以下を追加する。
+
+```typescript
+  juice: {
+    // ヒットストップ（完全停止）するフレーム数
+    hitstop: { enemyKill: 4, item: 2, death: 3 },
+    // スローモー: frames=持続 real-tick 数, factor=何 tick に1回 sim を進めるか
+    slowMo: { nearMissFrames: 12, nearMissFactor: 3 },
+  },
+```
+
+- [ ] **Step 2: 型チェックで壊れていないことを確認**
+
+Run: `npm run typecheck`
+Expected: PASS（エラーなし）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/non-brake-descent/config.ts
+git commit -m "feat: NBD に juice 数値設定を追加
+
+- ヒットストップ/スローモーのフレーム数を Config.juice に集約"
+```
+
+---
+
+## Task 2: GameClock — 生成・ヒットストップ・通常進行（TDD）
+
+**Files:**
+- Create: `src/features/non-brake-descent/application/game-loop/game-clock.ts`
+- Test: `src/features/non-brake-descent/application/game-loop/game-clock.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/non-brake-descent/application/game-loop/game-clock.test.ts` を新規作成。
+
+```typescript
+import { advanceClock, createGameClock, triggerHitstop } from './game-clock';
+
+describe('GameClock', () => {
+  describe('createGameClock', () => {
+    describe('正常系', () => {
+      it('停止・スローモーともに0の初期クロックを生成する', () => {
+        // Arrange / Act
+        const clock = createGameClock();
+
+        // Assert
+        expect(clock.hitstopFrames).toBe(0);
+        expect(clock.slowMoFrames).toBe(0);
+        expect(clock.tickCounter).toBe(0);
+      });
+    });
+  });
+
+  describe('triggerHitstop', () => {
+    describe('正常系', () => {
+      it('指定フレーム数のヒットストップを設定する', () => {
+        // Arrange
+        const clock = createGameClock();
+
+        // Act
+        const result = triggerHitstop(clock, 4);
+
+        // Assert
+        expect(result.hitstopFrames).toBe(4);
+      });
+
+      it('既存より長いヒットストップで上書きする（max 合成）', () => {
+        // Arrange
+        const clock = triggerHitstop(createGameClock(), 2);
+
+        // Act
+        const result = triggerHitstop(clock, 5);
+
+        // Assert
+        expect(result.hitstopFrames).toBe(5);
+      });
+
+      it('既存より短い指定では上書きしない', () => {
+        // Arrange
+        const clock = triggerHitstop(createGameClock(), 5);
+
+        // Act
+        const result = triggerHitstop(clock, 2);
+
+        // Assert
+        expect(result.hitstopFrames).toBe(5);
+      });
+    });
+
+    describe('境界値', () => {
+      it('0フレーム指定では停止しない', () => {
+        // Arrange
+        const clock = createGameClock();
+
+        // Act
+        const result = triggerHitstop(clock, 0);
+
+        // Assert
+        expect(result.hitstopFrames).toBe(0);
+      });
+    });
+  });
+
+  describe('advanceClock', () => {
+    describe('正常系', () => {
+      it('通常時はシミュレーションを進める', () => {
+        // Arrange
+        const clock = createGameClock();
+
+        // Act
+        const { shouldStepSim } = advanceClock(clock);
+
+        // Assert
+        expect(shouldStepSim).toBe(true);
+      });
+
+      it('ヒットストップ中はシミュレーションを止める', () => {
+        // Arrange
+        const clock = triggerHitstop(createGameClock(), 2);
+
+        // Act
+        const { clock: next, shouldStepSim } = advanceClock(clock);
+
+        // Assert
+        expect(shouldStepSim).toBe(false);
+        expect(next.hitstopFrames).toBe(1);
+      });
+
+      it('ヒットストップが切れた次の tick で再びシミュレーションを進める', () => {
+        // Arrange
+        const first = advanceClock(triggerHitstop(createGameClock(), 1));
+
+        // Act
+        const second = advanceClock(first.clock);
+
+        // Assert
+        expect(first.shouldStepSim).toBe(false);
+        expect(second.shouldStepSim).toBe(true);
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- src/features/non-brake-descent/application/game-loop/game-clock.test.ts`
+Expected: FAIL（`Cannot find module './game-clock'`）
+
+- [ ] **Step 3: 最小実装を書く**
+
+`src/features/non-brake-descent/application/game-loop/game-clock.ts` を新規作成。
+
+```typescript
+/**
+ * ゲームクロック（タイムスケール制御）
+ *
+ * ゲームループ先頭のゲートとして使い、ヒットストップ（完全停止）と
+ * スローモー（間引き）を純粋関数として表現する。副作用は持たない。
+ */
+
+/** タイムスケールの状態 */
+export interface GameClock {
+  /** 完全停止する残り tick 数（ヒットストップ） */
+  readonly hitstopFrames: number;
+  /** スローモー残り tick 数 */
+  readonly slowMoFrames: number;
+  /** 何 tick に1回 sim を進めるか（スローモー間引き） */
+  readonly slowMoFactor: number;
+  /** スローモー間引き判定用のカウンタ */
+  readonly tickCounter: number;
+}
+
+/** advanceClock の戻り値 */
+export interface AdvanceResult {
+  readonly clock: GameClock;
+  readonly shouldStepSim: boolean;
+}
+
+const DEFAULT_SLOWMO_FACTOR = 1;
+
+/** 初期クロックを生成する */
+export const createGameClock = (): GameClock => ({
+  hitstopFrames: 0,
+  slowMoFrames: 0,
+  slowMoFactor: DEFAULT_SLOWMO_FACTOR,
+  tickCounter: 0,
+});
+
+/** 正の整数に正規化する（負・非整数を弾く） */
+const normalizeFrames = (frames: number): number => Math.max(0, Math.floor(frames));
+
+/** ヒットストップを発動する（既存より長ければ上書き = max 合成） */
+export const triggerHitstop = (clock: GameClock, frames: number): GameClock => ({
+  ...clock,
+  hitstopFrames: Math.max(clock.hitstopFrames, normalizeFrames(frames)),
+});
+
+/** 1 real-tick 進め、シミュレーションを進めるべきか返す */
+export const advanceClock = (clock: GameClock): AdvanceResult => {
+  // ヒットストップ中: 完全停止
+  if (clock.hitstopFrames > 0) {
+    return {
+      clock: { ...clock, hitstopFrames: clock.hitstopFrames - 1 },
+      shouldStepSim: false,
+    };
+  }
+  // 通常進行
+  return { clock: { ...clock, tickCounter: 0 }, shouldStepSim: true };
+};
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- src/features/non-brake-descent/application/game-loop/game-clock.test.ts`
+Expected: PASS（全ケース成功）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/non-brake-descent/application/game-loop/game-clock.ts src/features/non-brake-descent/application/game-loop/game-clock.test.ts
+git commit -m "feat: NBD タイムスケール基盤 GameClock を追加
+
+- createGameClock/triggerHitstop/advanceClock を純粋関数で実装
+- ヒットストップ（完全停止）と通常進行をTDDで実装"
+```
+
+---
+
+## Task 3: GameClock — スローモー（間引き）を追加（TDD）
+
+**Files:**
+- Modify: `src/features/non-brake-descent/application/game-loop/game-clock.ts`
+- Modify: `src/features/non-brake-descent/application/game-loop/game-clock.test.ts`
+
+- [ ] **Step 1: 失敗するテストを追加**
+
+`game-clock.test.ts` の import 行を以下に差し替える。
+
+```typescript
+import { advanceClock, createGameClock, triggerHitstop, triggerSlowMo } from './game-clock';
+```
+
+`describe('GameClock', () => {` 直下、`describe('advanceClock', ...)` ブロックの**前**に以下の describe を追加する。
+
+```typescript
+  describe('triggerSlowMo', () => {
+    describe('正常系', () => {
+      it('指定フレーム数・factor のスローモーを設定する', () => {
+        // Arrange
+        const clock = createGameClock();
+
+        // Act
+        const result = triggerSlowMo(clock, 12, 3);
+
+        // Assert
+        expect(result.slowMoFrames).toBe(12);
+        expect(result.slowMoFactor).toBe(3);
+      });
+    });
+
+    describe('境界値', () => {
+      it('factor は最小1に正規化される', () => {
+        // Arrange
+        const clock = createGameClock();
+
+        // Act
+        const result = triggerSlowMo(clock, 12, 0);
+
+        // Assert
+        expect(result.slowMoFactor).toBe(1);
+      });
+    });
+  });
+
+  describe('advanceClock（スローモー）', () => {
+    describe('正常系', () => {
+      it('factor=3 のスローモーでは3 tick に1回だけ sim を進める', () => {
+        // Arrange
+        let clock = triggerSlowMo(createGameClock(), 12, 3);
+        const steps: boolean[] = [];
+
+        // Act: 3 tick 進める
+        for (let i = 0; i < 3; i++) {
+          const result = advanceClock(clock);
+          clock = result.clock;
+          steps.push(result.shouldStepSim);
+        }
+
+        // Assert: 1,2回目はスキップ、3回目で進む
+        expect(steps).toEqual([false, false, true]);
+      });
+
+      it('スローモー残数を毎 tick 減らす', () => {
+        // Arrange
+        const clock = triggerSlowMo(createGameClock(), 12, 3);
+
+        // Act
+        const { clock: next } = advanceClock(clock);
+
+        // Assert
+        expect(next.slowMoFrames).toBe(11);
+      });
+
+      it('ヒットストップはスローモーより優先される', () => {
+        // Arrange
+        const clock = triggerSlowMo(triggerHitstop(createGameClock(), 2), 12, 3);
+
+        // Act
+        const { shouldStepSim, clock: next } = advanceClock(clock);
+
+        // Assert: hitstop を先に消費し、slowMo は減らない
+        expect(shouldStepSim).toBe(false);
+        expect(next.hitstopFrames).toBe(1);
+        expect(next.slowMoFrames).toBe(12);
+      });
+    });
+  });
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- src/features/non-brake-descent/application/game-loop/game-clock.test.ts`
+Expected: FAIL（`triggerSlowMo is not a function` 等）
+
+- [ ] **Step 3: 実装を追加**
+
+`game-clock.ts` に `triggerSlowMo` を追加する（`triggerHitstop` の定義の直後に挿入）。
+
+```typescript
+/** スローモーを発動する（frames tick の間、factor 間引き） */
+export const triggerSlowMo = (clock: GameClock, frames: number, factor: number): GameClock => ({
+  ...clock,
+  slowMoFrames: Math.max(clock.slowMoFrames, normalizeFrames(frames)),
+  slowMoFactor: Math.max(1, Math.floor(factor)),
+});
+```
+
+`advanceClock` の「通常進行」コメントの直前（`return { ...通常 }` の前）にスローモー分岐を挿入し、関数全体を以下に置き換える。
+
+```typescript
+/** 1 real-tick 進め、シミュレーションを進めるべきか返す */
+export const advanceClock = (clock: GameClock): AdvanceResult => {
+  // ヒットストップ中: 完全停止（スローモーより優先）
+  if (clock.hitstopFrames > 0) {
+    return {
+      clock: { ...clock, hitstopFrames: clock.hitstopFrames - 1 },
+      shouldStepSim: false,
+    };
+  }
+  // スローモー中: factor tick に1回だけ sim を進める
+  if (clock.slowMoFrames > 0) {
+    const tickCounter = clock.tickCounter + 1;
+    const shouldStepSim = tickCounter % clock.slowMoFactor === 0;
+    return {
+      clock: { ...clock, slowMoFrames: clock.slowMoFrames - 1, tickCounter },
+      shouldStepSim,
+    };
+  }
+  // 通常進行
+  return { clock: { ...clock, tickCounter: 0 }, shouldStepSim: true };
+};
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- src/features/non-brake-descent/application/game-loop/game-clock.test.ts`
+Expected: PASS（全ケース成功）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/non-brake-descent/application/game-loop/game-clock.ts src/features/non-brake-descent/application/game-loop/game-clock.test.ts
+git commit -m "feat: NBD GameClock にスローモー（間引き）を追加
+
+- triggerSlowMo と advanceClock のスローモー分岐をTDDで実装
+- ヒットストップ優先・factor間引きの bullet-time を実現"
+```
+
+---
+
+## Task 4: ゲームループにクロックゲートと撃破/取得ヒットストップを配線
+
+**Files:**
+- Modify: `src/features/non-brake-descent/presentation/hooks/use-game-engine.ts`
+
+既存 sim ロジックは無改変。ループ先頭に `advanceClock` ゲートを追加し、敵撃破・アイテム取得時にヒットストップを発動する。
+
+- [ ] **Step 1: import とクロック ref を追加**
+
+`use-game-engine.ts` の import 群（37〜38行目付近、`import { useIsMobile } from './use-mobile';` の直前）に追加する。
+
+```typescript
+import { advanceClock, createGameClock, triggerHitstop } from '../../application/game-loop/game-clock';
+```
+
+`const passedObs = useRef<Set<string>>(new Set());`（175行目付近）の直後に追加する。
+
+```typescript
+  const clockRef = useRef(createGameClock());
+```
+
+- [ ] **Step 2: ゲームループ先頭にクロックゲートを挿入**
+
+ゲームループ `useEffect`（410行目付近）の `const loop = window.setInterval(() => {` の直後、`frameRef.current++;` の**前**に以下を挿入する。
+
+```typescript
+      // タイムスケールゲート: 停止/間引き tick は sim をスキップ
+      const advance = advanceClock(clockRef.current);
+      clockRef.current = advance.clock;
+      if (!advance.shouldStepSim) {
+        setShake(current => Math.max(0, current * Config.animation.shakeDecay));
+        return;
+      }
+```
+
+- [ ] **Step 3: 敵撃破ヒットストップを配線**
+
+`onEnemyKill` コールバック（509〜515行目付近）の本体末尾、`addScorePopup(ox, prev.ramp * RAMP_H - camY, ` の行の直後に1行追加する。変更後の `onEnemyKill` は以下になる。
+
+```typescript
+            onEnemyKill: ox => {
+              Audio.play('enemyKill');
+              setScore(current => current + Config.score.enemy);
+              setSpeed(current => Math.max(MIN_SPD, current - Config.combat.enemyKillSlowdown));
+              addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ff8800', 10);
+              addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.enemy}`, '#ff8800');
+              clockRef.current = triggerHitstop(clockRef.current, Config.juice.hitstop.enemyKill);
+            },
+```
+
+- [ ] **Step 4: アイテム取得ヒットストップを配線**
+
+`onScore` コールバック（498〜503行目付近）の本体末尾、`addScorePopup(ox, prev.ramp * RAMP_H - camY, ` の行の直後に1行追加する。変更後の `onScore` は以下になる。
+
+```typescript
+            onScore: ox => {
+              Audio.play('score');
+              setScore(current => current + Config.score.item);
+              addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ffdd00', 6);
+              addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.item}`, '#ffdd00');
+              clockRef.current = triggerHitstop(clockRef.current, Config.juice.hitstop.item);
+            },
+```
+
+- [ ] **Step 5: 型チェックと既存テストの回帰確認**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+Run: `npm test -- src/features/non-brake-descent`
+Expected: PASS（既存テストが全て通る）
+
+- [ ] **Step 6: 手動動作確認**
+
+Run: `npm start`
+ブラウザで `/non-brake-descent`（ゲーム一覧から「Non-Brake Descent」）を開き、プレイして以下を確認:
+- 中速で敵に当たって撃破した瞬間、画面が一瞬止まる（ヒットストップ）
+- アイテム取得時にごく短い溜めがある
+- ゲームが固まらず通常進行に戻る
+
+確認後、`Ctrl+C` で停止。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+git commit -m "feat: NBD ループにヒットストップを配線
+
+- ゲームループ先頭にタイムスケールゲートを追加（sim無改変）
+- 敵撃破・アイテム取得時にヒットストップを発動"
+```
+
+---
+
+## Task 5: Phase 0 の CI 全パス確認
+
+**Files:** （変更なし・検証のみ）
+
+- [ ] **Step 1: CI パイプライン全体を実行**
+
+Run: `npm run ci`
+Expected: PASS（lint:ci → typecheck → test → build が全て成功）
+
+失敗した場合は該当箇所を修正し、修正内容を `fix:` でコミットしてから次へ進む。
+
+---
+
+# Phase 1: ニアミス bullet-time・死亡インパクト・reduced-motion
+
+## Task 6: motion-scale 純粋ヘルパー（TDD）
+
+**Files:**
+- Create: `src/features/non-brake-descent/application/game-loop/motion-scale.ts`
+- Test: `src/features/non-brake-descent/application/game-loop/motion-scale.test.ts`
+
+`prefers-reduced-motion` が有効なときは時間操作（ヒットストップ/スローモー）を無効化する。係数（0 or 1）を純粋関数で表現する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/non-brake-descent/application/game-loop/motion-scale.test.ts` を新規作成。
+
+```typescript
+import { resolveMotionScale, scaleFrames } from './motion-scale';
+
+describe('motion-scale', () => {
+  describe('resolveMotionScale', () => {
+    describe('正常系', () => {
+      it('reduced-motion 無効時は係数1を返す', () => {
+        // Arrange / Act / Assert
+        expect(resolveMotionScale(false)).toBe(1);
+      });
+
+      it('reduced-motion 有効時は係数0を返す（時間操作を無効化）', () => {
+        // Arrange / Act / Assert
+        expect(resolveMotionScale(true)).toBe(0);
+      });
+    });
+  });
+
+  describe('scaleFrames', () => {
+    describe('正常系', () => {
+      it('係数1でフレーム数をそのまま返す', () => {
+        // Arrange / Act / Assert
+        expect(scaleFrames(12, 1)).toBe(12);
+      });
+
+      it('係数0でフレーム数を0にする', () => {
+        // Arrange / Act / Assert
+        expect(scaleFrames(12, 0)).toBe(0);
+      });
+    });
+
+    describe('境界値', () => {
+      it('小数係数は四捨五入する', () => {
+        // Arrange / Act / Assert
+        expect(scaleFrames(5, 0.5)).toBe(3);
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- src/features/non-brake-descent/application/game-loop/motion-scale.test.ts`
+Expected: FAIL（`Cannot find module './motion-scale'`）
+
+- [ ] **Step 3: 最小実装を書く**
+
+`src/features/non-brake-descent/application/game-loop/motion-scale.ts` を新規作成。
+
+```typescript
+/**
+ * reduced-motion 係数ヘルパー
+ *
+ * prefers-reduced-motion が有効なときは時間操作（ヒットストップ/スローモー）を
+ * 無効化するための係数を提供する。純粋関数。
+ */
+
+/** reduced-motion の有効/無効から演出強度の係数を解決する */
+export const resolveMotionScale = (reduced: boolean): number => (reduced ? 0 : 1);
+
+/** フレーム数に係数を掛けて四捨五入する */
+export const scaleFrames = (frames: number, scale: number): number => Math.round(frames * scale);
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- src/features/non-brake-descent/application/game-loop/motion-scale.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/non-brake-descent/application/game-loop/motion-scale.ts src/features/non-brake-descent/application/game-loop/motion-scale.test.ts
+git commit -m "feat: NBD reduced-motion 係数ヘルパーを追加
+
+- resolveMotionScale/scaleFrames をTDDで実装"
+```
+
+---
+
+## Task 7: useReducedMotion フック（TDD）
+
+**Files:**
+- Create: `src/features/non-brake-descent/presentation/hooks/use-reduced-motion.ts`
+- Test: `src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts` を新規作成。
+
+```typescript
+import { renderHook } from '@testing-library/react';
+import { useReducedMotion } from './use-reduced-motion';
+
+/** matchMedia をモックするヘルパー */
+const mockMatchMedia = (matches: boolean): void => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }),
+  });
+};
+
+describe('useReducedMotion', () => {
+  describe('正常系', () => {
+    it('prefers-reduced-motion が無効なら false を返す', () => {
+      // Arrange
+      mockMatchMedia(false);
+
+      // Act
+      const { result } = renderHook(() => useReducedMotion());
+
+      // Assert
+      expect(result.current).toBe(false);
+    });
+
+    it('prefers-reduced-motion が有効なら true を返す', () => {
+      // Arrange
+      mockMatchMedia(true);
+
+      // Act
+      const { result } = renderHook(() => useReducedMotion());
+
+      // Assert
+      expect(result.current).toBe(true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts`
+Expected: FAIL（`Cannot find module './use-reduced-motion'`）
+
+- [ ] **Step 3: 実装を書く**
+
+`src/features/non-brake-descent/presentation/hooks/use-reduced-motion.ts` を新規作成。
+
+```typescript
+import { useEffect, useState } from 'react';
+
+/**
+ * prefers-reduced-motion メディアクエリを監視するフック。
+ * ユーザーが「視差効果を減らす」設定をしている場合 true を返す。
+ */
+export const useReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(mq.matches);
+    const handler = (event: MediaQueryListEvent): void => setReduced(event.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return reduced;
+};
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/non-brake-descent/presentation/hooks/use-reduced-motion.ts src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts
+git commit -m "feat: NBD prefers-reduced-motion 監視フックを追加"
+```
+
+---
+
+## Task 8: ニアミス bullet-time と reduced-motion 適用を配線
+
+**Files:**
+- Modify: `src/features/non-brake-descent/presentation/hooks/use-game-engine.ts`
+
+ニアミス検出時にスローモーを発動する。すべての時間操作トリガーに reduced-motion 係数を適用する。
+
+- [ ] **Step 1: import と motionScale ref を追加**
+
+`use-game-engine.ts` の Task 4 で追加した import 行を以下に差し替える。
+
+```typescript
+import { advanceClock, createGameClock, triggerHitstop, triggerSlowMo } from '../../application/game-loop/game-clock';
+import { resolveMotionScale, scaleFrames } from '../../application/game-loop/motion-scale';
+import { useReducedMotion } from './use-reduced-motion';
+```
+
+`const clockRef = useRef(createGameClock());`（Task 4 で追加）の直後に追加する。
+
+```typescript
+  const reducedMotion = useReducedMotion();
+  const motionScaleRef = useRef(1);
+  useEffect(() => {
+    motionScaleRef.current = resolveMotionScale(reducedMotion);
+  }, [reducedMotion]);
+```
+
+- [ ] **Step 2: ヒットストップ呼び出しに係数を適用**
+
+Task 4 で追加した2箇所を以下に変更する。
+
+`onScore` 内:
+
+```typescript
+              clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.item, motionScaleRef.current));
+```
+
+`onEnemyKill` 内:
+
+```typescript
+              clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.enemyKill, motionScaleRef.current));
+```
+
+- [ ] **Step 3: ニアミス bullet-time を配線**
+
+ニアミス検出ブロック（528〜538行目付近）の末尾、`addScorePopup(ox, prev.ramp * RAMP_H - camY - 20, ` の行の直後に1行追加する。変更後のブロックは以下になる。
+
+```typescript
+          if (CollisionDomain.isDangerous(obstacle.t) && col.nearMiss && !passedObs.current.has(obsId)) {
+            passedObs.current.add(obsId);
+            Audio.play('nearMiss');
+            setNearMissCount(current => current + 1);
+            setScore(current => current + Config.score.nearMiss);
+            setNearMissEffects(current => [
+              ...current,
+              EntityFactory.createNearMissEffect(ox, prev.ramp * RAMP_H - camY + 25),
+            ]);
+            addScorePopup(ox, prev.ramp * RAMP_H - camY - 20, `NEAR MISS +${Config.score.nearMiss}`, '#44ffaa');
+            clockRef.current = triggerSlowMo(
+              clockRef.current,
+              scaleFrames(Config.juice.slowMo.nearMissFrames, motionScaleRef.current),
+              Config.juice.slowMo.nearMissFactor,
+            );
+          }
+```
+
+- [ ] **Step 4: 型チェックと回帰テスト**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+Run: `npm test -- src/features/non-brake-descent`
+Expected: PASS
+
+- [ ] **Step 5: 手動動作確認**
+
+Run: `npm start`
+`/non-brake-descent` をプレイし、障害物のすぐ脇を高速ですり抜けて（ニアミス）、一瞬スローモーになることを確認。OS の「視差効果を減らす」を ON にすると時間操作が無効化されることも確認（任意）。確認後 `Ctrl+C`。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+git commit -m "feat: NBD ニアミス bullet-time と reduced-motion 対応を追加
+
+- ニアミス時にスローモーを発動
+- 全時間操作トリガーに reduced-motion 係数を適用"
+```
+
+---
+
+## Task 9: 死亡時インパクトのヒットストップ（DYING アニメ凍結）
+
+**Files:**
+- Modify: `src/features/non-brake-descent/presentation/hooks/use-game-engine.ts`
+
+死亡時、衝撃の一瞬を止める。死亡で PLAY ループは終了するため、PLAY ではなく DYING アニメーションループ側をクロックでゲートし、死亡フレーム進行を数フレーム凍結する。
+
+- [ ] **Step 1: handleDeath で死亡ヒットストップを発動**
+
+`handleDeath`（260〜273行目付近）の本体末尾、`setState(GameState.DYING);` の**直前**に1行追加する。変更後の末尾は以下になる。
+
+```typescript
+      addParticles(player.x, player.ramp * RAMP_H - camY + 30, '#ff4444', rank === SpeedRank.HIGH ? 15 : 8);
+      clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.death, motionScaleRef.current));
+      setState(GameState.DYING);
+```
+
+注意: `handleDeath` の `useCallback` 依存配列には `clockRef`/`motionScaleRef` は ref のため追加不要（ESLint の exhaustive-deps は ref を要求しない）。
+
+- [ ] **Step 2: DYING アニメーションループにクロックゲートを追加**
+
+死亡アニメーション `useEffect`（333〜351行目付近）の `const iv = window.setInterval(() => {` の直後、`setDeath(current => {` の**前**に以下を挿入する。
+
+```typescript
+      // 死亡時ヒットストップ: 衝撃の一瞬を止める（死亡フレーム進行を凍結）
+      const advance = advanceClock(clockRef.current);
+      clockRef.current = advance.clock;
+      if (!advance.shouldStepSim) {
+        setShake(current => Math.max(0, current * Config.animation.shakeDecay));
+        return;
+      }
+```
+
+- [ ] **Step 3: 型チェックと回帰テスト**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+Run: `npm test -- src/features/non-brake-descent`
+Expected: PASS
+
+- [ ] **Step 4: 手動動作確認**
+
+Run: `npm start`
+`/non-brake-descent` をプレイし、障害物に激突した瞬間に一瞬画面が止まってから死亡アニメーションが始まることを確認。確認後 `Ctrl+C`。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+git commit -m "feat: NBD 死亡時インパクトのヒットストップを追加
+
+- handleDeath で死亡ヒットストップを発動
+- DYING アニメループをクロックでゲートし衝撃の一瞬を凍結"
+```
+
+---
+
+## Task 10: Phase 1 の CI 全パス確認
+
+**Files:** （変更なし・検証のみ）
+
+- [ ] **Step 1: CI パイプライン全体を実行**
+
+Run: `npm run ci`
+Expected: PASS（lint:ci → typecheck → test → build が全て成功）
+
+失敗時は修正し `fix:` でコミットしてから完了とする。
+
+- [ ] **Step 2: カバレッジ確認（任意）**
+
+Run: `npm run test:coverage -- src/features/non-brake-descent/application/game-loop`
+Expected: `game-clock.ts` / `motion-scale.ts` がともに 90% 以上。
+
+---
+
+## 後続フェーズ（別計画として作成）
+
+本計画（P0+P1）完了後、以下を**それぞれ独立した計画**として作成・実行する。各々が単体で動作・テスト可能な単位:
+
+- **P2: スピード感演出** — 速度線生成（純粋関数+TDD）、カメラ微ズーム、エッジビネット強化
+- **P3: エフェクト拡充** — 着地土煙、ニアミス火花、高速トレイル残像（サンプリング純粋関数+TDD）、スクワッシュ&ストレッチ、粒子グロー
+- **P4: サウンド強化** — 速度ランク連動BGM（プロファイル選択純粋関数+TDD）、コンボ段階音階、SFX追加
+- **P5: グラフィック質感** — CSS光/影/グラデ、コンボティント、背景パララックス強化
+
+これらは P0+P1 で導入した `GameClock` / `motion-scale` / `useReducedMotion` を基盤として利用する。
+
+---
+
+## 自己レビュー結果
+
+- **spec カバレッジ**: spec §2（GameClock）→ Task 2,3。§2.2 配線 → Task 4。§2.3 トリガー表（敵撃破/死亡/ニアミス/アイテム）→ Task 4,8,9。§3.1 → 全体。§5 テスト方針 → 各 Task の TDD ステップ + Task 5,10 CI。§6 アクセシビリティ → Task 6,7,8。§3.2〜3.5・§7 の P2〜P5 → 「後続フェーズ」で別計画化（本計画スコープ外を明示）。
+- **プレースホルダ**: なし（全ステップに実コード・実コマンド・期待結果を記載）。
+- **型整合性**: `GameClock` / `AdvanceResult` のプロパティ名（`hitstopFrames`/`slowMoFrames`/`slowMoFactor`/`tickCounter`/`shouldStepSim`）は全 Task で一貫。`triggerHitstop`/`triggerSlowMo`/`advanceClock`/`createGameClock`/`resolveMotionScale`/`scaleFrames`/`useReducedMotion` のシグネチャは定義と使用箇所で一致。`Config.juice.hitstop.{enemyKill,item,death}` / `Config.juice.slowMo.{nearMissFrames,nearMissFactor}` は Task 1 の定義と使用箇所で一致。

--- a/.docs/nbd-20260610-01/spec.md
+++ b/.docs/nbd-20260610-01/spec.md
@@ -1,0 +1,201 @@
+# Non-Brake Descent ゲームフィール刷新 設計仕様書
+
+- 対象ゲーム: `src/features/non-brake-descent/`
+- 作成日: 2026-06-10
+- ブランチ: `feature/nbd-gameplay-brushup-20260610`
+- 目的: ゲーム内容（メカニクスのバランス）ではなく、**手触り・爽快感（ゲームフィール）** を刷新し、プレイ体験のインパクトを最大化する。SNS連携等の外部機能は対象外。
+
+## 1. 背景とゴール
+
+Non-Brake Descent は「ブレーキなしで坂道を高速降下し続けるランニングアクション」。
+既に以下のフィードバック演出は実装済み:
+
+- パーティクル / ジェットパーティクル / スコアポップアップ / ニアミス演出
+- 画面振動（shake, 減衰0.88）/ トランジション演出 / 危険ビネット
+- 効果音（jump/score/hit/death/enemyKill/rampChange/nearMiss/combo）/ 簡易BGM・各種メロディ
+
+伸びしろ（本仕様で強化する点）:
+
+1. **ヒットストップが無い** — 衝突・撃破の瞬間の「溜め」が欠如
+2. **スローモーが無い** — ニアミスの危うさ演出が弱い
+3. **スピード感の視覚演出が弱い** — 高速時の没入感不足
+4. **細かいフィードバックが薄い** — 着地・火花・残像・スクワッシュ等が未実装
+5. **サウンドが単純** — BGMが4音ループ固定、速度/コンボに非連動
+6. **グラフィック質感** — 光/影/グラデ等の作り込み余地
+
+### 既存メカニクスは維持
+
+スコア計算・難易度バランス・障害物テーブル等の**ゲームバランスは変更しない**。本仕様は演出（フィール）層に限定する。
+
+## 2. アーキテクチャ方針（タイムスケール層）
+
+現状のゲームループは `presentation/hooks/use-game-engine.ts` 内の単一 `setInterval(1000/60)`。
+ここを全面リライトせず、**最小侵襲**でタイムスケール制御を導入する。
+
+### 2.1 GameClock（新規・純粋ロジック・TDD対象）
+
+```typescript
+// application/game-loop/game-clock.ts
+export interface GameClock {
+  readonly hitstopFrames: number;  // 完全停止する残り tick 数（ヒットストップ）
+  readonly slowMoFrames: number;   // スローモー残り tick 数
+  readonly slowMoFactor: number;   // 何 tick に1回 sim を進めるか（例: 3）
+  readonly tickCounter: number;    // スローモー間引き判定用カウンタ
+}
+
+export const createGameClock: () => GameClock;
+
+// ヒットストップ発動（既存値より長ければ上書き = max 合成）
+export const triggerHitstop: (clock: GameClock, frames: number) => GameClock;
+
+// スローモー発動（frames tick の間、factor 間引き）
+export const triggerSlowMo: (clock: GameClock, frames: number, factor: number) => GameClock;
+
+// 1 real-tick 進める。シミュレーションを進めるべきか返す
+export const advanceClock: (clock: GameClock) => {
+  readonly clock: GameClock;
+  readonly shouldStepSim: boolean;
+};
+```
+
+**advanceClock の判定規則**:
+
+1. `hitstopFrames > 0` → `hitstopFrames--`、`shouldStepSim = false`（完全停止）
+2. else `slowMoFrames > 0` → `slowMoFrames--`、`tickCounter++`、
+   `shouldStepSim = (tickCounter % slowMoFactor === 0)`（間引きで bullet-time）
+3. else → `shouldStepSim = true`（通常）
+
+**設計意図**: スローモーを「速度を 0.3 倍」ではなく「N tick に1回 sim を進める」方式にすることで、
+`jumpCD` やコンボタイマー等のフレームベース整数計算を壊さず、bullet-time の質感を出す。
+
+### 2.2 ループへの配線（use-game-engine.ts）
+
+```typescript
+const clockRef = useRef<GameClock>(createGameClock());
+
+// ループ先頭
+const { clock, shouldStepSim } = advanceClock(clockRef.current);
+clockRef.current = clock;
+if (!shouldStepSim) {
+  // 停止/間引き tick: 振動の減衰のみ進め、sim 本体はスキップ
+  setShake(s => Math.max(0, s * Config.animation.shakeDecay));
+  return;
+}
+// 以降は既存の sim 更新ロジック（変更なし）
+```
+
+イベント発生箇所で `clockRef.current = triggerHitstop(...)` / `triggerSlowMo(...)` を呼ぶ。
+
+**設計意図**: 既存 sim ロジックを一切書き換えず、先頭ゲートの追加とトリガー呼び出しのみで完結させる（リスク最小化）。
+
+### 2.3 トリガー対応表
+
+| イベント | 効果 | パラメータ（初期値・調整可） |
+|---------|------|------------------------|
+| 敵撃破（onEnemyKill） | ヒットストップ | 4 frames |
+| プレイヤー死亡（handleDeath 冒頭） | ヒットストップ | 6 frames |
+| ニアミス（nearMiss 判定） | スローモー | 12 frames / factor 3 |
+| アイテム取得（onScore） | ヒットストップ（任意・弱） | 2 frames |
+
+数値は `Config` に集約し、調整しやすくする（マジックナンバー禁止）。
+
+## 3. 演出機能の詳細（5本柱）
+
+### 3.1 ヒットストップ & スローモー
+2章の GameClock で実現。トリガーは 2.3 の通り。
+
+### 3.2 スピード感演出
+- **速度線（スピードライン）**: 速度ランク HIGH 時、画面端から中央へ流れる線を描画。生成・更新ロジックは純粋関数化（テスト対象）。
+- **カメラ微ズーム**: 高速時にワールドコンテナへ僅かな `transform: scale`（例: 1.0 → 1.04）。速度に連動した補間。
+- **エッジビネット強化**: 高速・危険時に画面外周の暗化/着色を多段化（既存 danger vignette を拡張）。
+- **加速時の流線**: 加速入力中にエッジへ短い流線を追加。
+
+### 3.3 エフェクト拡充
+- **着地土煙**: ジャンプ着地（didLand 検出）時に dust バースト粒子。
+- **ニアミス火花**: 既存 NearMissEffect にスパーク粒子を追加。
+- **高速トレイル残像**: 高速時にプレイヤーの残像を数フレーム分サンプリング描画（サンプリングロジックは純粋関数化）。
+- **スクワッシュ & ストレッチ**: ジャンプ/着地でプレイヤーを縦横変形（CSS transform）。
+- **粒子グロー**: 既存粒子に加算合成風の発光（CSS `mix-blend-mode` / box-shadow）。
+
+### 3.4 サウンド強化
+- **速度ランク連動BGM**: LOW/MID/HIGH でテンポ・レイヤーを変化させる。どのBGMパターンを選ぶかは純粋関数 `selectBgmProfile(rank)` 等で表現（テスト対象）。
+- **コンボ段階上昇音階**: 既存 `playCombo(level)` を段階的に拡張（コンボ数で音階上昇）。
+- **SFX追加**: 着地音、トレイル/加速音、ニアミス音の質感改善。
+- インターフェースは既存 `AudioPort` を拡張（後方互換維持）。
+
+### 3.5 グラフィック質感（演出強化中心 / アート全面刷新はしない）
+- CSS の光/影/グラデーションを強化（プレイヤー・ランプ・障害物にグロー・影）。
+- **コンボ時の画面ティント/フラッシュ**: コンボ段階で画面に淡い色被せ。
+- **背景パララックス強化**: 雲・ビルの奥行き表現を多層化。
+
+## 4. プレゼンテーション構成
+
+新規UI状態は既存 `UIState`（`application/game-loop/game-state.ts`）に追加:
+
+```typescript
+interface UIState {
+  // 既存
+  particles; jetParticles; scorePopups; nearMissEffects; clouds; shake; transitionEffect;
+  // 追加
+  speedLines: readonly SpeedLine[];
+  dustParticles: readonly Particle[];
+  playerTrail: readonly TrailSample[];
+  comboTint: number;     // 0..1 コンボ演出の強度
+  cameraZoom: number;    // 1.0.. ワールド拡大率
+}
+```
+
+描画は既存 `renderers/{effects,entities,environment,ui}` 構造を踏襲して新コンポーネントを追加:
+- `effects/`: SpeedLines, PlayerTrail, ComboTint, DustParticles
+- `entities/`: プレイヤーのスクワッシュ&ストレッチ対応
+
+## 5. テスト方針（TDD 厳守）
+
+| 対象 | 種別 | 目標 |
+|------|------|------|
+| `game-clock.ts` | 単体（完全網羅） | 停止カウントダウン/スローモー間引き/トリガー遷移/境界値 |
+| 速度線生成・トレイルサンプリング・BGMプロファイル選択 | 単体 | 純粋関数として網羅 |
+| 新レンダラーコンポーネント | 描画スモーク | 表示崩れ無しの確認 |
+| 既存テスト | 回帰 | 全パス維持 |
+
+- Red → Green → Refactor を厳守。純粋ロジックは先にテストを書く。
+- カバレッジ: 新規ドメイン/アプリ層ロジック 90%+、プレゼンテーション 70%+。
+- 各フェーズ末で `npm run ci`（lint:ci + typecheck + test + build）グリーン必須。
+
+## 6. アクセシビリティ
+
+`prefers-reduced-motion: reduce` を尊重する。ON 時は以下を減衰/無効化:
+- 画面振動の強度低減、ヒットストップ/スローモーの軽量化、速度線・トレイル・ティントの抑制。
+
+判定はメディアクエリ由来の「motion intensity」係数として一元管理し、各演出が参照する。
+（プロジェクト UI 規約「`prefers-reduced-motion` でオプトアウト可能」に準拠）
+
+## 7. フェーズ分割（段階リリース）
+
+| Phase | 内容 |
+|-------|------|
+| **P0** | GameClock 基盤（TDD）＋敵撃破・死亡ヒットストップ配線 |
+| **P1** | ニアミス bullet-time（スローモー）＋ `prefers-reduced-motion` 基盤 |
+| **P2** | スピード感（速度線・カメラズーム・エッジ演出） |
+| **P3** | エフェクト拡充（土煙・トレイル・スクワッシュ&ストレッチ・火花・グロー） |
+| **P4** | サウンド強化（動的BGM・コンボ音階・SFX追加） |
+| **P5** | グラフィック質感（光/影/グラデ・コンボティント・パララックス強化） |
+
+各フェーズは独立して `npm run ci` グリーン＋コミット可能な単位とする。
+
+## 8. 非対象（YAGNI / スコープ外）
+
+- ゲームバランス・難易度・スコア計算式の変更
+- アート全面刷新（エンティティ/背景の再デザイン）
+- SNS連携・ランキング共有等の外部機能
+- ゲームループの rAF 全面リライト（C案は不採用）
+- 新規メカニクス（ダッシュ・ゲージ技等の戦略要素追加）
+
+## 9. リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| ループゲート追加で既存挙動が変わる | sim 本体は無改変。ゲートは「スキップするか否か」のみ。回帰テストで担保 |
+| ヒットストップ中に入力/タイマーがズレる | 停止 tick は sim 全体をスキップするため内部的に時間が止まり整合 |
+| 演出過多で可読性低下（チラつき） | `prefers-reduced-motion` 対応＋強度を Config 集約で調整可能に |
+| パフォーマンス低下（粒子/残像増） | 上限数を Config で制御。プロファイルで確認 |

--- a/.docs/nbd-20260610-01/spec.md
+++ b/.docs/nbd-20260610-01/spec.md
@@ -93,11 +93,13 @@ if (!shouldStepSim) {
 | イベント | 効果 | パラメータ（初期値・調整可） |
 |---------|------|------------------------|
 | 敵撃破（onEnemyKill） | ヒットストップ | 4 frames |
-| プレイヤー死亡（handleDeath 冒頭） | ヒットストップ | 6 frames |
+| プレイヤー死亡（handleDeath） | ヒットストップ | 3 frames |
 | ニアミス（nearMiss 判定） | スローモー | 12 frames / factor 3 |
 | アイテム取得（onScore） | ヒットストップ（任意・弱） | 2 frames |
 
 数値は `Config` に集約し、調整しやすくする（マジックナンバー禁止）。
+
+**死亡ヒットストップが 3 frames である理由**: 敵撃破・アイテム取得は 60fps の PLAY ループ（約16ms/tick）上で消費されるが、死亡ヒットストップは DYING アニメーションループ（`Config.animation.deathAnimInterval = 35ms/tick`）上で消費される。同じ「3 frames」でも実時間は約105ms となり、衝撃の溜めとして十分。6 frames（約210ms）は冗長なため 3 frames を採用する。
 
 ## 3. 演出機能の詳細（5本柱）
 

--- a/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
@@ -55,6 +55,17 @@ describe('GameClock', () => {
         // Assert
         expect(result.hitstopFrames).toBe(0);
       });
+
+      it('負のフレーム指定では停止しない', () => {
+        // Arrange
+        const clock = createGameClock();
+
+        // Act
+        const result = triggerHitstop(clock, -3);
+
+        // Assert
+        expect(result.hitstopFrames).toBe(0);
+      });
     });
   });
 

--- a/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
@@ -10,6 +10,7 @@ describe('GameClock', () => {
         // Assert
         expect(clock.hitstopFrames).toBe(0);
         expect(clock.slowMoFrames).toBe(0);
+        expect(clock.slowMoFactor).toBe(1);
         expect(clock.tickCounter).toBe(0);
       });
     });
@@ -67,6 +68,30 @@ describe('GameClock', () => {
         // Assert
         expect(result.slowMoFrames).toBe(12);
         expect(result.slowMoFactor).toBe(3);
+      });
+
+      it('factor は後勝ちで上書きされる（既存より小さい値も適用される）', () => {
+        // Arrange
+        const clock = triggerSlowMo(createGameClock(), 12, 5);
+
+        // Act
+        const result = triggerSlowMo(clock, 12, 2);
+
+        // Assert
+        expect(result.slowMoFactor).toBe(2);
+      });
+
+      it('再発動で間引き位相（tickCounter）が初期化される', () => {
+        // Arrange: スローモー中に tickCounter を進める
+        let clock = triggerSlowMo(createGameClock(), 12, 3);
+        clock = advanceClock(clock).clock; // tickCounter=1
+        clock = advanceClock(clock).clock; // tickCounter=2
+
+        // Act: 再発動
+        const result = triggerSlowMo(clock, 12, 3);
+
+        // Assert
+        expect(result.tickCounter).toBe(0);
       });
     });
 

--- a/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
@@ -1,0 +1,92 @@
+import { advanceClock, createGameClock, triggerHitstop } from './game-clock';
+
+describe('GameClock', () => {
+  describe('createGameClock', () => {
+    describe('正常系', () => {
+      it('停止・スローモーともに0の初期クロックを生成する', () => {
+        // Arrange / Act
+        const clock = createGameClock();
+
+        // Assert
+        expect(clock.hitstopFrames).toBe(0);
+        expect(clock.slowMoFrames).toBe(0);
+        expect(clock.tickCounter).toBe(0);
+      });
+    });
+  });
+
+  describe('triggerHitstop', () => {
+    describe('正常系', () => {
+      it('指定フレーム数のヒットストップを設定する', () => {
+        // Arrange
+        const clock = createGameClock();
+        // Act
+        const result = triggerHitstop(clock, 4);
+        // Assert
+        expect(result.hitstopFrames).toBe(4);
+      });
+
+      it('既存より長いヒットストップで上書きする（max 合成）', () => {
+        // Arrange
+        const clock = triggerHitstop(createGameClock(), 2);
+        // Act
+        const result = triggerHitstop(clock, 5);
+        // Assert
+        expect(result.hitstopFrames).toBe(5);
+      });
+
+      it('既存より短い指定では上書きしない', () => {
+        // Arrange
+        const clock = triggerHitstop(createGameClock(), 5);
+        // Act
+        const result = triggerHitstop(clock, 2);
+        // Assert
+        expect(result.hitstopFrames).toBe(5);
+      });
+    });
+
+    describe('境界値', () => {
+      it('0フレーム指定では停止しない', () => {
+        // Arrange
+        const clock = createGameClock();
+        // Act
+        const result = triggerHitstop(clock, 0);
+        // Assert
+        expect(result.hitstopFrames).toBe(0);
+      });
+    });
+  });
+
+  describe('advanceClock', () => {
+    describe('正常系', () => {
+      it('通常時はシミュレーションを進める', () => {
+        // Arrange
+        const clock = createGameClock();
+        // Act
+        const { shouldStepSim } = advanceClock(clock);
+        // Assert
+        expect(shouldStepSim).toBe(true);
+      });
+
+      it('ヒットストップ中はシミュレーションを止める', () => {
+        // Arrange
+        const clock = triggerHitstop(createGameClock(), 2);
+        // Act
+        const { clock: next, shouldStepSim } = advanceClock(clock);
+        // Assert
+        expect(shouldStepSim).toBe(false);
+        expect(next.hitstopFrames).toBe(1);
+      });
+
+      it('ヒットストップが切れた次の tick で再びシミュレーションを進める', () => {
+        // Arrange
+        const first = advanceClock(triggerHitstop(createGameClock(), 1));
+        // Act
+        const second = advanceClock(first.clock);
+        // Assert
+        expect(first.shouldStepSim).toBe(false);
+        expect(second.shouldStepSim).toBe(true);
+      });
+    });
+  });
+});

--- a/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.test.ts
@@ -1,4 +1,4 @@
-import { advanceClock, createGameClock, triggerHitstop } from './game-clock';
+import { advanceClock, createGameClock, triggerHitstop, triggerSlowMo } from './game-clock';
 
 describe('GameClock', () => {
   describe('createGameClock', () => {
@@ -53,6 +53,69 @@ describe('GameClock', () => {
         const result = triggerHitstop(clock, 0);
         // Assert
         expect(result.hitstopFrames).toBe(0);
+      });
+    });
+  });
+
+  describe('triggerSlowMo', () => {
+    describe('正常系', () => {
+      it('指定フレーム数・factor のスローモーを設定する', () => {
+        // Arrange
+        const clock = createGameClock();
+        // Act
+        const result = triggerSlowMo(clock, 12, 3);
+        // Assert
+        expect(result.slowMoFrames).toBe(12);
+        expect(result.slowMoFactor).toBe(3);
+      });
+    });
+
+    describe('境界値', () => {
+      it('factor は最小1に正規化される', () => {
+        // Arrange
+        const clock = createGameClock();
+        // Act
+        const result = triggerSlowMo(clock, 12, 0);
+        // Assert
+        expect(result.slowMoFactor).toBe(1);
+      });
+    });
+  });
+
+  describe('advanceClock（スローモー）', () => {
+    describe('正常系', () => {
+      it('factor=3 のスローモーでは3 tick に1回だけ sim を進める', () => {
+        // Arrange
+        let clock = triggerSlowMo(createGameClock(), 12, 3);
+        const steps: boolean[] = [];
+        // Act
+        for (let i = 0; i < 3; i++) {
+          const result = advanceClock(clock);
+          clock = result.clock;
+          steps.push(result.shouldStepSim);
+        }
+        // Assert
+        expect(steps).toEqual([false, false, true]);
+      });
+
+      it('スローモー残数を毎 tick 減らす', () => {
+        // Arrange
+        const clock = triggerSlowMo(createGameClock(), 12, 3);
+        // Act
+        const { clock: next } = advanceClock(clock);
+        // Assert
+        expect(next.slowMoFrames).toBe(11);
+      });
+
+      it('ヒットストップはスローモーより優先される', () => {
+        // Arrange
+        const clock = triggerSlowMo(triggerHitstop(createGameClock(), 2), 12, 3);
+        // Act
+        const { shouldStepSim, clock: next } = advanceClock(clock);
+        // Assert
+        expect(shouldStepSim).toBe(false);
+        expect(next.hitstopFrames).toBe(1);
+        expect(next.slowMoFrames).toBe(12);
       });
     });
   });

--- a/src/features/non-brake-descent/application/game-loop/game-clock.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.ts
@@ -42,11 +42,18 @@ export const triggerHitstop = (clock: GameClock, frames: number): GameClock => (
   hitstopFrames: Math.max(clock.hitstopFrames, normalizeFrames(frames)),
 });
 
-/** スローモーを発動する（frames tick の間、factor 間引き） */
+/**
+ * スローモーを発動する（frames tick の間、factor 間引き）。
+ * - frames: 既存より長ければ延長（max 合成）
+ * - factor: 後勝ち（最後に指定した値で上書き）
+ * - tickCounter を 0 にリセットし、(再)発動ごとに間引き位相を初期化する
+ *   （ニアミス連発などの再発動時に挙動を決定的に保つため）
+ */
 export const triggerSlowMo = (clock: GameClock, frames: number, factor: number): GameClock => ({
   ...clock,
   slowMoFrames: Math.max(clock.slowMoFrames, normalizeFrames(frames)),
   slowMoFactor: Math.max(1, Math.floor(factor)),
+  tickCounter: 0,
 });
 
 /** 1 real-tick 進め、シミュレーションを進めるべきか返す */

--- a/src/features/non-brake-descent/application/game-loop/game-clock.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.ts
@@ -42,13 +42,29 @@ export const triggerHitstop = (clock: GameClock, frames: number): GameClock => (
   hitstopFrames: Math.max(clock.hitstopFrames, normalizeFrames(frames)),
 });
 
+/** スローモーを発動する（frames tick の間、factor 間引き） */
+export const triggerSlowMo = (clock: GameClock, frames: number, factor: number): GameClock => ({
+  ...clock,
+  slowMoFrames: Math.max(clock.slowMoFrames, normalizeFrames(frames)),
+  slowMoFactor: Math.max(1, Math.floor(factor)),
+});
+
 /** 1 real-tick 進め、シミュレーションを進めるべきか返す */
 export const advanceClock = (clock: GameClock): AdvanceResult => {
-  // ヒットストップ中: 完全停止
+  // ヒットストップ中: 完全停止（スローモーより優先）
   if (clock.hitstopFrames > 0) {
     return {
       clock: { ...clock, hitstopFrames: clock.hitstopFrames - 1 },
       shouldStepSim: false,
+    };
+  }
+  // スローモー中: factor tick に1回だけ sim を進める
+  if (clock.slowMoFrames > 0) {
+    const tickCounter = clock.tickCounter + 1;
+    const shouldStepSim = tickCounter % clock.slowMoFactor === 0;
+    return {
+      clock: { ...clock, slowMoFrames: clock.slowMoFrames - 1, tickCounter },
+      shouldStepSim,
     };
   }
   // 通常進行

--- a/src/features/non-brake-descent/application/game-loop/game-clock.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-clock.ts
@@ -1,0 +1,56 @@
+/**
+ * ゲームクロック（タイムスケール制御）
+ *
+ * ゲームループ先頭のゲートとして使い、ヒットストップ（完全停止）と
+ * スローモー（間引き）を純粋関数として表現する。副作用は持たない。
+ */
+
+/** タイムスケールの状態 */
+export interface GameClock {
+  /** 完全停止する残り tick 数（ヒットストップ） */
+  readonly hitstopFrames: number;
+  /** スローモー残り tick 数 */
+  readonly slowMoFrames: number;
+  /** 何 tick に1回 sim を進めるか（スローモー間引き） */
+  readonly slowMoFactor: number;
+  /** スローモー間引き判定用のカウンタ */
+  readonly tickCounter: number;
+}
+
+/** advanceClock の戻り値 */
+export interface AdvanceResult {
+  readonly clock: GameClock;
+  readonly shouldStepSim: boolean;
+}
+
+const DEFAULT_SLOWMO_FACTOR = 1;
+
+/** 初期クロックを生成する */
+export const createGameClock = (): GameClock => ({
+  hitstopFrames: 0,
+  slowMoFrames: 0,
+  slowMoFactor: DEFAULT_SLOWMO_FACTOR,
+  tickCounter: 0,
+});
+
+/** 正の整数に正規化する（負・非整数を弾く） */
+const normalizeFrames = (frames: number): number => Math.max(0, Math.floor(frames));
+
+/** ヒットストップを発動する（既存より長ければ上書き = max 合成） */
+export const triggerHitstop = (clock: GameClock, frames: number): GameClock => ({
+  ...clock,
+  hitstopFrames: Math.max(clock.hitstopFrames, normalizeFrames(frames)),
+});
+
+/** 1 real-tick 進め、シミュレーションを進めるべきか返す */
+export const advanceClock = (clock: GameClock): AdvanceResult => {
+  // ヒットストップ中: 完全停止
+  if (clock.hitstopFrames > 0) {
+    return {
+      clock: { ...clock, hitstopFrames: clock.hitstopFrames - 1 },
+      shouldStepSim: false,
+    };
+  }
+  // 通常進行
+  return { clock: { ...clock, tickCounter: 0 }, shouldStepSim: true };
+};

--- a/src/features/non-brake-descent/application/game-loop/motion-scale.test.ts
+++ b/src/features/non-brake-descent/application/game-loop/motion-scale.test.ts
@@ -1,0 +1,38 @@
+import { resolveMotionScale, scaleFrames } from './motion-scale';
+
+describe('motion-scale', () => {
+  describe('resolveMotionScale', () => {
+    describe('正常系', () => {
+      it('reduced-motion 無効時は係数1を返す', () => {
+        // Arrange / Act / Assert
+        expect(resolveMotionScale(false)).toBe(1);
+      });
+
+      it('reduced-motion 有効時は係数0を返す（時間操作を無効化）', () => {
+        // Arrange / Act / Assert
+        expect(resolveMotionScale(true)).toBe(0);
+      });
+    });
+  });
+
+  describe('scaleFrames', () => {
+    describe('正常系', () => {
+      it('係数1でフレーム数をそのまま返す', () => {
+        // Arrange / Act / Assert
+        expect(scaleFrames(12, 1)).toBe(12);
+      });
+
+      it('係数0でフレーム数を0にする', () => {
+        // Arrange / Act / Assert
+        expect(scaleFrames(12, 0)).toBe(0);
+      });
+    });
+
+    describe('境界値', () => {
+      it('小数係数は四捨五入する', () => {
+        // Arrange / Act / Assert
+        expect(scaleFrames(5, 0.5)).toBe(3);
+      });
+    });
+  });
+});

--- a/src/features/non-brake-descent/application/game-loop/motion-scale.ts
+++ b/src/features/non-brake-descent/application/game-loop/motion-scale.ts
@@ -1,0 +1,12 @@
+/**
+ * reduced-motion 係数ヘルパー
+ *
+ * prefers-reduced-motion が有効なときは時間操作（ヒットストップ/スローモー）を
+ * 無効化するための係数を提供する。純粋関数。
+ */
+
+/** reduced-motion の有効/無効から演出強度の係数を解決する */
+export const resolveMotionScale = (reduced: boolean): number => (reduced ? 0 : 1);
+
+/** フレーム数に係数を掛けて四捨五入する */
+export const scaleFrames = (frames: number, scale: number): number => Math.round(frames * scale);

--- a/src/features/non-brake-descent/config.ts
+++ b/src/features/non-brake-descent/config.ts
@@ -20,4 +20,10 @@ export const Config = {
   combat: { enemyKillSlowdown: 2, bounceMultiplier: 0.4, bounceSpeed: 5 },
   camera: { followRate: 0.1, offsetDivisor: 3 },
   animation: { deathFrames: 40, clearPhase1Frames: 60, countdownInterval: 800, titleMelodyDelay: 500, gameOverScreenDelay: 300, shakeDecay: 0.88, deathAnimInterval: 35, clearAnimInterval: 30 },
+  juice: {
+    // ヒットストップ（完全停止）するフレーム数
+    hitstop: { enemyKill: 4, item: 2, death: 3 },
+    // スローモー: frames=持続 real-tick 数, factor=何 tick に1回 sim を進めるか
+    slowMo: { nearMissFrames: 12, nearMissFactor: 3 },
+  },
 } as const;

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -34,7 +34,9 @@ import type {
   TouchKeys,
 } from '../../types';
 import type { GameWorld, UIState } from '../../application/game-loop/game-state';
-import { advanceClock, createGameClock, triggerHitstop } from '../../application/game-loop/game-clock';
+import { advanceClock, createGameClock, triggerHitstop, triggerSlowMo } from '../../application/game-loop/game-clock';
+import { resolveMotionScale, scaleFrames } from '../../application/game-loop/motion-scale';
+import { useReducedMotion } from './use-reduced-motion';
 import { useIsMobile } from './use-mobile';
 import { getHighScore, saveScore } from '../../../../utils/score-storage';
 
@@ -175,6 +177,11 @@ export const useGameEngine = (
   const touchKeys = useRef<TouchKeys>({ left: false, right: false, accel: false, jump: false });
   const passedObs = useRef<Set<string>>(new Set());
   const clockRef = useRef(createGameClock());
+  const reducedMotion = useReducedMotion();
+  const motionScaleRef = useRef(1);
+  useEffect(() => {
+    motionScaleRef.current = resolveMotionScale(reducedMotion);
+  }, [reducedMotion]);
 
   const isMobile = useIsMobile();
   const handleCheat = useCheatCode('jinjinjin', () => {
@@ -510,7 +517,7 @@ export const useGameEngine = (
               setScore(current => current + Config.score.item);
               addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ffdd00', 6);
               addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.item}`, '#ffdd00');
-              clockRef.current = triggerHitstop(clockRef.current, Config.juice.hitstop.item);
+              clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.item, motionScaleRef.current));
             },
             onEffect: type => {
               if (!type) return;
@@ -523,7 +530,7 @@ export const useGameEngine = (
               setSpeed(current => Math.max(MIN_SPD, current - Config.combat.enemyKillSlowdown));
               addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ff8800', 10);
               addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.enemy}`, '#ff8800');
-              clockRef.current = triggerHitstop(clockRef.current, Config.juice.hitstop.enemyKill);
+              clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.enemyKill, motionScaleRef.current));
             },
             onBounce: vx => {
               Audio.play('hit');
@@ -547,6 +554,11 @@ export const useGameEngine = (
               EntityFactory.createNearMissEffect(ox, prev.ramp * RAMP_H - camY + 25),
             ]);
             addScorePopup(ox, prev.ramp * RAMP_H - camY - 20, `NEAR MISS +${Config.score.nearMiss}`, '#44ffaa');
+            clockRef.current = triggerSlowMo(
+              clockRef.current,
+              scaleFrames(Config.juice.slowMo.nearMissFrames, motionScaleRef.current),
+              Config.juice.slowMo.nearMissFactor,
+            );
           }
           const handler = handlers[obstacle.t];
           if (handler) {

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -34,6 +34,7 @@ import type {
   TouchKeys,
 } from '../../types';
 import type { GameWorld, UIState } from '../../application/game-loop/game-state';
+import { advanceClock, createGameClock, triggerHitstop } from '../../application/game-loop/game-clock';
 import { useIsMobile } from './use-mobile';
 import { getHighScore, saveScore } from '../../../../utils/score-storage';
 
@@ -173,6 +174,7 @@ export const useGameEngine = (
   const keys = useRef<Record<string, boolean>>({});
   const touchKeys = useRef<TouchKeys>({ left: false, right: false, accel: false, jump: false });
   const passedObs = useRef<Set<string>>(new Set());
+  const clockRef = useRef(createGameClock());
 
   const isMobile = useIsMobile();
   const handleCheat = useCheatCode('jinjinjin', () => {
@@ -410,6 +412,13 @@ export const useGameEngine = (
   useEffect(() => {
     if (state !== GameState.PLAY) return;
     const loop = window.setInterval(() => {
+      // タイムスケールゲート: 停止/間引き tick は sim をスキップ
+      const advance = advanceClock(clockRef.current);
+      clockRef.current = advance.clock;
+      if (!advance.shouldStepSim) {
+        setShake(current => Math.max(0, current * Config.animation.shakeDecay));
+        return;
+      }
       frameRef.current++;
       const keyState = keys.current;
       const touchState = touchKeys.current;
@@ -500,6 +509,7 @@ export const useGameEngine = (
               setScore(current => current + Config.score.item);
               addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ffdd00', 6);
               addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.item}`, '#ffdd00');
+              clockRef.current = triggerHitstop(clockRef.current, Config.juice.hitstop.item);
             },
             onEffect: type => {
               if (!type) return;
@@ -512,6 +522,7 @@ export const useGameEngine = (
               setSpeed(current => Math.max(MIN_SPD, current - Config.combat.enemyKillSlowdown));
               addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ff8800', 10);
               addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.enemy}`, '#ff8800');
+              clockRef.current = triggerHitstop(clockRef.current, Config.juice.hitstop.enemyKill);
             },
             onBounce: vx => {
               Audio.play('hit');

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -277,6 +277,7 @@ export const useGameEngine = (
       setDeath({ type, frame: 0, fast: rank === SpeedRank.HIGH });
       setShake(rank === SpeedRank.HIGH ? 18 : 6);
       addParticles(player.x, player.ramp * RAMP_H - camY + 30, '#ff4444', rank === SpeedRank.HIGH ? 15 : 8);
+      clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.death, motionScaleRef.current));
       setState(GameState.DYING);
     },
     [speed, score, speedBonus, player, camY, RAMP_H, addParticles, commitScore]
@@ -343,6 +344,13 @@ export const useGameEngine = (
   useEffect(() => {
     if (state !== GameState.DYING) return;
     const iv = window.setInterval(() => {
+      // 死亡時ヒットストップ: 衝撃の一瞬を止める（死亡フレーム進行を凍結）
+      const advance = advanceClock(clockRef.current);
+      clockRef.current = advance.clock;
+      if (!advance.shouldStepSim) {
+        setShake(current => Math.max(0, current * Config.animation.shakeDecay));
+        return;
+      }
       setDeath(current => {
         if (!current) return current;
         if (current.frame >= Config.animation.deathFrames) {

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -219,6 +219,7 @@ export const useGameEngine = (
     setClouds(BackgroundGen.initClouds());
     passedObs.current = new Set();
     frameRef.current = 0;
+    clockRef.current = createGameClock();
   }, [MIN_SPD]);
 
   const startCountdown = useCallback(() => {

--- a/src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { useReducedMotion } from './use-reduced-motion';
 
 /** matchMedia をモックするヘルパー */
@@ -38,6 +38,37 @@ describe('useReducedMotion', () => {
 
       // Act
       const { result } = renderHook(() => useReducedMotion());
+
+      // Assert
+      expect(result.current).toBe(true);
+    });
+
+    it('OS設定が実行時に変化したら追従する', () => {
+      // Arrange: change ハンドラを捕捉できるモック
+      let changeHandler: ((event: MediaQueryListEvent) => void) | undefined;
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: (query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addEventListener: (_: string, handler: (event: MediaQueryListEvent) => void) => {
+            changeHandler = handler;
+          },
+          removeEventListener: jest.fn(),
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        }),
+      });
+      const { result } = renderHook(() => useReducedMotion());
+      expect(result.current).toBe(false);
+
+      // Act: change イベントで reduce を有効化
+      act(() => {
+        changeHandler?.({ matches: true } as MediaQueryListEvent);
+      });
 
       // Assert
       expect(result.current).toBe(true);

--- a/src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-reduced-motion.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react';
+import { useReducedMotion } from './use-reduced-motion';
+
+/** matchMedia をモックするヘルパー */
+const mockMatchMedia = (matches: boolean): void => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }),
+  });
+};
+
+describe('useReducedMotion', () => {
+  describe('正常系', () => {
+    it('prefers-reduced-motion が無効なら false を返す', () => {
+      // Arrange
+      mockMatchMedia(false);
+
+      // Act
+      const { result } = renderHook(() => useReducedMotion());
+
+      // Assert
+      expect(result.current).toBe(false);
+    });
+
+    it('prefers-reduced-motion が有効なら true を返す', () => {
+      // Arrange
+      mockMatchMedia(true);
+
+      // Act
+      const { result } = renderHook(() => useReducedMotion());
+
+      // Assert
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/src/features/non-brake-descent/presentation/hooks/use-reduced-motion.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-reduced-motion.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * prefers-reduced-motion メディアクエリを監視するフック。
+ * ユーザーが「視差効果を減らす」設定をしている場合 true を返す。
+ */
+export const useReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(mq.matches);
+    const handler = (event: MediaQueryListEvent): void => setReduced(event.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return reduced;
+};


### PR DESCRIPTION
## 概要
Non-Brake Descent（ノーブレーキ降下）の**手触り・爽快感（ゲームフィール）刷新**の第1弾（P0+P1）。ゲームループにタイムスケール層（GameClock）を導入し、衝突の瞬間の「溜め」とニアミスの bullet-time を、既存メカニクス・バランス無改変で追加する。

## 変更内容
- **GameClock（タイムスケール基盤）**: `application/game-loop/game-clock.ts` を純粋関数で新規実装。ヒットストップ（完全停止）とスローモー（factor 間引きの bullet-time）。カバレッジ100%。
- **ヒットストップ配線**: 敵撃破(4f)・アイテム取得(2f)・死亡時(3f)。ゲームループ先頭にゲートを挿入し、sim 本体は無改変。
- **ニアミス bullet-time**: ニアミス検出時に 12f / factor3 のスローモーを発動。
- **死亡時インパクト**: DYING アニメループをクロックでゲートし、衝撃の一瞬を凍結。
- **アクセシビリティ**: `useReducedMotion` フック + `motion-scale` ヘルパーで `prefers-reduced-motion` 有効時は全時間操作を無効化。
- **設計/計画ドキュメント**: `.docs/nbd-20260610-01/`（spec.md / plan.md）。

設計原則（DDD / TDD / Clean Architecture）に準拠。application 層は外部依存ゼロ、既存 sim ロジックの削除・改変なし。

## テスト方法
- [x] `npm run ci`（lint:ci → typecheck → test → build）全パス（exit 0）
- [x] GameClock / motion-scale カバレッジ 100%
- [ ] 手動: 敵撃破・アイテム取得で一瞬停止（ヒットストップ）
- [ ] 手動: 障害物脇を高速すり抜けでスローモー（bullet-time）
- [ ] 手動: 激突時に一瞬凍結してから死亡演出
- [ ] 手動: OS「視差効果を減らす」ON で時間操作が無効化

## 後続（別PR予定）
P2 スピード感演出 / P3 エフェクト拡充 / P4 サウンド強化 / P5 グラフィック質感（本PRの GameClock 基盤を利用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
