### PR TITLE
refactor: Non-Brake Descent ループの frame-processor 化（B2 S1+S2）

### DIFF
--- a/.docs/nbd-20260610-01/plan-b2-refactor.md
+++ b/.docs/nbd-20260610-01/plan-b2-refactor.md
@@ -1,0 +1,66 @@
+# Non-Brake Descent ループ・リファクタ計画（B2: frame-processor 化）
+
+> 前提: B0/B1 = `use-game-engine.test.tsx`（PR #102）の安全網が main にある状態で実施。
+> 目標アーキテクチャ: `.docs/nbd-20260610-01/spec.md` §2-3。
+> 方針: 一括書き換えはしない。各 Stage は CI 緑・単独コミット/マージ可能。既存挙動（ゲームフィール・スコア・当たり判定・P2-P5 演出）は不変。
+
+## 解消する課題
+1. `setState` updater 内の副作用多発（React 契約違反）。
+2. 25+ の `useState` が分散し `application/game-loop`（`GameWorld`/`UIState`）と二重化・乖離。
+3. ループ本体が無テスト（B1 は外形的統合テストのみ）。
+
+## 既存資産（再利用可能）
+- `application/game-loop/game-state.ts`: `GameWorld`/`UIState`/`createInitialGameWorld`/`createInitialUIState`
+- `application/game-loop/game-clock.ts`/`motion-scale.ts`（P0-P1 で配線済み）
+- `application/collision/collision-processor.ts`: `processCollisions`
+- `domain/events/game-events.ts`: `GameEvent`
+- `domain/strategies/collision/*`: 衝突ハンドラ Strategy
+- 安全網: `presentation/hooks/use-game-engine.test.tsx`（全 Stage の回帰テスト）
+
+## Stage 一覧
+
+| Stage | 内容 | 規模 | リスク |
+|-------|------|:---:|:---:|
+| **S1** | 副作用の分離（ループ外 ref パターン確立・updater 内副作用排除） | 中 | 中 |
+| **S2** | `processFrame` 純粋関数の抽出 + 単体テスト | 大 | 低 |
+| **S3** | `useReducer(GameWorld)` へ集約 | 小 | 低 |
+| **S4** | `useReducer(UIState)` + 副作用イベント化の完成 | 中 | 中 |
+| **S5** | 旧 `domains/` import 整理（cleanup） | 極小 | 極低 |
+
+各 Stage 完了で `npm run ci` グリーン → コミット。S2 完了後にユーザーの体感確認チェックポイントを推奨。
+
+---
+
+## S1: 副作用の分離（ループ外 ref パターン）
+- 対象: `use-game-engine.ts`
+- ループ内の `setPlayer(prev => {...})` 2連（移動/遷移系・衝突系）を **1パスで finalPlayer を計算**する形へ。updater 内の `Audio.play`/`setScore`/`setParticles`/`clockRef` 等の副作用を排除し、**ローカルの副作用リスト**（audioEvents/scoreDelta/particleSpawns/hitstop 等）に蓄積 → updater 外でまとめて適用。
+- stale closure 解消のため `player`/`speed`/`ramps`/`camY`/`effect`/`combo`/`comboTimer`/`lastRamp` を ref に昇格（setter で ref を同期）。ゲームループ `useEffect` の依存配列を `[state]` のみに縮小。
+- 外部 API（`UseGameEngineResult`）は不変。新規テスト不要（B1 が守る）。
+- リスク緩和: ref 同期は updater 形式で flush と整合。B1 の Audio 呼び出し検証が副作用漏れを検出。
+
+## S2: `processFrame` 純粋関数の抽出
+- 新規: `application/game-loop/frame-processor.ts` + `.test.ts`
+- `processFrame(world, ui, input, ctx): FrameResult`（副作用なし・Audio/React/DOM 非依存）。
+  - `FrameContext`: screenW/H, rampHeight, minSpeed, isGodMode, motionScale, passedObstacles, frameIndex, wasOnGround。
+  - `FrameResult`: world, ui, events[], isGoal, isDead, newPassedObstacles[], hitstopFrames, slowMoFrames, slowMoFactor。
+  - 内部: effect timer / speed / combo timer / particles / clouds / jet / speedLines / trail / 移動・ジャンプ / 遷移 / danger / `processCollisions` / camera / rank 変化検出。
+  - 着地検出は `ctx.wasOnGround` で純粋化。
+- フック側: ループ内 200+ 行を `processFrame` 呼び出し + ref 即時更新 + events 処理 + clock 更新 + dispatch に簡素化。
+- 必要なら `game-events.ts` に `SPEED_RANK_CHANGED`/`LANDED` 等を追加。
+- 高価値テスト資産: `frame-processor.test.ts`（effect timer / rank 変化 / 遷移 / 着地 / 不変条件）。純粋関数なので Audio モック不要。
+
+## S3: `useReducer(GameWorld)`
+- 変更: `game-state.ts` に `worldReducer`（`COMMIT_FRAME`/`RESET`）+ `game-state.test.ts`。
+- フック: GameWorld 系 11 useState を `useReducer` 1本へ。`worldRef` で最新値をループに供給。戻り値は `world.*` から展開（呼び出し側変更ゼロ）。
+
+## S4: `useReducer(UIState)` + イベント化完成
+- 変更: `game-state.ts` の `UIState` に `speedLines`/`playerTrail` を追加（spec §4）。`uiReducer`（`COMMIT_UI`/`RESET_UI`）。
+- フック: UI 系 useState を `useReducer` へ。`dispatchGameEvent(event)` を **ループ外** の `useCallback` として実装し、`Audio.play`/`Audio.setSpeedRank`/`handleDeath`/`handleClear` をここで処理。→ updater 内副作用が完全に消える。
+- 注意: `shake` は死亡ループとゲームループ双方が更新するため、統合は慎重に（必要なら useState 維持 or 専用 action）。
+
+## S5: 旧 import 整理
+- 対象: `use-game-engine.ts` の `../../domains/*`（@deprecated 再エクスポート）参照を `domain/services/` 直参照へ、または `processFrame` 統合で不要化して削除。
+- typecheck/CI で確認。旧 `domains/*.ts` 本体の削除は別 PR（スコープ外）。
+
+## YAGNI（見送り）
+- rAF 全面移行 / `GameAction` の細分化 / immer / `shake` の reducer 統合 / 旧 `domains/*` ファイル削除。

--- a/src/features/non-brake-descent/application/game-loop/frame-processor.test.ts
+++ b/src/features/non-brake-descent/application/game-loop/frame-processor.test.ts
@@ -1,0 +1,390 @@
+/**
+ * processFrame 単体テスト（B2-S2）
+ *
+ * 純粋関数なので Audio モック不要。
+ * AAA パターン・日本語テスト名で記述。
+ */
+import { createPlayer } from '../../domain/entities/player';
+import { Config } from '../../config';
+import { ObstacleType, RampType, SpeedRank } from '../../constants';
+import type { Ramp } from '../../types';
+import { processFrame } from './frame-processor';
+import type { FrameContext } from './frame-processor';
+import { createInitialGameWorld, createInitialUIState } from './game-state';
+import { BackgroundGen } from '../../generators';
+
+// --- テスト用ヘルパー ---
+
+/** テスト用のシンプルなランプ配列を生成する（障害物なし） */
+const buildSimpleRamps = (count: number): Ramp[] =>
+  Array.from({ length: count }, (_, i): Ramp => ({
+    dir: i % 2 === 0 ? 1 : -1,
+    obs: [],
+    type: RampType.NORMAL,
+    isGoal: i === count - 1,
+  }));
+
+/** テスト用の最小 FrameContext を生成する */
+const buildCtx = (overrides?: Partial<FrameContext>): FrameContext => ({
+  screenWidth: Config.screen.width,
+  screenHeight: Config.screen.height,
+  rampHeight: Config.ramp.height,
+  minSpeed: Config.speed.min,
+  isGodMode: false,
+  motionScale: 1,
+  frameIndex: 1,
+  wasOnGround: true,
+  prevRank: 0,
+  lastRamp: 0,
+  passedObstacles: new Set(),
+  ...overrides,
+});
+
+/** テスト用の最小 GameWorld を生成する */
+const buildWorld = (ramps: Ramp[], overrides?: Parameters<typeof createInitialGameWorld>[1] extends object ? object : never) => {
+  const player = createPlayer();
+  const world = createInitialGameWorld(player, ramps);
+  return { ...world, speed: Config.speed.min, ...overrides } as typeof world;
+};
+
+/** 入力なし（何も押していない）状態 */
+const noInput = { left: false, right: false, accel: false, jump: false };
+
+// --- テストスイート ---
+
+describe('processFrame 単体テスト', () => {
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('正常系: エフェクトタイマー', () => {
+    it('effect.timer > 0 のとき 1 減算されること', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const world = {
+        ...buildWorld(ramps),
+        effect: { type: 'reverse' as const, timer: 10 },
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx();
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.world.effect.timer).toBe(9);
+      expect(result.world.effect.type).toBe('reverse');
+    });
+
+    it('effect.timer === 0 のとき type が undefined になること', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const world = {
+        ...buildWorld(ramps),
+        effect: { type: 'reverse' as const, timer: 0 },
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx();
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.world.effect.type).toBeUndefined();
+      expect(result.world.effect.timer).toBe(0);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('正常系: 速度ランク変化', () => {
+    it('速度が MID 閾値を超えると newRank !== prevRank になり SPEED_RANK_CHANGED イベントが発火すること', () => {
+      // Arrange
+      // SpeedDomain.getRank: speed < 6 → LOW(0), speed < 10 → MID(1)
+      const ramps = buildSimpleRamps(3);
+      const world = {
+        ...buildWorld(ramps),
+        // 速度を MID 閾値ちょうどにしておき、加速で超えさせる
+        speed: 9.9,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      // prevRank = MID（1）で、speed 9.9 → 加速 → HIGH(2) に変化
+      const ctx = buildCtx({ prevRank: SpeedRank.MID });
+
+      // Act
+      const result = processFrame(world, ui, { ...noInput, accel: true }, ctx);
+
+      // Assert: 速度が HIGH 閾値(10)以上に到達していること
+      expect(result.world.speed).toBeGreaterThanOrEqual(10);
+      // ランク変化イベントが含まれること
+      const rankEvent = result.events.find(e => e.type === 'SPEED_RANK_CHANGED');
+      expect(rankEvent).toBeDefined();
+      if (rankEvent && rankEvent.type === 'SPEED_RANK_CHANGED') {
+        expect(rankEvent.rank).toBe(SpeedRank.HIGH);
+      }
+      expect(result.newRank).toBe(SpeedRank.HIGH);
+    });
+
+    it('速度ランクが変化しない場合は SPEED_RANK_CHANGED イベントが発火しないこと', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const world = { ...buildWorld(ramps), speed: Config.speed.min };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      // prevRank = LOW(0)、速度も LOW のまま
+      const ctx = buildCtx({ prevRank: SpeedRank.LOW });
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      const rankEvent = result.events.find(e => e.type === 'SPEED_RANK_CHANGED');
+      expect(rankEvent).toBeUndefined();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('正常系: ランプ遷移', () => {
+    it('ランプ端に到達すると遷移後の player.ramp が進むこと（isGoal=false）', () => {
+      // Arrange: ランプ 0 の右端近くにプレイヤーを配置
+      const ramps = buildSimpleRamps(5);
+      const player = createPlayer(Config.screen.width - Config.ramp.transitionMargin + 1, 0);
+      const world = {
+        ...createInitialGameWorld(player, ramps),
+        speed: Config.speed.min,
+        combo: { count: 0, timer: 0 },
+        effect: { type: undefined as undefined, timer: 0 },
+        lastRamp: 0,
+        nearMissCount: 0,
+        dangerLevel: 0,
+        score: 0,
+        speedBonus: 0,
+        camY: 0,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx({ lastRamp: 0 });
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.isGoal).toBe(false);
+      expect(result.isDead).toBe(false);
+      expect(result.world.player.ramp).toBe(1);
+    });
+
+    it('最終ランプの端に到達すると isGoal=true になること', () => {
+      // Arrange: 2ランプ構成の最後（index 1）にいる状態で右端を超える
+      const ramps: Ramp[] = [
+        { dir: 1, obs: [], type: RampType.NORMAL, isGoal: false },
+        { dir: -1, obs: [], type: RampType.NORMAL, isGoal: true },
+      ];
+      // ランプ 1 の dir=-1 なので、左端 (x <= transitionMargin) でゴール
+      const player = createPlayer(Config.ramp.transitionMargin - 1, 0);
+      const playerWithRamp = { ...player, ramp: 1 };
+      const world = {
+        ...createInitialGameWorld(playerWithRamp, ramps),
+        speed: Config.speed.min,
+        combo: { count: 0, timer: 0 },
+        effect: { type: undefined as undefined, timer: 0 },
+        lastRamp: 1,
+        nearMissCount: 0,
+        dangerLevel: 0,
+        score: 0,
+        speedBonus: 0,
+        camY: 0,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx({ lastRamp: 1 });
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.isGoal).toBe(true);
+      // GOAL_REACHED イベントが含まれること
+      const goalEvent = result.events.find(e => e.type === 'GOAL_REACHED');
+      expect(goalEvent).toBeDefined();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('正常系: 着地検出', () => {
+    it('前フレームが空中（wasOnGround=false）で着地（onGround=true）したとき AUDIO(land) イベントが発火すること', () => {
+      // Arrange:
+      // Physics.applyJump の仕様: jumpCD <= 0 かつ jumping=false のとき onGround=true になる。
+      // jumpCD=0, jumping=false, y=0 のプレイヤーを「前フレームは空中（wasOnGround=false）」
+      // という条件で渡すことで、「今フレームで onGround=true」の着地条件を満たす。
+      const ramps = buildSimpleRamps(3);
+      const player = {
+        ...createPlayer(100, 0),
+        y: 0,
+        vy: 0,
+        jumping: false,
+        jumpCD: 0,
+        onGround: false, // 前フレームは onGround=false (jumpCD を消化したタイミング)
+      };
+      const world = {
+        ...createInitialGameWorld(player, ramps),
+        speed: Config.speed.min,
+        combo: { count: 0, timer: 0 },
+        effect: { type: undefined as undefined, timer: 0 },
+        lastRamp: 0,
+        nearMissCount: 0,
+        dangerLevel: 0,
+        score: 0,
+        speedBonus: 0,
+        camY: 0,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      // wasOnGround=false（前フレームは空中）
+      const ctx = buildCtx({ wasOnGround: false });
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert: jumpCD=0 かつ jumping=false → applyJump 後 onGround=true になる
+      expect(result.world.player.onGround).toBe(true);
+      // AUDIO land イベントが含まれること
+      const landEvent = result.events.find(
+        e => e.type === 'AUDIO' && (e as { type: 'AUDIO'; sound: string }).sound === 'land'
+      );
+      expect(landEvent).toBeDefined();
+    });
+
+    it('前フレームが接地（wasOnGround=true）の場合は AUDIO(land) が発火しないこと', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const player = { ...createPlayer(100, 0), onGround: true, jumping: false };
+      const world = {
+        ...createInitialGameWorld(player, ramps),
+        speed: Config.speed.min,
+        combo: { count: 0, timer: 0 },
+        effect: { type: undefined as undefined, timer: 0 },
+        lastRamp: 0,
+        nearMissCount: 0,
+        dangerLevel: 0,
+        score: 0,
+        speedBonus: 0,
+        camY: 0,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      // wasOnGround=true
+      const ctx = buildCtx({ wasOnGround: true });
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      const landEvent = result.events.find(
+        e => e.type === 'AUDIO' && (e as { type: 'AUDIO'; sound: string }).sound === 'land'
+      );
+      expect(landEvent).toBeUndefined();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('不変条件', () => {
+    it('world.speed >= minSpeed が常に維持されること', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const world = { ...buildWorld(ramps), speed: Config.speed.min };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx();
+
+      // Act: 加速なし（デフォルト減速）
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.world.speed).toBeGreaterThanOrEqual(Config.speed.min);
+    });
+
+    it('world.score >= 0 が常に維持されること（score=0 起点で差分が負にならない）', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const world = { ...buildWorld(ramps), score: 0 };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx();
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.world.score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('isGoal と isDead が同時に true にならないこと', () => {
+      // Arrange
+      const ramps = buildSimpleRamps(3);
+      const world = buildWorld(ramps);
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx();
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert
+      expect(result.isGoal && result.isDead).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('異常系: ramp が取得できない場合', () => {
+    it('player.ramp が範囲外のとき例外を投げずカメラのみ更新して返すこと', () => {
+      // Arrange: ramp インデックス 0 にプレイヤーがいるがランプ配列が空
+      const ramps: Ramp[] = [];
+      const player = createPlayer();
+      const world = {
+        ...createInitialGameWorld(player, ramps),
+        speed: Config.speed.min,
+        combo: { count: 0, timer: 0 },
+        effect: { type: undefined as undefined, timer: 0 },
+        lastRamp: 0,
+        nearMissCount: 0,
+        dangerLevel: 0,
+        score: 0,
+        speedBonus: 0,
+        camY: 0,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx();
+
+      // Act & Assert: 例外を投げないこと
+      expect(() => processFrame(world, ui, noInput, ctx)).not.toThrow();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe('正常系: ゴッドモード', () => {
+    it('ゴッドモードが有効な場合、岩に衝突しても isDead=false のままであること', () => {
+      // Arrange: プレイヤーの直前に ROCK を配置
+      const rockObs = {
+        t: ObstacleType.ROCK as (typeof ObstacleType)[keyof typeof ObstacleType],
+        pos: 0.5,
+        passed: false,
+      };
+      // dir=1 のランプで pos=0.5 → ox = 40 + 0.5 * (400-80) = 40 + 160 = 200
+      const ramps: Ramp[] = [
+        { dir: 1, obs: [rockObs], type: RampType.NORMAL, isGoal: false },
+        { dir: -1, obs: [], type: RampType.NORMAL, isGoal: true },
+      ];
+      // プレイヤーを ox=200 の直前に配置（衝突範囲 groundThreshold=22 以内）
+      const player = createPlayer(200, 0);
+      const world = {
+        ...createInitialGameWorld(player, ramps),
+        speed: Config.speed.min,
+        combo: { count: 0, timer: 0 },
+        effect: { type: undefined as undefined, timer: 0 },
+        lastRamp: 0,
+        nearMissCount: 0,
+        dangerLevel: 0,
+        score: 0,
+        speedBonus: 0,
+        camY: 0,
+      };
+      const ui = createInitialUIState(BackgroundGen.initClouds());
+      const ctx = buildCtx({ isGodMode: true });
+
+      // Act
+      const result = processFrame(world, ui, noInput, ctx);
+
+      // Assert: ゴッドモードなので死亡しない
+      expect(result.isDead).toBe(false);
+    });
+  });
+});

--- a/src/features/non-brake-descent/application/game-loop/frame-processor.ts
+++ b/src/features/non-brake-descent/application/game-loop/frame-processor.ts
@@ -1,0 +1,752 @@
+/**
+ * 1フレーム分のゲームシミュレーション処理（純粋関数）
+ *
+ * B2-S2: use-game-engine.ts のゲームループ本体をここに抽出する。
+ * Audio / React / DOM / setState を一切呼ばない。
+ * 副作用は events 配列と FrameResult のフラグ群で表現する。
+ *
+ * 純粋性の妥協点（挙動保存を優先）:
+ *   - 衝突ハンドラ内の obstacle.t in-place 書き換えは旧挙動の一部であり、
+ *     collision-processor.ts とは別実装（フックの createCollisionHandlers 相当）を用いる。
+ *     完全な不変化は S3/S4 以降の課題とする。
+ */
+
+import { Config } from '../../config';
+import { EffectType, ObstacleType, SpeedRank } from '../../constants';
+import { CollisionDomain } from '../../domain/services/collision-service';
+import { ComboDomain } from '../../domain/services/combo-service';
+import { DangerDomain } from '../../domain/services/danger-service';
+import { GeometryDomain } from '../../domain/services/geometry-service';
+import { Physics } from '../../domain/services/physics-service';
+import { ScoringDomain } from '../../domain/services/scoring-service';
+import { createDust } from '../../domain/services/dust-service';
+import { spawnSpeedLines, updateSpeedLines } from '../../domain/services/speed-line-service';
+import { SpeedDomain } from '../../domain/services/speed-service';
+import { sampleTrail } from '../../domain/services/trail-service';
+import { EntityFactory } from '../../entities';
+import { MathUtils } from '../../domain/math-utils';
+import { ParticleSys } from '../../particles';
+import { scaleFrames } from './motion-scale';
+import type { GameWorld, UIState } from './game-state';
+import type { GameEvent } from '../../domain/events/game-events';
+import type { DeathState, EffectState, InputState, Ramp } from '../../types';
+
+// --- 定数 ---
+
+/** 残像トレイルの最大サンプル保持数 */
+const MAX_TRAIL_SAMPLES = 10;
+
+/** 着地時の土煙パーティクル数（通常着地） */
+const DUST_PARTICLE_COUNT = 6;
+
+// --- 公開インターフェース ---
+
+/**
+ * processFrame に渡す「フレーム外コンテキスト」
+ * フックの ref 群から組み立てて渡す。純粋関数側から書き換えない。
+ */
+export interface FrameContext {
+  /** 画面幅（ピクセル） */
+  readonly screenWidth: number;
+  /** 画面高さ（ピクセル） */
+  readonly screenHeight: number;
+  /** ランプの高さ（ピクセル） */
+  readonly rampHeight: number;
+  /** 速度の最小値（下限クランプ用） */
+  readonly minSpeed: number;
+  /** ゴッドモード（衝突死亡・バウンス無効） */
+  readonly isGodMode: boolean;
+  /** reduced-motion 係数（0: モーション無効 / 1: 通常） */
+  readonly motionScale: number;
+  /** 現フレームのインデックス（偶数フレームにのみジェット生成等の判定に使用） */
+  readonly frameIndex: number;
+  /** 前フレームの接地状態（着地検出: false→true で land イベント発火） */
+  readonly wasOnGround: boolean;
+  /** 前フレームの速度ランク（ランク変化検出で BGM 切替に使用） */
+  readonly prevRank: number;
+  /** 最後に到達したランプインデックス（lastRamp ref 相当） */
+  readonly lastRamp: number;
+  /** 既にニアミス通過済みの障害物 ID セット（重複判定用） */
+  readonly passedObstacles: ReadonlySet<string>;
+}
+
+/**
+ * processFrame の戻り値
+ * フックはこれを受け取り各 state/ref に展開する。
+ */
+export interface FrameResult {
+  /** 更新後のゲームワールド（score/combo/camera 等すべて反映済み） */
+  readonly world: GameWorld;
+  /**
+   * 更新後の UI 状態（particles/popups/speedLines/trail/dust 等反映済み）
+   * ただし shake は hitstopFrames/slowMoFrames の適用前の値である。
+   * フック側で hitstopFrames を clockRef に適用し shake は別途管理する。
+   */
+  readonly ui: UIState;
+  /** Audio 再生・死亡・クリア・ランク変化等の副作用イベント */
+  readonly events: readonly GameEvent[];
+  /** このフレームでゴールに到達したか */
+  readonly isGoal: boolean;
+  /** このフレームで死亡したか */
+  readonly isDead: boolean;
+  /** 死亡タイプ（isDead=true の場合のみ意味を持つ） */
+  readonly deathType?: DeathState['type'];
+  /** 今フレームで新たにニアミス通過とみなした障害物 ID */
+  readonly newPassedObstacles: readonly string[];
+  /**
+   * 衝突で発生したヒットストップフレーム数（0 = なし）
+   * フック側で clockRef.current = triggerHitstop(clockRef.current, hitstopFrames) を呼ぶ。
+   */
+  readonly hitstopFrames: number;
+  /** スローモーフレーム数（0 = なし） */
+  readonly slowMoFrames: number;
+  /** スローモー間引き係数 */
+  readonly slowMoFactor: number;
+  /** 更新後の速度ランク（prevRank と異なれば BGM 切替 SPEED_RANK_CHANGED を events に含む） */
+  readonly newRank: number;
+}
+
+// --- 内部ヘルパー ---
+
+/** 衝突コールバック群（副作用を収集するためのインターフェース） */
+type CollisionSideEffects = {
+  collisionDied: boolean;
+  deathType: DeathState['type'] | undefined;
+  collisionSlowed: boolean;
+  newVxFromBounce: number | undefined;
+  audioEventsFromCollision: Array<{ sound: string }>;
+  scoreDeltaFromCollision: number;
+  speedDeltaFromCollision: number;
+  particlesFromCollision: Array<{ x: number; y: number; color: string; count: number }>;
+  popupsFromCollision: Array<{ x: number; y: number; text: string; color: string }>;
+  nearMissFromCollision: Array<{ x: number; y: number }>;
+  nearMissDeltaCount: number;
+  nearMissScoreDelta: number;
+  nearMissPopupsFromCollision: Array<{ x: number; y: number; text: string; color: string }>;
+  newEffectFromCollision: EffectState | undefined;
+  hitstopFrames: number;
+  slowMoFrames: number;
+  slowMoFactor: number;
+  newPassedObstacles: string[];
+};
+
+/** CollisionSideEffects の初期値 */
+const createEmptyCollisionSideEffects = (): CollisionSideEffects => ({
+  collisionDied: false,
+  deathType: undefined,
+  collisionSlowed: false,
+  newVxFromBounce: undefined,
+  audioEventsFromCollision: [],
+  scoreDeltaFromCollision: 0,
+  speedDeltaFromCollision: 0,
+  particlesFromCollision: [],
+  popupsFromCollision: [],
+  nearMissFromCollision: [],
+  nearMissDeltaCount: 0,
+  nearMissScoreDelta: 0,
+  nearMissPopupsFromCollision: [],
+  newEffectFromCollision: undefined,
+  hitstopFrames: 0,
+  slowMoFrames: 0,
+  slowMoFactor: 1,
+  newPassedObstacles: [],
+});
+
+/**
+ * 衝突処理を実行し副作用を収集する
+ *
+ * 注意: この関数はフックの createCollisionHandlers 相当の実装であり、
+ * collision-processor.ts の processCollisions とは別物。
+ * obstacle.t の in-place 書き換えが現状動作の一部のため、挙動保存を優先してそのまま残す。
+ * （不変化は S3/S4 以降の課題）
+ */
+const processCollisionLoop = (
+  ramp: Ramp,
+  afterTransitionPlayer: { x: number; y: number; ramp: number; jumping: boolean; onGround: boolean; vx: number; vy: number; jumpCD: boolean | number },
+  nextSpeed: number,
+  camY: number,
+  ctx: FrameContext,
+  fx: CollisionSideEffects
+): void => {
+  const rank = SpeedDomain.getRank(nextSpeed);
+  const W = ctx.screenWidth;
+  const RAMP_H = ctx.rampHeight;
+  const godMode = ctx.isGodMode;
+  const motionScale = ctx.motionScale;
+
+  const die = godMode
+    ? (_type: DeathState['type']) => { /* ゴッドモード時は die を無視する（collisionDied を設定しない） */ }
+    : (type: DeathState['type']) => {
+        fx.collisionDied = true;
+        fx.deathType = type;
+      };
+
+  const bounce = godMode
+    ? (_vx: number) => { /* ゴッドモード時はバウンスしない */ }
+    : (vx: number) => {
+        fx.audioEventsFromCollision.push({ sound: 'hit' });
+        fx.newVxFromBounce = vx;
+      };
+
+  const handleEnemy = (
+    col: ReturnType<typeof CollisionDomain.check>,
+    obs: Ramp['obs'][number],
+    ox: number,
+    px: number
+  ): boolean | 'slow' => {
+    if (!col.hit) return false;
+    if (rank === SpeedRank.HIGH) {
+      die('enemy');
+      return true;
+    }
+    if (rank === SpeedRank.MID) {
+      // 注意: in-place 書き換え（挙動保存のため意図的に残す）
+      obs.t = ObstacleType.DEAD;
+      fx.audioEventsFromCollision.push({ sound: 'enemyKill' });
+      fx.scoreDeltaFromCollision += Config.score.enemy;
+      fx.speedDeltaFromCollision -= Config.combat.enemyKillSlowdown;
+      fx.particlesFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - camY + 25, color: '#ff8800', count: 10 });
+      fx.popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - camY, text: `+${Config.score.enemy}`, color: '#ff8800' });
+      fx.hitstopFrames = Math.max(fx.hitstopFrames, scaleFrames(Config.juice.hitstop.enemyKill, motionScale));
+      return 'slow';
+    }
+    bounce(px < ox ? -Config.combat.bounceSpeed : Config.combat.bounceSpeed);
+    return false;
+  };
+
+  for (const obstacle of ramp.obs) {
+    if (!CollisionDomain.isActive(obstacle)) continue;
+
+    const ox = GeometryDomain.getObstacleX(obstacle, ramp, W);
+    const col = CollisionDomain.check(afterTransitionPlayer.x, ox, afterTransitionPlayer.jumping, afterTransitionPlayer.y);
+    const obsId = `${afterTransitionPlayer.ramp}-${obstacle.pos}`;
+
+    // ニアミス判定
+    if (CollisionDomain.isDangerous(obstacle.t) && col.nearMiss && !ctx.passedObstacles.has(obsId) && !fx.newPassedObstacles.includes(obsId)) {
+      fx.newPassedObstacles.push(obsId);
+      fx.nearMissDeltaCount += 1;
+      fx.nearMissScoreDelta += Config.score.nearMiss;
+      fx.nearMissFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - camY + 25 });
+      fx.nearMissPopupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - camY - 20, text: `NEAR MISS +${Config.score.nearMiss}`, color: '#44ffaa' });
+      fx.slowMoFrames = Math.max(fx.slowMoFrames, scaleFrames(Config.juice.slowMo.nearMissFrames, motionScale));
+      fx.slowMoFactor = Config.juice.slowMo.nearMissFactor;
+    }
+
+    // 衝突ハンドラ
+    let result: boolean | 'slow' = false;
+    switch (obstacle.t) {
+      case ObstacleType.HOLE_S:
+        result = col.ground && rank === SpeedRank.LOW ? (die('fall'), true) : false;
+        break;
+      case ObstacleType.HOLE_L:
+        result = col.ground ? (die('fall'), true) : false;
+        break;
+      case ObstacleType.ROCK:
+        result = col.hit ? (die('rock'), true) : false;
+        break;
+      case ObstacleType.ENEMY:
+      case ObstacleType.ENEMY_V:
+        result = handleEnemy(col, obstacle, ox, afterTransitionPlayer.x);
+        break;
+      case ObstacleType.SCORE:
+        if (col.hit) {
+          // 注意: in-place 書き換え（挙動保存のため意図的に残す）
+          obstacle.t = ObstacleType.TAKEN;
+          fx.audioEventsFromCollision.push({ sound: 'score' });
+          fx.scoreDeltaFromCollision += Config.score.item;
+          fx.particlesFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - camY + 25, color: '#ffdd00', count: 6 });
+          fx.popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - camY, text: `+${Config.score.item}`, color: '#ffdd00' });
+          fx.hitstopFrames = Math.max(fx.hitstopFrames, scaleFrames(Config.juice.hitstop.item, motionScale));
+        }
+        break;
+      case ObstacleType.REVERSE:
+        if (col.hit) {
+          // 注意: in-place 書き換え（挙動保存のため意図的に残す）
+          obstacle.t = ObstacleType.TAKEN;
+          fx.audioEventsFromCollision.push({ sound: 'hit' });
+          fx.newEffectFromCollision = { type: EffectType.REVERSE, timer: Config.effect.duration };
+        }
+        break;
+      case ObstacleType.FORCE_JUMP:
+        if (col.hit) {
+          // 注意: in-place 書き換え（挙動保存のため意図的に残す）
+          obstacle.t = ObstacleType.TAKEN;
+          fx.audioEventsFromCollision.push({ sound: 'hit' });
+          fx.newEffectFromCollision = { type: EffectType.FORCE_JUMP, timer: Config.effect.duration };
+        }
+        break;
+      default:
+        break;
+    }
+
+    if (result === true) {
+      // 旧挙動の再現: die が実際に collisionDied をセットした場合のみ break する。
+      // ゴッドモード時は die が no-op なので collisionDied = false のまま break する。
+      // (die を呼んだ後の result=true は「衝突ループを抜けよ」のシグナルのみ)
+      if (fx.collisionDied) break;
+      // ゴッドモード時: break しない（障害物の当たり判定を無視して進む）
+    }
+    if (result === 'slow') {
+      fx.collisionSlowed = true;
+      break;
+    }
+  }
+};
+
+// --- 公開関数 ---
+
+/**
+ * 1フレーム分のゲームシミュレーションを実行する純粋関数
+ *
+ * Audio / React / DOM への依存は一切持たない。
+ * フック側でこの関数を呼び出し、返却された events を処理する。
+ *
+ * @param world - 現フレーム開始時のゲームワールド
+ * @param ui - 現フレーム開始時の UI 状態
+ * @param input - このフレームの入力状態
+ * @param ctx - フレーム外コンテキスト（ref 群から組み立てる）
+ * @returns 更新後の状態と副作用イベント群
+ */
+export const processFrame = (
+  world: GameWorld,
+  ui: UIState,
+  input: InputState,
+  ctx: FrameContext
+): FrameResult => {
+  const W = ctx.screenWidth;
+  const H = ctx.screenHeight;
+  const RAMP_H = ctx.rampHeight;
+  const MIN_SPD = ctx.minSpeed;
+
+  const currentEffect = world.effect;
+  const currentSpeed = world.speed;
+  const currentPlayer = world.player;
+  const currentRamps = world.ramps as Ramp[];
+  const currentCamY = world.camY;
+  const currentCombo = world.combo.count;
+  const currentComboTimer = world.combo.timer;
+  const currentLastRamp = ctx.lastRamp;
+
+  const events: GameEvent[] = [];
+
+  // --- エフェクトタイマー更新 ---
+  const nextEffect: EffectState = currentEffect.timer <= 0
+    ? { type: undefined, timer: 0 }
+    : { ...currentEffect, timer: currentEffect.timer - 1 };
+
+  // --- 速度更新 ---
+  const nextSpeed = SpeedDomain.accelerate(currentSpeed, input.accel);
+
+  // --- パーティクル系更新（純粋変換） ---
+  // readonly 配列はスプレッドでコピーしてから渡す（ParticleSys は mutable 配列を受け取る）
+  const nextParticles = ParticleSys.updateAndFilter(
+    [...ui.particles],
+    ParticleSys.updateParticle
+  );
+  const nextScorePopups = ParticleSys.updateAndFilter(
+    [...ui.scorePopups],
+    ParticleSys.updatePopup
+  );
+  const nextNearMissEffects = ParticleSys.updateAndFilter(
+    [...ui.nearMissEffects],
+    ParticleSys.updateNearMiss
+  );
+
+  // --- コンボタイマー更新 ---
+  const nextComboTimer = ComboDomain.tick(currentComboTimer);
+
+  // transitionEffect を減衰
+  const nextTransitionEffect = Math.max(0, ui.transitionEffect - 0.1);
+
+  // 雲の更新
+  const nextClouds = ParticleSys.updateClouds([...ui.clouds], nextSpeed);
+
+  // --- ジェットパーティクル更新 ---
+  let nextJetParticles = ParticleSys.updateAndFilter(
+    [...ui.jetParticles],
+    ParticleSys.updateParticle
+  );
+  if (nextSpeed > Config.particle.jetSpeedThreshold && ctx.frameIndex % 2 === 0) {
+    const ramp = currentRamps[currentPlayer.ramp];
+    if (ramp) {
+      const geo = GeometryDomain.getRampGeometry(ramp, W, RAMP_H);
+      const slopeY = GeometryDomain.getSlopeY(currentPlayer.x, geo, ramp.type);
+      nextJetParticles = [
+        ...nextJetParticles,
+        EntityFactory.createJetParticle(
+          currentPlayer.x,
+          currentPlayer.ramp * RAMP_H - currentCamY + slopeY,
+          ramp.dir
+        ),
+      ];
+    }
+  }
+
+  // --- 速度線の更新・生成（HIGH ランク時のみ生成） ---
+  const currentRank = SpeedDomain.getRank(nextSpeed);
+  let nextSpeedLines = updateSpeedLines(ui.speedLines);
+  if (ctx.motionScale > 0) {
+    nextSpeedLines = spawnSpeedLines(nextSpeedLines, currentRank, W, H);
+  }
+
+  // --- プレイヤー残像トレイルの更新 ---
+  const trailRamp = currentRamps[currentPlayer.ramp];
+  let nextPlayerTrail = ui.playerTrail as ReturnType<typeof sampleTrail>;
+  if (trailRamp) {
+    const trailGeo = GeometryDomain.getRampGeometry(trailRamp, W, RAMP_H);
+    const trailSlopeY = GeometryDomain.getSlopeY(currentPlayer.x, trailGeo, trailRamp.type);
+    const trailY = currentPlayer.ramp * RAMP_H - currentCamY + trailSlopeY;
+    const isHighSpeed = nextSpeed > Config.particle.jetSpeedThreshold;
+    const enableTrail = ctx.motionScale > 0 && isHighSpeed;
+    nextPlayerTrail = sampleTrail(
+      ui.playerTrail,
+      currentPlayer.x,
+      trailY,
+      enableTrail ? MAX_TRAIL_SAMPLES : 0
+    );
+  }
+
+  // --- 速度ランク変化の検出 ---
+  const newRank = currentRank;
+  if (newRank !== ctx.prevRank) {
+    events.push({ type: 'SPEED_RANK_CHANGED', rank: newRank });
+  }
+
+  // --- 危険レベル計算 ---
+  const currentRampForDanger = currentRamps[currentPlayer.ramp];
+  const nextDangerLevel = currentRampForDanger
+    ? DangerDomain.calcLevel(currentRampForDanger.obs, currentPlayer.x, currentRampForDanger.dir, nextSpeed, W)
+    : world.dangerLevel;
+
+  // --- フェーズ1: 移動・ジャンプ・ランプ遷移 ---
+  const rampForMove = currentRamps[currentPlayer.ramp];
+  if (!rampForMove) {
+    // ramp が取れない場合はカメラのみ更新して終了
+    const nextCamY = MathUtils.lerp(
+      currentCamY,
+      currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor,
+      Config.camera.followRate
+    );
+    const nextWorld: GameWorld = {
+      ...world,
+      effect: nextEffect,
+      speed: nextSpeed,
+      combo: { count: currentCombo, timer: nextComboTimer },
+      camY: nextCamY,
+      dangerLevel: nextDangerLevel,
+    };
+    const nextUI: UIState = {
+      ...ui,
+      particles: nextParticles,
+      jetParticles: nextJetParticles,
+      scorePopups: nextScorePopups,
+      nearMissEffects: nextNearMissEffects,
+      clouds: nextClouds,
+      transitionEffect: nextTransitionEffect,
+      speedLines: nextSpeedLines,
+      playerTrail: nextPlayerTrail,
+    };
+    return {
+      world: nextWorld,
+      ui: nextUI,
+      events,
+      isGoal: false,
+      isDead: false,
+      newPassedObstacles: [],
+      hitstopFrames: 0,
+      slowMoFrames: 0,
+      slowMoFactor: 1,
+      newRank,
+    };
+  }
+
+  let movedPlayer = Physics.applyMovement(currentPlayer, input, nextSpeed, rampForMove.dir);
+  const jumpResult = Physics.applyJump(movedPlayer, input, nextEffect.type, nextEffect.timer);
+  movedPlayer = jumpResult.player;
+  const didJump = jumpResult.didJump;
+
+  // ゴール／ランプ遷移を解決
+  const transition = Physics.checkTransition(movedPlayer, currentRamps, W);
+
+  // ゴール時は isGoal=true で即返す
+  if (transition.isGoal) {
+    // ゴールイベント
+    events.push({ type: 'GOAL_REACHED' });
+    // ジャンプ音（ゴール直前のジャンプはゴール処理前に発火）
+    if (didJump) {
+      events.push({ type: 'AUDIO', sound: 'jump' });
+    }
+    // カメラ更新
+    const nextCamY = MathUtils.lerp(
+      currentCamY,
+      currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor,
+      Config.camera.followRate
+    );
+    const nextWorld: GameWorld = {
+      ...world,
+      player: movedPlayer,
+      effect: nextEffect,
+      speed: nextSpeed,
+      combo: { count: currentCombo, timer: nextComboTimer },
+      camY: nextCamY,
+      dangerLevel: nextDangerLevel,
+    };
+    const nextUI: UIState = {
+      ...ui,
+      particles: nextParticles,
+      jetParticles: nextJetParticles,
+      scorePopups: nextScorePopups,
+      nearMissEffects: nextNearMissEffects,
+      clouds: nextClouds,
+      transitionEffect: nextTransitionEffect,
+      speedLines: nextSpeedLines,
+      playerTrail: nextPlayerTrail,
+    };
+    return {
+      world: nextWorld,
+      ui: nextUI,
+      events,
+      isGoal: true,
+      isDead: false,
+      newPassedObstacles: [],
+      hitstopFrames: 0,
+      slowMoFrames: 0,
+      slowMoFactor: 1,
+      newRank,
+    };
+  }
+
+  // 遷移後の副作用収集
+  let afterTransitionPlayer = movedPlayer;
+  let afterTransitionRamp = rampForMove;
+  let didRampChange = false;
+  let newLastRamp = currentLastRamp;
+  let scoreDeltaFromRamp = 0;
+  let newCombo = currentCombo;
+  let newComboTimer2 = nextComboTimer;
+  let shouldPlayCombo = false;
+  let comboCountForAudio = 0;
+  let newSpeedBonusDelta = 0;
+  let comboPopupText = '';
+
+  if (transition.transitioned) {
+    afterTransitionPlayer = transition.player;
+    afterTransitionRamp = currentRamps[transition.player.ramp] ?? rampForMove;
+    didRampChange = true;
+
+    if (transition.player.ramp > currentLastRamp) {
+      newLastRamp = transition.player.ramp;
+      // コンボ有効判定は tick 適用前の comboTimer 値を参照する（旧挙動と一致）
+      const scoreResult = ScoringDomain.calcRampScore(nextSpeed, currentComboTimer > 0 ? currentCombo : 0);
+
+      if (ComboDomain.shouldActivate(nextSpeed)) {
+        const comboResult = ComboDomain.increment(currentCombo, nextComboTimer);
+        newCombo = comboResult.combo;
+        newComboTimer2 = comboResult.timer;
+        if (comboResult.combo > 1) {
+          const comboScore = ScoringDomain.calcRampScore(nextSpeed, comboResult.combo);
+          scoreDeltaFromRamp = comboScore.base + comboScore.bonus;
+          shouldPlayCombo = true;
+          comboCountForAudio = comboResult.combo;
+          comboPopupText = `+${comboScore.base + comboScore.bonus} (${comboResult.combo}x)`;
+        } else {
+          scoreDeltaFromRamp = scoreResult.base;
+        }
+      } else {
+        const reset = ComboDomain.reset();
+        newCombo = reset.combo;
+        newComboTimer2 = reset.timer;
+        scoreDeltaFromRamp = scoreResult.base;
+      }
+      newSpeedBonusDelta = SpeedDomain.getBonus(nextSpeed);
+    }
+  }
+
+  // --- 着地検出 ---
+  const justLanded = !ctx.wasOnGround && afterTransitionPlayer.onGround;
+
+  // --- フェーズ2: 衝突処理 ---
+  const fx = createEmptyCollisionSideEffects();
+  const collisionRamp = currentRamps[afterTransitionPlayer.ramp];
+  if (collisionRamp) {
+    processCollisionLoop(
+      collisionRamp,
+      afterTransitionPlayer,
+      nextSpeed,
+      currentCamY,
+      ctx,
+      fx
+    );
+  }
+
+  // 衝突結果をプレイヤーに反映
+  let finalPlayer = afterTransitionPlayer;
+  if (fx.collisionSlowed) {
+    finalPlayer = { ...afterTransitionPlayer, vx: -afterTransitionPlayer.vx * Config.combat.bounceMultiplier };
+  } else if (fx.newVxFromBounce !== undefined) {
+    finalPlayer = { ...afterTransitionPlayer, vx: fx.newVxFromBounce };
+  }
+
+  // --- 副作用の収集（events・状態に反映） ---
+
+  // ジャンプ音
+  if (didJump) {
+    events.push({ type: 'AUDIO', sound: 'jump' });
+  }
+
+  // 現時点のスコア・コンボ・speedBonus（更新を積み上げる用）
+  let nextScore = world.score;
+  let nextSpeedBonus = world.speedBonus;
+  let nextComboFinal = currentCombo;
+  let nextComboTimerFinal = nextComboTimer;
+  let nextLastRamp = currentLastRamp;
+  let finalTransitionEffect = nextTransitionEffect;
+  let mutableParticles = [...nextParticles];
+  let mutableScorePopups = [...nextScorePopups];
+  let mutableNearMissEffects = [...nextNearMissEffects];
+
+  // ランプ遷移の副作用
+  if (didRampChange && transition.transitioned && transition.player.ramp > currentLastRamp) {
+    nextLastRamp = newLastRamp;
+    nextComboFinal = newCombo;
+    nextComboTimerFinal = newComboTimer2;
+    nextScore += scoreDeltaFromRamp;
+    nextSpeedBonus += newSpeedBonusDelta;
+    finalTransitionEffect = 1;
+    if (shouldPlayCombo) {
+      // コンボ音: フック側で Audio.playCombo(comboCountForAudio) を呼ぶ
+      events.push({ type: 'AUDIO', sound: `combo:${comboCountForAudio}` });
+      mutableScorePopups = [
+        ...mutableScorePopups,
+        EntityFactory.createScorePopup(W / 2, 120, comboPopupText, '#ffaa00'),
+      ];
+    }
+    events.push({ type: 'AUDIO', sound: 'rampChange' });
+  }
+
+  // 着地の副作用
+  if (justLanded) {
+    events.push({ type: 'AUDIO', sound: 'land' });
+    if (ctx.motionScale > 0) {
+      const dustGeo = GeometryDomain.getRampGeometry(afterTransitionRamp, W, RAMP_H);
+      const dustSlopeY = GeometryDomain.getSlopeY(afterTransitionPlayer.x, dustGeo, afterTransitionRamp.type);
+      const dustScreenY = afterTransitionPlayer.ramp * RAMP_H - currentCamY + dustSlopeY;
+      const dustParticles = createDust(afterTransitionPlayer.x, dustScreenY, DUST_PARTICLE_COUNT);
+      mutableParticles = [...mutableParticles, ...dustParticles];
+    }
+  }
+
+  // ニアミス副作用（死亡フラグに関わらず適用: 旧挙動と一致）
+  if (fx.nearMissScoreDelta !== 0) {
+    nextScore += fx.nearMissScoreDelta;
+    // nearMissCount は world へ反映
+    for (const nm of fx.nearMissFromCollision) {
+      mutableNearMissEffects = [
+        ...mutableNearMissEffects,
+        EntityFactory.createNearMissEffect(nm.x, nm.y),
+      ];
+    }
+    for (const popup of fx.nearMissPopupsFromCollision) {
+      mutableScorePopups = [
+        ...mutableScorePopups,
+        EntityFactory.createScorePopup(popup.x, popup.y, popup.text, popup.color),
+      ];
+    }
+    // ニアミス音はフック側で Audio.play('nearMiss') を呼ぶ（旧挙動と一致: 死亡判定前に発火）
+    for (let i = 0; i < fx.nearMissDeltaCount; i++) {
+      events.push({ type: 'AUDIO', sound: 'nearMiss' });
+    }
+  }
+
+  // スローモー（ニアミス由来）をフレーム結果に含める
+  // フック側で clockRef.current = triggerSlowMo(...) を呼ぶ
+
+  let finalSpeed = nextSpeed;
+  let finalEffect = nextEffect;
+
+  if (!fx.collisionDied) {
+    // 生存時: スコア・エフェクト・パーティクルを適用
+    if (fx.scoreDeltaFromCollision !== 0) {
+      nextScore += fx.scoreDeltaFromCollision;
+    }
+    if (fx.speedDeltaFromCollision !== 0) {
+      finalSpeed = Math.max(MIN_SPD, nextSpeed + fx.speedDeltaFromCollision);
+    }
+    for (const p of fx.particlesFromCollision) {
+      mutableParticles = [
+        ...mutableParticles,
+        ...EntityFactory.createParticles(p.x, p.y, p.color, p.count),
+      ];
+    }
+    for (const popup of fx.popupsFromCollision) {
+      mutableScorePopups = [
+        ...mutableScorePopups,
+        EntityFactory.createScorePopup(popup.x, popup.y, popup.text, popup.color),
+      ];
+    }
+    if (fx.newEffectFromCollision) {
+      finalEffect = fx.newEffectFromCollision;
+    }
+    // hitstopFrames（アイテム取得・敵撃破由来）はフック側で clockRef に適用する
+  } else {
+    // 死亡: 衝突の audio イベントをフック側に渡す（handleDeath 呼び出しなど）
+    for (const ae of fx.audioEventsFromCollision) {
+      events.push({ type: 'AUDIO', sound: ae.sound });
+    }
+    // 死亡イベント（フック側で handleDeath を呼ぶ）
+    events.push({ type: 'PLAYER_DIED', deathType: fx.deathType ?? 'rock' });
+  }
+
+  // --- カメラ更新 ---
+  // 修正3: カメラ目標は常に前フレームのプレイヤー ramp を使う（旧挙動と一致）
+  const nextCamY = MathUtils.lerp(
+    currentCamY,
+    currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor,
+    Config.camera.followRate
+  );
+
+  // --- world/ui の組み立て ---
+  const nextNearMissCount = world.nearMissCount + fx.nearMissDeltaCount;
+
+  const resultWorld: GameWorld = {
+    ...world,
+    player: fx.collisionDied ? afterTransitionPlayer : finalPlayer,
+    ramps: currentRamps,
+    speed: finalSpeed,
+    camY: nextCamY,
+    score: nextScore,
+    speedBonus: nextSpeedBonus,
+    combo: { count: nextComboFinal, timer: nextComboTimerFinal },
+    effect: finalEffect,
+    lastRamp: nextLastRamp,
+    nearMissCount: nextNearMissCount,
+    dangerLevel: nextDangerLevel,
+  };
+
+  const resultUI: UIState = {
+    ...ui,
+    particles: mutableParticles,
+    jetParticles: nextJetParticles,
+    scorePopups: mutableScorePopups,
+    nearMissEffects: mutableNearMissEffects,
+    clouds: nextClouds,
+    transitionEffect: finalTransitionEffect,
+    speedLines: nextSpeedLines,
+    playerTrail: nextPlayerTrail,
+    // shake はフックが hitstopFrames 由来の処理と一体で管理するため変更しない
+  };
+
+  return {
+    world: resultWorld,
+    ui: resultUI,
+    events,
+    isGoal: false,
+    isDead: fx.collisionDied,
+    deathType: fx.deathType,
+    newPassedObstacles: fx.newPassedObstacles,
+    hitstopFrames: fx.hitstopFrames,
+    slowMoFrames: fx.slowMoFrames,
+    slowMoFactor: fx.slowMoFactor,
+    newRank,
+  };
+};

--- a/src/features/non-brake-descent/application/game-loop/frame-processor.ts
+++ b/src/features/non-brake-descent/application/game-loop/frame-processor.ts
@@ -111,6 +111,11 @@ export interface FrameResult {
 /** 衝突コールバック群（副作用を収集するためのインターフェース） */
 type CollisionSideEffects = {
   collisionDied: boolean;
+  /**
+   * 死亡系ハンドラが呼ばれたか（godMode でも true になる）
+   * 旧挙動再現: result=true を返したハンドラが呼ばれたら godMode に関わらず break する。
+   */
+  hitByDeathHandler: boolean;
   deathType: DeathState['type'] | undefined;
   collisionSlowed: boolean;
   newVxFromBounce: number | undefined;
@@ -133,6 +138,7 @@ type CollisionSideEffects = {
 /** CollisionSideEffects の初期値 */
 const createEmptyCollisionSideEffects = (): CollisionSideEffects => ({
   collisionDied: false,
+  hitByDeathHandler: false,
   deathType: undefined,
   collisionSlowed: false,
   newVxFromBounce: undefined,
@@ -174,12 +180,14 @@ const processCollisionLoop = (
   const godMode = ctx.isGodMode;
   const motionScale = ctx.motionScale;
 
-  const die = godMode
-    ? (_type: DeathState['type']) => { /* ゴッドモード時は die を無視する（collisionDied を設定しない） */ }
-    : (type: DeathState['type']) => {
-        fx.collisionDied = true;
-        fx.deathType = type;
-      };
+  const die = (type: DeathState['type']) => {
+    if (!godMode) {
+      fx.collisionDied = true;
+      fx.deathType = type;
+    }
+    // ゴッドモード時も fx.hitByDeathHandler を立てる（ループ break シグナルに使用）
+    fx.hitByDeathHandler = true;
+  };
 
   const bounce = godMode
     ? (_vx: number) => { /* ゴッドモード時はバウンスしない */ }
@@ -280,11 +288,11 @@ const processCollisionLoop = (
     }
 
     if (result === true) {
-      // 旧挙動の再現: die が実際に collisionDied をセットした場合のみ break する。
-      // ゴッドモード時は die が no-op なので collisionDied = false のまま break する。
-      // (die を呼んだ後の result=true は「衝突ループを抜けよ」のシグナルのみ)
-      if (fx.collisionDied) break;
-      // ゴッドモード時: break しない（障害物の当たり判定を無視して進む）
+      // 旧挙動の再現: ハンドラが true を返したら godMode に関わらず break する。
+      // ただし死亡イベント（PLAYER_DIED）は godMode でない時のみ発火する。
+      // 旧コード: `result === true` → `collisionDied = true; break;` という流れで
+      // godMode 時は `die()` が no-op だが、ループ break 自体は起きていた。
+      if (fx.hitByDeathHandler) break;
     }
     if (result === 'slow') {
       fx.collisionSlowed = true;
@@ -471,11 +479,8 @@ export const processFrame = (
   // ゴール時は isGoal=true で即返す
   if (transition.isGoal) {
     // ゴールイベント
+    // 旧挙動: ゴール時は `handleClear(); return;` のみ。didJump は処理されず jump 音なし。
     events.push({ type: 'GOAL_REACHED' });
-    // ジャンプ音（ゴール直前のジャンプはゴール処理前に発火）
-    if (didJump) {
-      events.push({ type: 'AUDIO', sound: 'jump' });
-    }
     // カメラ更新
     const nextCamY = MathUtils.lerp(
       currentCamY,

--- a/src/features/non-brake-descent/application/game-loop/frame-processor.ts
+++ b/src/features/non-brake-descent/application/game-loop/frame-processor.ts
@@ -545,7 +545,9 @@ export const processFrame = (
       const scoreResult = ScoringDomain.calcRampScore(nextSpeed, currentComboTimer > 0 ? currentCombo : 0);
 
       if (ComboDomain.shouldActivate(nextSpeed)) {
-        const comboResult = ComboDomain.increment(currentCombo, nextComboTimer);
+        // increment の第2引数は tick 前の comboTimer 値を使う（旧挙動と一致）。
+        // calcRampScore のコンボ有効判定も currentComboTimer（tick 前）を参照しており整合する。
+        const comboResult = ComboDomain.increment(currentCombo, currentComboTimer);
         newCombo = comboResult.combo;
         newComboTimer2 = comboResult.timer;
         if (comboResult.combo > 1) {

--- a/src/features/non-brake-descent/application/game-loop/game-state.ts
+++ b/src/features/non-brake-descent/application/game-loop/game-state.ts
@@ -13,6 +13,8 @@ import type {
   Ramp,
   ScorePopup,
 } from '../../types';
+import type { SpeedLine } from '../../domain/services/speed-line-service';
+import type { TrailSample } from '../../domain/services/trail-service';
 
 /** コンボの状態 */
 export interface ComboState {
@@ -44,6 +46,10 @@ export interface UIState {
   readonly clouds: readonly Cloud[];
   readonly shake: number;
   readonly transitionEffect: number;
+  /** 速度線エフェクト（HIGH ランク時に表示） */
+  readonly speedLines: readonly SpeedLine[];
+  /** プレイヤー残像トレイル（高速時に表示） */
+  readonly playerTrail: readonly TrailSample[];
 }
 
 /** useReducer で使用するゲームアクション型 */
@@ -93,4 +99,6 @@ export const createInitialUIState = (clouds: readonly Cloud[] = []): UIState => 
   clouds,
   shake: 0,
   transitionEffect: 0,
+  speedLines: [],
+  playerTrail: [],
 });

--- a/src/features/non-brake-descent/domain/events/game-events.ts
+++ b/src/features/non-brake-descent/domain/events/game-events.ts
@@ -13,6 +13,8 @@ export type GameEvent =
   | { readonly type: 'PLAYER_BOUNCED'; readonly velocity: number }
   | { readonly type: 'GOAL_REACHED' }
   | { readonly type: 'AUDIO'; readonly sound: string }
+  /** 速度ランク変化時に BGM プロファイルを切り替えるイベント */
+  | { readonly type: 'SPEED_RANK_CHANGED'; readonly rank: number }
   | { readonly type: 'PARTICLE'; readonly x: number; readonly y: number; readonly color: string; readonly count: number }
   | { readonly type: 'SCORE_POPUP'; readonly x: number; readonly y: number; readonly text: string; readonly color: string };
 

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -156,7 +156,7 @@ export const useGameEngine = (
   // 各 setter 呼び出し時に同期更新する。
   const playerRef = useRef<Player>(EntityFactory.createPlayer());
   const speedRef = useRef<number>(MIN_SPD);
-  const ramsRef = useRef<Ramp[]>([]);
+  const rampsRef = useRef<Ramp[]>([]);
   const camYRef = useRef<number>(0);
   const effectRef = useRef<EffectState>({ type: undefined, timer: 0 });
   const comboRef = useRef<number>(0);
@@ -239,7 +239,7 @@ export const useGameEngine = (
   const startCountdown = useCallback(() => {
     Audio.init();
     const generated = RampGen.generate(TOTAL);
-    ramsRef.current = generated;
+    rampsRef.current = generated;
     setRamps(generated);
     resetGameState();
     setCountdown(3);
@@ -453,7 +453,7 @@ export const useGameEngine = (
       // ref から現フレームの動的値を読み取る（stale closure 回避）
       const currentEffect = effectRef.current;
       const currentPlayer = playerRef.current;
-      const currentRamps = ramsRef.current;
+      const currentRamps = rampsRef.current;
       const currentCamY = camYRef.current;
 
       // reverse エフェクト中は左右を入れ替える
@@ -604,24 +604,58 @@ export const useGameEngine = (
         return;
       }
 
-      // 修正6: 死亡フレームでも旧挙動に合わせてカメラを更新する。
-      // 旧挙動: 衝突死亡後の else ブロックの外でカメラ更新が実行されていた。
+      // --- state/ref の更新 ---
+      const w = result.world;
+
+      // 死亡フレームではニアミス副作用・スコア差分・カメラのみを適用し、
+      // プレイヤー位置・速度・コンボ・エフェクト等の world コミットは行わない。
+      // 旧挙動（a9ea5b9）: 衝突死亡時は !collisionDied ブロックをスキップし、
+      // nearMiss 副作用（スコア・カウント・エフェクト・ポップアップ・slowMo）と
+      // カメラ更新だけが実行されていた。
       if (result.isDead) {
-        camYRef.current = result.world.camY;
-        setCamY(result.world.camY);
+        // ニアミス由来スローモー（旧: slowMoFrames > 0 のとき triggerSlowMo 呼び出し）
+        if (result.slowMoFrames > 0) {
+          clockRef.current = triggerSlowMo(clockRef.current, result.slowMoFrames, result.slowMoFactor);
+        }
+
+        // スコア差分（nearMiss 由来 + ランプ遷移由来）
+        if (w.score !== 0) {
+          setScore(prev => prev + w.score);
+        }
+
+        // ニアミスカウント
+        if (w.nearMissCount !== 0) {
+          setNearMissCount(prev => prev + w.nearMissCount);
+        }
+
+        // ニアミスエフェクト追記（nearMiss 由来の新規生成分）
+        if (result.ui.nearMissEffects.length > 0) {
+          setNearMissEffects(prev => [...prev, ...result.ui.nearMissEffects as typeof prev]);
+        }
+
+        // スコアポップアップ追記（nearMiss 由来の新規生成分）
+        if (result.ui.scorePopups.length > 0) {
+          setScorePopups(prev => [...prev, ...result.ui.scorePopups as typeof prev]);
+        }
+
+        // パーティクル追記（着地由来・nearMiss 由来の新規生成分）
+        if (result.ui.particles.length > 0) {
+          setParticles(prev => [...prev, ...result.ui.particles as typeof prev]);
+        }
+
+        // カメラ更新（旧挙動: 衝突死亡後も else ブロック外でカメラ更新が実行されていた）
+        camYRef.current = w.camY;
+        setCamY(w.camY);
         return;
       }
 
-      // --- clockRef 更新 ---
+      // --- clockRef 更新（生存時のみ） ---
       if (result.hitstopFrames > 0) {
         clockRef.current = triggerHitstop(clockRef.current, result.hitstopFrames);
       }
       if (result.slowMoFrames > 0) {
         clockRef.current = triggerSlowMo(clockRef.current, result.slowMoFrames, result.slowMoFactor);
       }
-
-      // --- state/ref の更新 ---
-      const w = result.world;
 
       // 速度
       speedRef.current = w.speed;
@@ -666,21 +700,21 @@ export const useGameEngine = (
       setDangerLevel(w.dangerLevel);
 
       // transitionEffect（processFrame が計算した値で上書き）
-      // 修正1: ref も同期して次フレームの processFrame に最新値を渡す。
+      // ref も同期して次フレームの processFrame に最新値を渡す。
       transitionEffectRef.current = result.ui.transitionEffect;
       setTransitionEffect(result.ui.transitionEffect);
 
       // ジェットパーティクル（processFrame が完全に管理）
-      // 修正3: 生成のないフレームでも既存粒子を更新する（length > 0 ガード撤廃）。
+      // 生成のないフレームでも既存粒子を更新する（length > 0 ガード撤廃）。
       // 旧挙動: 毎フレーム updateAndFilter を実行してから新規粒子を追加していた。
       setJetParticles(prev => [
         ...ParticleSys.updateAndFilter(prev, ParticleSys.updateParticle),
         ...result.ui.jetParticles,
       ]);
 
-      // 雲の更新（修正4: result.world.speed を使う）
+      // 雲の更新（result.world.speed を使う）
       // 旧挙動: setClouds(current => ParticleSys.updateClouds(current, nextSpeed)) で加速後速度を使用。
-      // 新: processFrame 後の result.world.speed を使うことで旧と同値になる。
+      // processFrame 後の result.world.speed を使うことで旧と同値になる。
       setClouds(current => ParticleSys.updateClouds(current, result.world.speed));
 
       // 速度線（processFrame が管理）

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -3,6 +3,10 @@
  *
  * NonBrakeDescentGame.tsx から状態管理・ゲームループロジックを抽出する。
  * 元のコードの動作を忠実に再現しつつ、プレゼンテーション層から分離する。
+ *
+ * B2-S1: setState updater 内の副作用をループ外へ分離。
+ * 動的値（player/speed/ramps/camY/effect/combo/comboTimer/lastRamp/godMode）を
+ * ref に昇格させ、ゲームループの依存配列を [state] のみに縮小した。
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Audio } from '../../audio';
@@ -211,12 +215,27 @@ export const useGameEngine = (
     motionScaleRef.current = resolveMotionScale(reducedMotion);
   }, [reducedMotion]);
 
+  // --- B2-S1: stale closure 回避のための ref 群 ---
+  // ゲームループ useEffect の依存配列から動的 state を除外するため、
+  // 各 setter 呼び出し時に同期更新する。
+  const playerRef = useRef<Player>(EntityFactory.createPlayer());
+  const speedRef = useRef<number>(MIN_SPD);
+  const ramsRef = useRef<Ramp[]>([]);
+  const camYRef = useRef<number>(0);
+  const effectRef = useRef<EffectState>({ type: undefined, timer: 0 });
+  const comboRef = useRef<number>(0);
+  const comboTimerRef = useRef<number>(0);
+  const lastRampRef = useRef<number>(0);
+  const godModeRef = useRef<boolean>(false);
+
   const isMobile = useIsMobile();
   const handleCheat = useCheatCode('jinjinjin', () => {
     setGodMode(current => {
+      const next = !current;
+      godModeRef.current = next;
       Audio.init();
-      Audio.play(!current ? 'score' : 'death');
-      return !current;
+      Audio.play(next ? 'score' : 'death');
+      return next;
     });
   });
 
@@ -231,14 +250,21 @@ export const useGameEngine = (
   }, []);
 
   const resetGameState = useCallback(() => {
-    setPlayer(EntityFactory.createPlayer());
+    const initialPlayer = EntityFactory.createPlayer();
+    playerRef.current = initialPlayer;
+    setPlayer(initialPlayer);
+    speedRef.current = MIN_SPD;
     setSpeed(MIN_SPD);
+    camYRef.current = 0;
     setCamY(0);
     setScore(0);
+    lastRampRef.current = 0;
     setLastRamp(0);
     setSpeedBonus(0);
     setStartTime(Date.now());
-    setEffect({ type: undefined, timer: 0 });
+    const initialEffect: EffectState = { type: undefined, timer: 0 };
+    effectRef.current = initialEffect;
+    setEffect(initialEffect);
     setDeath(undefined);
     setParticles([]);
     setJetParticles([]);
@@ -247,7 +273,9 @@ export const useGameEngine = (
     setNearMissCount(0);
     setClearAnim({ phase: 0, frame: 0 });
     setIsNewHighScore(false);
+    comboRef.current = 0;
     setCombo(0);
+    comboTimerRef.current = 0;
     setComboTimer(0);
     setTransitionEffect(0);
     setDangerLevel(0);
@@ -265,7 +293,9 @@ export const useGameEngine = (
 
   const startCountdown = useCallback(() => {
     Audio.init();
-    setRamps(RampGen.generate(TOTAL));
+    const generated = RampGen.generate(TOTAL);
+    ramsRef.current = generated;
+    setRamps(generated);
     resetGameState();
     setCountdown(3);
     setState(GameState.COUNTDOWN);
@@ -305,16 +335,16 @@ export const useGameEngine = (
     (type: DeathState['type']) => {
       Audio.stopBGM();
       Audio.playMelody('gameOver');
-      const rank = SpeedDomain.getRank(speed);
+      const rank = SpeedDomain.getRank(speedRef.current);
       const finalScore = ScoringDomain.calcFinal(score, speedBonus);
       commitScore(finalScore);
       setDeath({ type, frame: 0, fast: rank === SpeedRank.HIGH });
       setShake(rank === SpeedRank.HIGH ? 18 : 6);
-      addParticles(player.x, player.ramp * RAMP_H - camY + 30, '#ff4444', rank === SpeedRank.HIGH ? 15 : 8);
+      addParticles(playerRef.current.x, playerRef.current.ramp * RAMP_H - camYRef.current + 30, '#ff4444', rank === SpeedRank.HIGH ? 15 : 8);
       clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.death, motionScaleRef.current));
       setState(GameState.DYING);
     },
-    [speed, score, speedBonus, player, camY, RAMP_H, addParticles, commitScore]
+    [score, speedBonus, RAMP_H, addParticles, commitScore]
   );
 
   const handleClear = useCallback(() => {
@@ -459,6 +489,7 @@ export const useGameEngine = (
   }, [state]);
 
   // ゲームループ
+  // B2-S1: 依存配列を [state] のみに縮小。動的値はすべて ref 経由で読む。
   useEffect(() => {
     if (state !== GameState.PLAY) return;
     const loop = window.setInterval(() => {
@@ -472,37 +503,67 @@ export const useGameEngine = (
       frameRef.current++;
       const keyState = keys.current;
       const touchState = touchKeys.current;
-      const reverse = effect.type === EffectType.REVERSE;
+
+      // ref から現フレームの動的値を読み取る（stale closure 回避）
+      const currentEffect = effectRef.current;
+      const currentSpeed = speedRef.current;
+      const currentPlayer = playerRef.current;
+      const currentRamps = ramsRef.current;
+      const currentCamY = camYRef.current;
+      const currentCombo = comboRef.current;
+      const currentComboTimer = comboTimerRef.current;
+      const currentLastRamp = lastRampRef.current;
+      const currentGodMode = godModeRef.current;
+
+      const reverse = currentEffect.type === EffectType.REVERSE;
       const input: InputState = {
         left: reverse ? keyState.ArrowRight || touchState.right : keyState.ArrowLeft || touchState.left,
         right: reverse ? keyState.ArrowLeft || touchState.left : keyState.ArrowRight || touchState.right,
         accel: keyState.KeyZ || touchState.accel,
         jump: keyState.KeyX || touchState.jump,
       };
-      setEffect(current =>
-        current.timer <= 0 ? { type: undefined, timer: 0 } : { ...current, timer: current.timer - 1 }
-      );
-      setSpeed(current => SpeedDomain.accelerate(current, input.accel));
+
+      // --- エフェクトタイマー更新 ---
+      const nextEffect: EffectState = currentEffect.timer <= 0
+        ? { type: undefined, timer: 0 }
+        : { ...currentEffect, timer: currentEffect.timer - 1 };
+      effectRef.current = nextEffect;
+      setEffect(nextEffect);
+
+      // --- 速度更新 ---
+      const nextSpeed = SpeedDomain.accelerate(currentSpeed, input.accel);
+      speedRef.current = nextSpeed;
+      setSpeed(nextSpeed);
+
+      // --- パーティクル系更新（副作用なし・純粋変換） ---
       setParticles(current => ParticleSys.updateAndFilter(current, ParticleSys.updateParticle));
       setScorePopups(current => ParticleSys.updateAndFilter(current, ParticleSys.updatePopup));
       setNearMissEffects(current => ParticleSys.updateAndFilter(current, ParticleSys.updateNearMiss));
-      setComboTimer(ComboDomain.tick);
+
+      // --- コンボタイマー更新 ---
+      const nextComboTimer = ComboDomain.tick(currentComboTimer);
+      comboTimerRef.current = nextComboTimer;
+      setComboTimer(nextComboTimer);
+
       setTransitionEffect(current => Math.max(0, current - 0.1));
-      setClouds(current => ParticleSys.updateClouds(current, speed));
+      setClouds(current => ParticleSys.updateClouds(current, nextSpeed));
+
+      // --- ジェットパーティクル更新 ---
       setJetParticles(prev => {
         let updated = ParticleSys.updateAndFilter(prev, ParticleSys.updateParticle);
-        if (speed > Config.particle.jetSpeedThreshold && frameRef.current % 2 === 0) {
-          const ramp = ramps[player.ramp];
+        if (nextSpeed > Config.particle.jetSpeedThreshold && frameRef.current % 2 === 0) {
+          const ramp = currentRamps[currentPlayer.ramp];
           if (ramp) {
             const geo = GeometryDomain.getRampGeometry(ramp, W, RAMP_H);
-            const slopeY = GeometryDomain.getSlopeY(player.x, geo, ramp.type);
-            updated = [...updated, EntityFactory.createJetParticle(player.x, player.ramp * RAMP_H - camY + slopeY, ramp.dir)];
+            const slopeY = GeometryDomain.getSlopeY(currentPlayer.x, geo, ramp.type);
+            updated = [...updated, EntityFactory.createJetParticle(currentPlayer.x, currentPlayer.ramp * RAMP_H - currentCamY + slopeY, ramp.dir)];
           }
         }
         return updated;
       });
-      // 速度線の更新・生成（HIGH ランク時のみ生成）
-      const currentRank = SpeedDomain.getRank(speed);
+
+      // --- 速度線の更新・生成（HIGH ランク時のみ生成） ---
+      const currentRank = SpeedDomain.getRank(nextSpeed);
       setSpeedLines(prev => {
         const updated = updateSpeedLines(prev);
         return motionScaleRef.current > 0
@@ -510,169 +571,305 @@ export const useGameEngine = (
           : updated;
       });
 
-      // プレイヤー残像トレイルの更新（高速時かつ reduced-motion 無効時のみサンプル追加）
+      // --- プレイヤー残像トレイルの更新（高速時かつ reduced-motion 無効時のみサンプル追加） ---
       // 注: jetParticles と同様、当該 tick の setPlayer 更新前のプレイヤー位置（前フレーム相当）でサンプリングする。残像演出としては許容範囲。
-      const trailRamp = ramps[player.ramp];
+      const trailRamp = currentRamps[currentPlayer.ramp];
       if (trailRamp) {
         const trailGeo = GeometryDomain.getRampGeometry(trailRamp, W, RAMP_H);
-        const trailSlopeY = GeometryDomain.getSlopeY(player.x, trailGeo, trailRamp.type);
-        const trailY = player.ramp * RAMP_H - camY + trailSlopeY;
-        const isHighSpeed = speed > Config.particle.jetSpeedThreshold;
+        const trailSlopeY = GeometryDomain.getSlopeY(currentPlayer.x, trailGeo, trailRamp.type);
+        const trailY = currentPlayer.ramp * RAMP_H - currentCamY + trailSlopeY;
+        const isHighSpeed = nextSpeed > Config.particle.jetSpeedThreshold;
         const enableTrail = motionScaleRef.current > 0 && isHighSpeed;
         setPlayerTrail(prev =>
-          sampleTrail(prev, player.x, trailY, enableTrail ? MAX_TRAIL_SAMPLES : 0)
+          sampleTrail(prev, currentPlayer.x, trailY, enableTrail ? MAX_TRAIL_SAMPLES : 0)
         );
       }
 
-      // 速度ランク変化の検出（BGM プロファイル切替）
+      // --- 速度ランク変化の検出（BGM プロファイル切替） ---
       if (currentRank !== prevRankRef.current) {
         prevRankRef.current = currentRank;
         Audio.setSpeedRank(currentRank);
       }
 
-      const currentRampInLoop = ramps[player.ramp];
-      if (currentRampInLoop) {
-        setDangerLevel(DangerDomain.calcLevel(currentRampInLoop.obs, player.x, currentRampInLoop.dir, speed, W));
+      const currentRampForDanger = currentRamps[currentPlayer.ramp];
+      if (currentRampForDanger) {
+        setDangerLevel(DangerDomain.calcLevel(currentRampForDanger.obs, currentPlayer.x, currentRampForDanger.dir, nextSpeed, W));
       }
-      setPlayer(prev => {
-        const ramp = ramps[prev.ramp];
-        if (!ramp) return prev;
-        let updated = Physics.applyMovement(prev, input, speed, ramp.dir);
-        const jumpResult = Physics.applyJump(updated, input, effect.type, effect.timer);
-        updated = jumpResult.player;
-        if (jumpResult.didJump) Audio.play('jump');
 
-        // 先にゴール／ランプ遷移を解決し、最終的に確定するプレイヤーを求める。
-        // 着地検出はこの確定プレイヤーで行うことで、遷移時に prevOnGroundRef が
-        // 実際に返すプレイヤーと食い違って誤発火するのを防ぐ。
-        const transition = Physics.checkTransition(updated, ramps, W);
-        if (transition.isGoal) {
-          handleClear();
-          return prev;
-        }
+      // --- プレイヤー移動・遷移・衝突計算（副作用をすべて updater 外へ） ---
+      // B2-S1: 2つの setPlayer(prev=>{...}) updater を1パスに統合し、
+      //        副作用（Audio/setState/clockRef 操作）を updater の外で適用する。
 
-        let finalPlayer = updated;
-        let finalRamp = ramp;
-        if (transition.transitioned) {
-          Audio.play('rampChange');
-          if (transition.player.ramp > lastRamp) {
-            setLastRamp(transition.player.ramp);
-            const scoreResult = ScoringDomain.calcRampScore(speed, comboTimer > 0 ? combo : 0);
-            if (ComboDomain.shouldActivate(speed)) {
-              const comboResult = ComboDomain.increment(combo, comboTimer);
-              setCombo(comboResult.combo);
-              setComboTimer(comboResult.timer);
-              if (comboResult.combo > 1) {
-                const comboScore = ScoringDomain.calcRampScore(speed, comboResult.combo);
-                setScore(current => current + comboScore.base + comboScore.bonus);
-                Audio.playCombo(comboResult.combo);
-                addScorePopup(W / 2, 120, `+${comboScore.base + comboScore.bonus} (${comboResult.combo}x)`, '#ffaa00');
-              } else {
-                setScore(current => current + scoreResult.base);
-              }
+      // ── フェーズ1: 移動・ジャンプ・ランプ遷移 ──
+      const rampForMove = currentRamps[currentPlayer.ramp];
+      if (!rampForMove) {
+        // ramp が取れない場合はカメラのみ更新して終了
+        const nextCamY = MathUtils.lerp(currentCamY, currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate);
+        camYRef.current = nextCamY;
+        setCamY(nextCamY);
+        return;
+      }
+
+      let movedPlayer = Physics.applyMovement(currentPlayer, input, nextSpeed, rampForMove.dir);
+      const jumpResult = Physics.applyJump(movedPlayer, input, nextEffect.type, nextEffect.timer);
+      movedPlayer = jumpResult.player;
+      const didJump = jumpResult.didJump;
+
+      // ゴール／ランプ遷移を解決し、確定プレイヤーを求める
+      const transition = Physics.checkTransition(movedPlayer, currentRamps, W);
+
+      // ゴール時は handleClear を呼んで終了（updater 外で副作用）
+      if (transition.isGoal) {
+        handleClear();
+        return;
+      }
+
+      // 遷移後の副作用を収集するためのローカル変数
+      let afterTransitionPlayer = movedPlayer;
+      let afterTransitionRamp = rampForMove;
+      let didRampChange = false;
+      let newLastRamp = currentLastRamp;
+      let scoreDeltaFromRamp = 0;
+      let newCombo = currentCombo;
+      let newComboTimer2 = nextComboTimer;
+      let shouldPlayCombo = false;
+      let comboCountForAudio = 0;
+      let newSpeedBonusDelta = 0;
+      let comboPopupText = '';
+
+      if (transition.transitioned) {
+        afterTransitionPlayer = transition.player;
+        afterTransitionRamp = currentRamps[transition.player.ramp] ?? rampForMove;
+        didRampChange = true;
+
+        if (transition.player.ramp > currentLastRamp) {
+          newLastRamp = transition.player.ramp;
+          const scoreResult = ScoringDomain.calcRampScore(nextSpeed, nextComboTimer > 0 ? currentCombo : 0);
+
+          if (ComboDomain.shouldActivate(nextSpeed)) {
+            const comboResult = ComboDomain.increment(currentCombo, nextComboTimer);
+            newCombo = comboResult.combo;
+            newComboTimer2 = comboResult.timer;
+            if (comboResult.combo > 1) {
+              const comboScore = ScoringDomain.calcRampScore(nextSpeed, comboResult.combo);
+              scoreDeltaFromRamp = comboScore.base + comboScore.bonus;
+              shouldPlayCombo = true;
+              comboCountForAudio = comboResult.combo;
+              comboPopupText = `+${comboScore.base + comboScore.bonus} (${comboResult.combo}x)`;
             } else {
-              const reset = ComboDomain.reset();
-              setCombo(reset.combo);
-              setComboTimer(reset.timer);
-              setScore(current => current + scoreResult.base);
+              // combo=1 はポップアップなし（ベーススコアのみ加算）
+              scoreDeltaFromRamp = scoreResult.base;
             }
-            setSpeedBonus(current => current + SpeedDomain.getBonus(speed));
-            setTransitionEffect(1);
+          } else {
+            const reset = ComboDomain.reset();
+            newCombo = reset.combo;
+            newComboTimer2 = reset.timer;
+            scoreDeltaFromRamp = scoreResult.base;
           }
-          finalPlayer = transition.player;
-          finalRamp = ramps[transition.player.ramp] ?? ramp;
+          newSpeedBonusDelta = SpeedDomain.getBonus(nextSpeed);
         }
+      }
 
-        // 着地検出: 前フレームが空中で確定プレイヤーが接地に変化したとき
-        const wasOnGround = prevOnGroundRef.current;
-        if (!wasOnGround && finalPlayer.onGround) {
-          Audio.play('land');
-          if (motionScaleRef.current > 0) {
-            // 着地点の画面 Y 座標を計算して土煙を生成。
-            // camY は jetParticles/トレイルと同様に前フレーム相当だが、土煙は短命バーストのため許容範囲。
-            const dustGeo = GeometryDomain.getRampGeometry(finalRamp, W, RAMP_H);
-            const dustSlopeY = GeometryDomain.getSlopeY(finalPlayer.x, dustGeo, finalRamp.type);
-            const dustScreenY = finalPlayer.ramp * RAMP_H - camY + dustSlopeY;
-            setParticles(prevParticles => [
-              ...prevParticles,
-              ...createDust(finalPlayer.x, dustScreenY, DUST_PARTICLE_COUNT),
-            ]);
-          }
-        }
-        prevOnGroundRef.current = finalPlayer.onGround;
+      // 着地検出: 前フレームが空中で確定プレイヤーが接地に変化したとき
+      const wasOnGround = prevOnGroundRef.current;
+      const justLanded = !wasOnGround && afterTransitionPlayer.onGround;
+      prevOnGroundRef.current = afterTransitionPlayer.onGround;
 
-        return finalPlayer;
-      });
-      setPlayer(prev => {
-        const ramp = ramps[prev.ramp];
-        if (!ramp) return prev;
+      // ── フェーズ2: 衝突処理 ──
+      // 遷移後のプレイヤー・ランプで衝突判定を行う（移動→遷移→衝突の順序を保持）
+      let finalPlayer = afterTransitionPlayer;
+      let collisionDied = false;
+      let collisionSlowed = false;
+      let newVxFromBounce: number | undefined;
+
+      // 衝突処理中に発生した副作用を収集するローカル変数
+      const audioEventsFromCollision: Array<() => void> = [];
+      let scoreDeltaFromCollision = 0;
+      let speedDeltaFromCollision = 0;
+      const particlesFromCollision: Array<{ x: number; y: number; color: string; count: number }> = [];
+      const popupsFromCollision: Array<{ x: number; y: number; text: string; color: string }> = [];
+      const nearMissFromCollision: Array<{ x: number; y: number }> = [];
+      let nearMissDeltaCount = 0;
+      let nearMissScoreDelta = 0;
+      let newEffectFromCollision: EffectState | undefined;
+      let hitstopFrames = 0;
+      let slowMoFrames = 0;
+      let slowMoFactor = 1;
+
+      const collisionRamp = currentRamps[afterTransitionPlayer.ramp];
+      if (collisionRamp) {
+        // 衝突ハンドラのコールバックは副作用を収集するだけ（即時適用しない）
         const handlers = createCollisionHandlers(
-          SpeedDomain.getRank(speed),
+          SpeedDomain.getRank(nextSpeed),
           {
-            onDie: handleDeath,
-            onScore: ox => {
-              Audio.play('score');
-              setScore(current => current + Config.score.item);
-              addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ffdd00', 6);
-              addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.item}`, '#ffdd00');
-              clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.item, motionScaleRef.current));
+            onDie: (type) => {
+              collisionDied = true;
+              // handleDeath は updater 外で呼ぶ（後述）
+              // type を記録するためにクロージャに保存
+              audioEventsFromCollision.push(() => handleDeath(type));
             },
-            onEffect: type => {
+            onScore: (ox) => {
+              audioEventsFromCollision.push(() => Audio.play('score'));
+              scoreDeltaFromCollision += Config.score.item;
+              particlesFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25, color: '#ffdd00', count: 6 });
+              popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY, text: `+${Config.score.item}`, color: '#ffdd00' });
+              hitstopFrames = Math.max(hitstopFrames, scaleFrames(Config.juice.hitstop.item, motionScaleRef.current));
+            },
+            onEffect: (type) => {
               if (!type) return;
-              Audio.play('hit');
-              setEffect({ type, timer: Config.effect.duration });
+              audioEventsFromCollision.push(() => Audio.play('hit'));
+              newEffectFromCollision = { type, timer: Config.effect.duration };
             },
-            onEnemyKill: ox => {
-              Audio.play('enemyKill');
-              setScore(current => current + Config.score.enemy);
-              setSpeed(current => Math.max(MIN_SPD, current - Config.combat.enemyKillSlowdown));
-              addParticles(ox, prev.ramp * RAMP_H - camY + 25, '#ff8800', 10);
-              addScorePopup(ox, prev.ramp * RAMP_H - camY, `+${Config.score.enemy}`, '#ff8800');
-              clockRef.current = triggerHitstop(clockRef.current, scaleFrames(Config.juice.hitstop.enemyKill, motionScaleRef.current));
+            onEnemyKill: (ox) => {
+              audioEventsFromCollision.push(() => Audio.play('enemyKill'));
+              scoreDeltaFromCollision += Config.score.enemy;
+              speedDeltaFromCollision -= Config.combat.enemyKillSlowdown;
+              particlesFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25, color: '#ff8800', count: 10 });
+              popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY, text: `+${Config.score.enemy}`, color: '#ff8800' });
+              hitstopFrames = Math.max(hitstopFrames, scaleFrames(Config.juice.hitstop.enemyKill, motionScaleRef.current));
             },
-            onBounce: vx => {
-              Audio.play('hit');
-              setPlayer(current => ({ ...current, vx }));
+            onBounce: (vx) => {
+              audioEventsFromCollision.push(() => Audio.play('hit'));
+              newVxFromBounce = vx;
             },
           },
-          godMode
+          currentGodMode
         );
-        for (const obstacle of ramp.obs) {
+
+        for (const obstacle of collisionRamp.obs) {
           if (!CollisionDomain.isActive(obstacle)) continue;
-          const ox = GeometryDomain.getObstacleX(obstacle, ramp, W);
-          const col = CollisionDomain.check(prev.x, ox, prev.jumping, prev.y);
-          const obsId = `${prev.ramp}-${obstacle.pos}`;
+          const ox = GeometryDomain.getObstacleX(obstacle, collisionRamp, W);
+          const col = CollisionDomain.check(afterTransitionPlayer.x, ox, afterTransitionPlayer.jumping, afterTransitionPlayer.y);
+          const obsId = `${afterTransitionPlayer.ramp}-${obstacle.pos}`;
+
           if (CollisionDomain.isDangerous(obstacle.t) && col.nearMiss && !passedObs.current.has(obsId)) {
             passedObs.current.add(obsId);
-            Audio.play('nearMiss');
-            setNearMissCount(current => current + 1);
-            setScore(current => current + Config.score.nearMiss);
-            setNearMissEffects(current => [
-              ...current,
-              EntityFactory.createNearMissEffect(ox, prev.ramp * RAMP_H - camY + 25),
-            ]);
-            addScorePopup(ox, prev.ramp * RAMP_H - camY - 20, `NEAR MISS +${Config.score.nearMiss}`, '#44ffaa');
-            clockRef.current = triggerSlowMo(
-              clockRef.current,
-              scaleFrames(Config.juice.slowMo.nearMissFrames, motionScaleRef.current),
-              Config.juice.slowMo.nearMissFactor,
-            );
+            audioEventsFromCollision.push(() => Audio.play('nearMiss'));
+            nearMissDeltaCount += 1;
+            nearMissScoreDelta += Config.score.nearMiss;
+            nearMissFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25 });
+            popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY - 20, text: `NEAR MISS +${Config.score.nearMiss}`, color: '#44ffaa' });
+            slowMoFrames = Math.max(slowMoFrames, scaleFrames(Config.juice.slowMo.nearMissFrames, motionScaleRef.current));
+            slowMoFactor = Config.juice.slowMo.nearMissFactor;
           }
+
           const handler = handlers[obstacle.t];
           if (handler) {
-            const result = handler(col, obstacle, ox, prev.x);
-            if (result === true) return prev;
-            if (result === 'slow') return { ...prev, vx: -prev.vx * Config.combat.bounceMultiplier };
+            const result = handler(col, obstacle, ox, afterTransitionPlayer.x);
+            if (result === true) {
+              collisionDied = true;
+              break;
+            }
+            if (result === 'slow') {
+              collisionSlowed = true;
+              break;
+            }
           }
         }
-        return prev;
-      });
-      setCamY(current => MathUtils.lerp(current, player.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate));
+      }
+
+      // 衝突結果をプレイヤーに適用
+      if (collisionSlowed) {
+        finalPlayer = { ...afterTransitionPlayer, vx: -afterTransitionPlayer.vx * Config.combat.bounceMultiplier };
+      } else if (newVxFromBounce !== undefined) {
+        finalPlayer = { ...afterTransitionPlayer, vx: newVxFromBounce };
+      }
+
+      // ── 副作用の適用（updater 外） ──
+
+      // ジャンプ音
+      if (didJump) {
+        Audio.play('jump');
+      }
+
+      // ランプ遷移の副作用
+      if (didRampChange && transition.player.ramp > currentLastRamp) {
+        lastRampRef.current = newLastRamp;
+        setLastRamp(newLastRamp);
+        comboRef.current = newCombo;
+        setCombo(newCombo);
+        comboTimerRef.current = newComboTimer2;
+        setComboTimer(newComboTimer2);
+        setScore(prev => prev + scoreDeltaFromRamp);
+        setSpeedBonus(prev => prev + newSpeedBonusDelta);
+        setTransitionEffect(1);
+        if (shouldPlayCombo) {
+          Audio.playCombo(comboCountForAudio);
+          addScorePopup(W / 2, 120, comboPopupText, '#ffaa00');
+        }
+        Audio.play('rampChange');
+      }
+
+      // 着地の副作用
+      if (justLanded) {
+        Audio.play('land');
+        if (motionScaleRef.current > 0) {
+          // 着地点の画面 Y 座標を計算して土煙を生成。
+          // camY は jetParticles/トレイルと同様に前フレーム相当だが、土煙は短命バーストのため許容範囲。
+          const dustGeo = GeometryDomain.getRampGeometry(afterTransitionRamp, W, RAMP_H);
+          const dustSlopeY = GeometryDomain.getSlopeY(afterTransitionPlayer.x, dustGeo, afterTransitionRamp.type);
+          const dustScreenY = afterTransitionPlayer.ramp * RAMP_H - currentCamY + dustSlopeY;
+          setParticles(prevParticles => [
+            ...prevParticles,
+            ...createDust(afterTransitionPlayer.x, dustScreenY, DUST_PARTICLE_COUNT),
+          ]);
+        }
+      }
+
+      // 衝突の副作用（死亡はこの中で handleDeath を呼ぶ）
+      if (!collisionDied) {
+        // 死亡していない場合のみスコア・エフェクト・パーティクルを適用
+        if (scoreDeltaFromCollision !== 0) {
+          setScore(prev => prev + scoreDeltaFromCollision);
+        }
+        if (nearMissScoreDelta !== 0) {
+          setScore(prev => prev + nearMissScoreDelta);
+          setNearMissCount(prev => prev + nearMissDeltaCount);
+          for (const nm of nearMissFromCollision) {
+            setNearMissEffects(prev => [...prev, EntityFactory.createNearMissEffect(nm.x, nm.y)]);
+          }
+        }
+        if (speedDeltaFromCollision !== 0) {
+          const newSpd = Math.max(MIN_SPD, nextSpeed + speedDeltaFromCollision);
+          speedRef.current = newSpd;
+          setSpeed(newSpd);
+        }
+        for (const p of particlesFromCollision) {
+          addParticles(p.x, p.y, p.color, p.count);
+        }
+        for (const popup of popupsFromCollision) {
+          addScorePopup(popup.x, popup.y, popup.text, popup.color);
+        }
+        if (newEffectFromCollision) {
+          effectRef.current = newEffectFromCollision;
+          setEffect(newEffectFromCollision);
+        }
+        if (hitstopFrames > 0) {
+          clockRef.current = triggerHitstop(clockRef.current, hitstopFrames);
+        }
+        if (slowMoFrames > 0) {
+          clockRef.current = triggerSlowMo(clockRef.current, slowMoFrames, slowMoFactor);
+        }
+
+        // 確定プレイヤーを ref + state に反映
+        playerRef.current = finalPlayer;
+        setPlayer(finalPlayer);
+      } else {
+        // 死亡: 副作用（handleDeath 呼び出しなど）を実行
+        for (const fn of audioEventsFromCollision) {
+          fn();
+        }
+      }
+
+      // --- カメラ更新 ---
+      // プレイヤーの確定位置を使って camY を lerp する
+      const targetPlayer = collisionDied ? currentPlayer : finalPlayer;
+      const nextCamY = MathUtils.lerp(currentCamY, targetPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate);
+      camYRef.current = nextCamY;
+      setCamY(nextCamY);
     }, 1000 / 60);
     return () => window.clearInterval(loop);
-  }, [state, W, H, MIN_SPD, RAMP_H, addParticles, addScorePopup,
-      speed, player, ramps, camY, effect, combo, comboTimer,
-      lastRamp, godMode, handleDeath, handleClear]);
+  }, [state, W, H, MIN_SPD, RAMP_H, addParticles, addScorePopup, handleDeath, handleClear]);
 
   // クリーンアップ
   useEffect(() => () => Audio.cleanup(), []);

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -644,7 +644,8 @@ export const useGameEngine = (
 
         if (transition.player.ramp > currentLastRamp) {
           newLastRamp = transition.player.ramp;
-          const scoreResult = ScoringDomain.calcRampScore(nextSpeed, nextComboTimer > 0 ? currentCombo : 0);
+          // 修正2: コンボ有効判定は tick 適用前の comboTimer 値を参照する（旧挙動と一致）
+          const scoreResult = ScoringDomain.calcRampScore(nextSpeed, currentComboTimer > 0 ? currentCombo : 0);
 
           if (ComboDomain.shouldActivate(nextSpeed)) {
             const comboResult = ComboDomain.increment(currentCombo, nextComboTimer);
@@ -696,6 +697,9 @@ export const useGameEngine = (
       let slowMoFrames = 0;
       let slowMoFactor = 1;
 
+      // ニアミス専用ポップアップ（死亡時にも適用するため popupsFromCollision とは別管理）
+      const nearMissPopupsFromCollision: Array<{ x: number; y: number; text: string; color: string }> = [];
+
       const collisionRamp = currentRamps[afterTransitionPlayer.ramp];
       if (collisionRamp) {
         // 衝突ハンドラのコールバックは副作用を収集するだけ（即時適用しない）
@@ -744,11 +748,13 @@ export const useGameEngine = (
 
           if (CollisionDomain.isDangerous(obstacle.t) && col.nearMiss && !passedObs.current.has(obsId)) {
             passedObs.current.add(obsId);
-            audioEventsFromCollision.push(() => Audio.play('nearMiss'));
+            // ニアミス音は死亡に関わらず即時適用（旧挙動と一致）
+            Audio.play('nearMiss');
             nearMissDeltaCount += 1;
             nearMissScoreDelta += Config.score.nearMiss;
             nearMissFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25 });
-            popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY - 20, text: `NEAR MISS +${Config.score.nearMiss}`, color: '#44ffaa' });
+            // ニアミスポップアップは死亡時にも適用するため専用配列へ
+            nearMissPopupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY - 20, text: `NEAR MISS +${Config.score.nearMiss}`, color: '#44ffaa' });
             slowMoFrames = Math.max(slowMoFrames, scaleFrames(Config.juice.slowMo.nearMissFrames, motionScaleRef.current));
             slowMoFactor = Config.juice.slowMo.nearMissFactor;
           }
@@ -816,18 +822,29 @@ export const useGameEngine = (
         }
       }
 
+      // 修正1: ニアミス副作用（スコア・カウント・エフェクト・ポップアップ・スローモー）は
+      // 死亡フラグに関わらず適用する（旧挙動と一致）。
+      // 衝突ループは死亡時に break するため、死亡した障害物より後のニアミスは
+      // 収集されない（= 旧挙動の「障害物を順に処理し、死亡で即ループ終了」と等価）
+      if (nearMissScoreDelta !== 0) {
+        setScore(prev => prev + nearMissScoreDelta);
+        setNearMissCount(prev => prev + nearMissDeltaCount);
+        for (const nm of nearMissFromCollision) {
+          setNearMissEffects(prev => [...prev, EntityFactory.createNearMissEffect(nm.x, nm.y)]);
+        }
+        for (const popup of nearMissPopupsFromCollision) {
+          addScorePopup(popup.x, popup.y, popup.text, popup.color);
+        }
+      }
+      if (slowMoFrames > 0) {
+        clockRef.current = triggerSlowMo(clockRef.current, slowMoFrames, slowMoFactor);
+      }
+
       // 衝突の副作用（死亡はこの中で handleDeath を呼ぶ）
       if (!collisionDied) {
         // 死亡していない場合のみスコア・エフェクト・パーティクルを適用
         if (scoreDeltaFromCollision !== 0) {
           setScore(prev => prev + scoreDeltaFromCollision);
-        }
-        if (nearMissScoreDelta !== 0) {
-          setScore(prev => prev + nearMissScoreDelta);
-          setNearMissCount(prev => prev + nearMissDeltaCount);
-          for (const nm of nearMissFromCollision) {
-            setNearMissEffects(prev => [...prev, EntityFactory.createNearMissEffect(nm.x, nm.y)]);
-          }
         }
         if (speedDeltaFromCollision !== 0) {
           const newSpd = Math.max(MIN_SPD, nextSpeed + speedDeltaFromCollision);
@@ -847,9 +864,6 @@ export const useGameEngine = (
         if (hitstopFrames > 0) {
           clockRef.current = triggerHitstop(clockRef.current, hitstopFrames);
         }
-        if (slowMoFrames > 0) {
-          clockRef.current = triggerSlowMo(clockRef.current, slowMoFrames, slowMoFactor);
-        }
 
         // 確定プレイヤーを ref + state に反映
         playerRef.current = finalPlayer;
@@ -862,9 +876,10 @@ export const useGameEngine = (
       }
 
       // --- カメラ更新 ---
-      // プレイヤーの確定位置を使って camY を lerp する
-      const targetPlayer = collisionDied ? currentPlayer : finalPlayer;
-      const nextCamY = MathUtils.lerp(currentCamY, targetPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate);
+      // 修正3: カメラ目標は常に前フレームのプレイヤー ramp を使う（旧挙動と一致）
+      // 旧コードでは setCamY の updater 内で stale closure の player（前フレーム）を参照していた。
+      // 生存時・死亡時ともに currentPlayer（tick 開始時 = 前フレーム確定位置）を使用する。
+      const nextCamY = MathUtils.lerp(currentCamY, currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate);
       camYRef.current = nextCamY;
       setCamY(nextCamY);
     }, 1000 / 60);

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -7,29 +7,25 @@
  * B2-S1: setState updater 内の副作用をループ外へ分離。
  * 動的値（player/speed/ramps/camY/effect/combo/comboTimer/lastRamp/godMode）を
  * ref に昇格させ、ゲームループの依存配列を [state] のみに縮小した。
+ *
+ * B2-S2: ゲームループ本体を processFrame 純粋関数に抽出。
+ * フックはその結果を各 state/ref に展開するのみ。
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Audio } from '../../audio';
 import { Config } from '../../config';
-import { EffectType, GameState, ObstacleType, SpeedRank } from '../../constants';
-import { CollisionDomain } from '../../domains/collision-domain';
-import { ComboDomain } from '../../domains/combo-domain';
-import { DangerDomain } from '../../domains/danger-domain';
-import { GeometryDomain } from '../../domains/geometry-domain';
-import { ScoringDomain } from '../../domains/scoring-domain';
+import { GameState, SpeedRank } from '../../constants';
 import { SpeedDomain } from '../../domains/speed-domain';
-import { MathUtils } from '../../domains/math-utils';
+import { ScoringDomain } from '../../domains/scoring-domain';
 import { EntityFactory } from '../../entities';
 import { BackgroundGen, RampGen } from '../../generators';
 import { useCheatCode } from '../../hooks';
 import { ParticleSys } from '../../particles';
-import { Physics } from '../../physics';
 import type {
   ClearAnim,
   DeathState,
   EffectState,
   GameStateValue,
-  InputState,
   NearMissEffect,
   Particle,
   Player,
@@ -39,76 +35,16 @@ import type {
 } from '../../types';
 import type { GameWorld, UIState } from '../../application/game-loop/game-state';
 import { advanceClock, createGameClock, triggerHitstop, triggerSlowMo } from '../../application/game-loop/game-clock';
+import { processFrame } from '../../application/game-loop/frame-processor';
+import type { FrameContext } from '../../application/game-loop/frame-processor';
 import { resolveMotionScale, scaleFrames } from '../../application/game-loop/motion-scale';
 import { useReducedMotion } from './use-reduced-motion';
 import { useIsMobile } from './use-mobile';
 import { getHighScore, saveScore } from '../../../../utils/score-storage';
-import {
-  spawnSpeedLines,
-  updateSpeedLines,
-} from '../../domain/services/speed-line-service';
 import type { SpeedLine } from '../../domain/services/speed-line-service';
-import { sampleTrail } from '../../domain/services/trail-service';
 import type { TrailSample } from '../../domain/services/trail-service';
-import { createDust } from '../../domain/services/dust-service';
 
 const SCORE_KEY = 'non_brake_descent';
-
-/** 残像トレイルの最大サンプル保持数 */
-const MAX_TRAIL_SAMPLES = 10;
-
-/** 着地時の土煙パーティクル数（通常着地） */
-const DUST_PARTICLE_COUNT = 6;
-
-type CollisionHandlerResult = boolean | 'slow';
-
-type CollisionCallbacks = {
-  onDie: (type: DeathState['type']) => void;
-  onScore: (ox: number) => void;
-  onEffect: (type: EffectState['type']) => void;
-  onEnemyKill: (ox: number) => void;
-  onBounce: (vx: number) => void;
-};
-
-/** 衝突ハンドラを生成する */
-const createCollisionHandlers = (
-  rank: typeof SpeedRank[keyof typeof SpeedRank],
-  cb: CollisionCallbacks,
-  godMode: boolean
-): Partial<
-  Record<
-    (typeof ObstacleType)[keyof typeof ObstacleType],
-    (col: ReturnType<typeof CollisionDomain.check>, obs: Ramp['obs'][number], ox: number, px: number) => CollisionHandlerResult
-  >
-> => {
-  const { onDie, onScore, onEffect, onEnemyKill, onBounce } = cb;
-  const die = godMode ? (() => {}) : onDie;
-  const bounce = godMode ? (() => {}) : onBounce;
-  const handleEnemy = (col: ReturnType<typeof CollisionDomain.check>, obs: Ramp['obs'][number], ox: number, px: number) => {
-    if (!col.hit) return false;
-    if (rank === SpeedRank.HIGH) {
-      die('enemy');
-      return true;
-    }
-    if (rank === SpeedRank.MID) {
-      obs.t = ObstacleType.DEAD;
-      onEnemyKill(ox);
-      return 'slow';
-    }
-    bounce(px < ox ? -Config.combat.bounceSpeed : Config.combat.bounceSpeed);
-    return false;
-  };
-  return {
-    [ObstacleType.HOLE_S]: col => (col.ground && rank === SpeedRank.LOW ? (die('fall'), true) : false),
-    [ObstacleType.HOLE_L]: col => (col.ground ? (die('fall'), true) : false),
-    [ObstacleType.ROCK]: col => (col.hit ? (die('rock'), true) : false),
-    [ObstacleType.ENEMY]: handleEnemy,
-    [ObstacleType.ENEMY_V]: handleEnemy,
-    [ObstacleType.SCORE]: (col, obs, ox) => (col.hit ? ((obs.t = ObstacleType.TAKEN), onScore(ox), false) : false),
-    [ObstacleType.REVERSE]: (col, obs) => (col.hit ? ((obs.t = ObstacleType.TAKEN), onEffect('reverse'), false) : false),
-    [ObstacleType.FORCE_JUMP]: (col, obs) => (col.hit ? ((obs.t = ObstacleType.TAKEN), onEffect('forceJ'), false) : false),
-  };
-};
 
 /** ゲームエンジンフックの戻り値 */
 export interface UseGameEngineResult {
@@ -215,7 +151,7 @@ export const useGameEngine = (
     motionScaleRef.current = resolveMotionScale(reducedMotion);
   }, [reducedMotion]);
 
-  // --- B2-S1: stale closure 回避のための ref 群 ---
+  // --- B2-S1/S2: stale closure 回避のための ref 群 ---
   // ゲームループ useEffect の依存配列から動的 state を除外するため、
   // 各 setter 呼び出し時に同期更新する。
   const playerRef = useRef<Player>(EntityFactory.createPlayer());
@@ -227,6 +163,10 @@ export const useGameEngine = (
   const comboTimerRef = useRef<number>(0);
   const lastRampRef = useRef<number>(0);
   const godModeRef = useRef<boolean>(false);
+  /** 速度線の ref（processFrame に渡すための最新値を保持） */
+  const speedLinesRef = useRef<SpeedLine[]>([]);
+  /** プレイヤー残像トレイルの ref（processFrame に渡すための最新値を保持） */
+  const playerTrailRef = useRef<TrailSample[]>([]);
 
   const isMobile = useIsMobile();
   const handleCheat = useCheatCode('jinjinjin', () => {
@@ -243,10 +183,6 @@ export const useGameEngine = (
 
   const addParticles = useCallback((x: number, y: number, color: string, count: number) => {
     setParticles(prev => [...prev, ...EntityFactory.createParticles(x, y, color, count)]);
-  }, []);
-
-  const addScorePopup = useCallback((x: number, y: number, text: string, color: string) => {
-    setScorePopups(prev => [...prev, EntityFactory.createScorePopup(x, y, text, color)]);
   }, []);
 
   const resetGameState = useCallback(() => {
@@ -279,7 +215,9 @@ export const useGameEngine = (
     setComboTimer(0);
     setTransitionEffect(0);
     setDangerLevel(0);
+    speedLinesRef.current = [];
     setSpeedLines([]);
+    playerTrailRef.current = [];
     setPlayerTrail([]);
     setClouds(BackgroundGen.initClouds());
     passedObs.current = new Set();
@@ -489,7 +427,8 @@ export const useGameEngine = (
   }, [state]);
 
   // ゲームループ
-  // B2-S1: 依存配列を [state] のみに縮小。動的値はすべて ref 経由で読む。
+  // B2-S2: ループ本体を processFrame 純粋関数呼び出しに置換。
+  // 依存配列は [state] のみ（動的値はすべて ref 経由）。
   useEffect(() => {
     if (state !== GameState.PLAY) return;
     const loop = window.setInterval(() => {
@@ -506,385 +445,244 @@ export const useGameEngine = (
 
       // ref から現フレームの動的値を読み取る（stale closure 回避）
       const currentEffect = effectRef.current;
-      const currentSpeed = speedRef.current;
       const currentPlayer = playerRef.current;
       const currentRamps = ramsRef.current;
       const currentCamY = camYRef.current;
-      const currentCombo = comboRef.current;
-      const currentComboTimer = comboTimerRef.current;
-      const currentLastRamp = lastRampRef.current;
-      const currentGodMode = godModeRef.current;
 
-      const reverse = currentEffect.type === EffectType.REVERSE;
-      const input: InputState = {
+      // reverse エフェクト中は左右を入れ替える
+      const reverse = currentEffect.type === 'reverse';
+      const input = {
         left: reverse ? keyState.ArrowRight || touchState.right : keyState.ArrowLeft || touchState.left,
         right: reverse ? keyState.ArrowLeft || touchState.left : keyState.ArrowRight || touchState.right,
         accel: keyState.KeyZ || touchState.accel,
         jump: keyState.KeyX || touchState.jump,
       };
 
-      // --- エフェクトタイマー更新 ---
-      const nextEffect: EffectState = currentEffect.timer <= 0
-        ? { type: undefined, timer: 0 }
-        : { ...currentEffect, timer: currentEffect.timer - 1 };
-      effectRef.current = nextEffect;
-      setEffect(nextEffect);
+      // --- processFrame 用の world/ui を現在の各 state から組み立てる ---
+      const currentWorld: GameWorld = {
+        player: currentPlayer,
+        ramps: currentRamps,
+        speed: speedRef.current,
+        camY: currentCamY,
+        score: 0, // processFrame 内でスコア差分を計算するため、フック側の score state を直接使いたい
+        // → ただし純粋関数への score 渡しが必要なため、score は state の値をそのまま使う
+        // ここでは scoreRef が無いため、下記で別途扱う
+        speedBonus: 0,
+        combo: { count: comboRef.current, timer: comboTimerRef.current },
+        effect: currentEffect,
+        lastRamp: lastRampRef.current,
+        nearMissCount: 0,
+        dangerLevel: 0,
+      };
 
-      // --- 速度更新 ---
-      const nextSpeed = SpeedDomain.accelerate(currentSpeed, input.accel);
-      speedRef.current = nextSpeed;
-      setSpeed(nextSpeed);
+      // NOTE: score/speedBonus/nearMissCount/dangerLevel は useState で管理されており
+      // processFrame に渡すためには現在の最新値が必要。
+      // B2-S2 では世界状態をまだ ref に統合していないため（S3 の課題）、
+      // processFrame の world.score は差分加算の起点として使う。
+      // フックではその差分を processFrame の結果から取り出して setScore に適用する形になる。
+      // → 実際の score/speedBonus/nearMissCount は scoreRef が無いため、
+      //    processFrame は world.score=0 を受け取り「このフレームの差分」として返す設計とする。
+      // → この問題は processFrame 内でも score/speedBonus を初期値ゼロから加算する設計で対応可能だが
+      //    dangerLevel/nearMissCount については「現在値」が必要。
+      //
+      // 以上の理由から、B2-S2 ではスコア・パーティクル等の「差分」は processFrame の結果に入れ、
+      // フック側で useState の setXxx を通じて適用する（S3 以降で useReducer に一元化する）。
 
-      // --- パーティクル系更新（副作用なし・純粋変換） ---
+      // --- processFrame 用のコンテキストを組み立てる ---
+      const ctx: FrameContext = {
+        screenWidth: W,
+        screenHeight: H,
+        rampHeight: RAMP_H,
+        minSpeed: MIN_SPD,
+        isGodMode: godModeRef.current,
+        motionScale: motionScaleRef.current,
+        frameIndex: frameRef.current,
+        wasOnGround: prevOnGroundRef.current,
+        prevRank: prevRankRef.current,
+        lastRamp: lastRampRef.current,
+        passedObstacles: passedObs.current,
+      };
+
+      // processFrame には score/speedBonus/nearMissCount/dangerLevel を
+      // 現在の state 値として渡せないため（useState の値が stale になるリスク）、
+      // これらは processFrame から「差分」として返してもらい、フック側で適用する。
+      // 暫定的に world に 0 を渡し、結果の world から差分を計算して適用する。
+      // (S3 以降では useReducer で world 全体を ref で持つことでこの問題を解消する)
+      const inputWorld: GameWorld = {
+        ...currentWorld,
+        // score/speedBonus/nearMissCount/dangerLevel は「差分起点=0」として渡す
+        score: 0,
+        speedBonus: 0,
+        nearMissCount: 0,
+        dangerLevel: 0,
+      };
+
+      // 速度線・トレイル等の UI state も ref がないため現在の state を直接参照できないが、
+      // 各フレームで完全に再計算するため問題なし（updateSpeedLines, sampleTrail 等は前の状態から計算する）。
+      // B2-S2 暫定: UI の速度線・トレイルは processFrame に委任する。
+      // 既存の particles/scorePopups/nearMissEffects/clouds は processFrame が更新する。
+      // フック側の state は使わず、processFrame 結果を直接 setXxx で適用する。
+      const inputUI: UIState = {
+        particles: [], // processFrame は nextParticles（既存更新済み）を使うため、空からスタートではなく
+        // 現在の particles state が必要。しかし stale closure 問題がある。
+        // B2-S2 の暫定措置: processFrame は空配列を受け取り、
+        // dust/ニアミスエフェクト等の「新規生成」分のみ返す。
+        // 既存の更新（updateAndFilter）はフック側で継続する。
+        jetParticles: [],
+        scorePopups: [],
+        nearMissEffects: [],
+        clouds: [],
+        shake: 0,
+        transitionEffect: 0,
+        speedLines: speedLinesRef.current,
+        playerTrail: playerTrailRef.current,
+      };
+
+      // B2-S2 実装上の限界:
+      // particles/scorePopups/nearMissEffects/clouds は useState で管理されており
+      // processFrame に「現在の最新値」を渡せない（stale closure 問題）。
+      // S3/S4 で useReducer に移行するまでの暫定として、
+      // processFrame は「新規生成・追記分のみ」を返し、
+      // 既存のパーティクル更新はフック側の setXxx(prev => ...) で継続する。
+
+      // --- パーティクル系の既存更新（純粋変換・processFrame 外で継続） ---
       setParticles(current => ParticleSys.updateAndFilter(current, ParticleSys.updateParticle));
       setScorePopups(current => ParticleSys.updateAndFilter(current, ParticleSys.updatePopup));
       setNearMissEffects(current => ParticleSys.updateAndFilter(current, ParticleSys.updateNearMiss));
+      setClouds(current => ParticleSys.updateClouds(current, speedRef.current));
 
-      // --- コンボタイマー更新 ---
-      const nextComboTimer = ComboDomain.tick(currentComboTimer);
-      comboTimerRef.current = nextComboTimer;
-      setComboTimer(nextComboTimer);
+      // --- processFrame を呼び出す ---
+      const result = processFrame(inputWorld, inputUI, input, ctx);
 
-      setTransitionEffect(current => Math.max(0, current - 0.1));
-      setClouds(current => ParticleSys.updateClouds(current, nextSpeed));
+      // --- 前フレーム ref の更新 ---
+      prevOnGroundRef.current = result.world.player.onGround;
+      prevRankRef.current = result.newRank;
 
-      // --- ジェットパーティクル更新 ---
-      setJetParticles(prev => {
-        let updated = ParticleSys.updateAndFilter(prev, ParticleSys.updateParticle);
-        if (nextSpeed > Config.particle.jetSpeedThreshold && frameRef.current % 2 === 0) {
-          const ramp = currentRamps[currentPlayer.ramp];
-          if (ramp) {
-            const geo = GeometryDomain.getRampGeometry(ramp, W, RAMP_H);
-            const slopeY = GeometryDomain.getSlopeY(currentPlayer.x, geo, ramp.type);
-            updated = [...updated, EntityFactory.createJetParticle(currentPlayer.x, currentPlayer.ramp * RAMP_H - currentCamY + slopeY, ramp.dir)];
-          }
-        }
-        return updated;
-      });
-
-      // --- 速度線の更新・生成（HIGH ランク時のみ生成） ---
-      const currentRank = SpeedDomain.getRank(nextSpeed);
-      setSpeedLines(prev => {
-        const updated = updateSpeedLines(prev);
-        return motionScaleRef.current > 0
-          ? spawnSpeedLines(updated, currentRank, W, H)
-          : updated;
-      });
-
-      // --- プレイヤー残像トレイルの更新（高速時かつ reduced-motion 無効時のみサンプル追加） ---
-      // 注: jetParticles と同様、当該 tick の setPlayer 更新前のプレイヤー位置（前フレーム相当）でサンプリングする。残像演出としては許容範囲。
-      const trailRamp = currentRamps[currentPlayer.ramp];
-      if (trailRamp) {
-        const trailGeo = GeometryDomain.getRampGeometry(trailRamp, W, RAMP_H);
-        const trailSlopeY = GeometryDomain.getSlopeY(currentPlayer.x, trailGeo, trailRamp.type);
-        const trailY = currentPlayer.ramp * RAMP_H - currentCamY + trailSlopeY;
-        const isHighSpeed = nextSpeed > Config.particle.jetSpeedThreshold;
-        const enableTrail = motionScaleRef.current > 0 && isHighSpeed;
-        setPlayerTrail(prev =>
-          sampleTrail(prev, currentPlayer.x, trailY, enableTrail ? MAX_TRAIL_SAMPLES : 0)
-        );
+      // --- 新規 passedObstacles を追加 ---
+      for (const obsId of result.newPassedObstacles) {
+        passedObs.current.add(obsId);
       }
 
-      // --- 速度ランク変化の検出（BGM プロファイル切替） ---
-      if (currentRank !== prevRankRef.current) {
-        prevRankRef.current = currentRank;
-        Audio.setSpeedRank(currentRank);
-      }
-
-      const currentRampForDanger = currentRamps[currentPlayer.ramp];
-      if (currentRampForDanger) {
-        setDangerLevel(DangerDomain.calcLevel(currentRampForDanger.obs, currentPlayer.x, currentRampForDanger.dir, nextSpeed, W));
-      }
-
-      // --- プレイヤー移動・遷移・衝突計算（副作用をすべて updater 外へ） ---
-      // B2-S1: 2つの setPlayer(prev=>{...}) updater を1パスに統合し、
-      //        副作用（Audio/setState/clockRef 操作）を updater の外で適用する。
-
-      // ── フェーズ1: 移動・ジャンプ・ランプ遷移 ──
-      const rampForMove = currentRamps[currentPlayer.ramp];
-      if (!rampForMove) {
-        // ramp が取れない場合はカメラのみ更新して終了
-        const nextCamY = MathUtils.lerp(currentCamY, currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate);
-        camYRef.current = nextCamY;
-        setCamY(nextCamY);
-        return;
-      }
-
-      let movedPlayer = Physics.applyMovement(currentPlayer, input, nextSpeed, rampForMove.dir);
-      const jumpResult = Physics.applyJump(movedPlayer, input, nextEffect.type, nextEffect.timer);
-      movedPlayer = jumpResult.player;
-      const didJump = jumpResult.didJump;
-
-      // ゴール／ランプ遷移を解決し、確定プレイヤーを求める
-      const transition = Physics.checkTransition(movedPlayer, currentRamps, W);
-
-      // ゴール時は handleClear を呼んで終了（updater 外で副作用）
-      if (transition.isGoal) {
-        handleClear();
-        return;
-      }
-
-      // 遷移後の副作用を収集するためのローカル変数
-      let afterTransitionPlayer = movedPlayer;
-      let afterTransitionRamp = rampForMove;
-      let didRampChange = false;
-      let newLastRamp = currentLastRamp;
-      let scoreDeltaFromRamp = 0;
-      let newCombo = currentCombo;
-      let newComboTimer2 = nextComboTimer;
-      let shouldPlayCombo = false;
-      let comboCountForAudio = 0;
-      let newSpeedBonusDelta = 0;
-      let comboPopupText = '';
-
-      if (transition.transitioned) {
-        afterTransitionPlayer = transition.player;
-        afterTransitionRamp = currentRamps[transition.player.ramp] ?? rampForMove;
-        didRampChange = true;
-
-        if (transition.player.ramp > currentLastRamp) {
-          newLastRamp = transition.player.ramp;
-          // 修正2: コンボ有効判定は tick 適用前の comboTimer 値を参照する（旧挙動と一致）
-          const scoreResult = ScoringDomain.calcRampScore(nextSpeed, currentComboTimer > 0 ? currentCombo : 0);
-
-          if (ComboDomain.shouldActivate(nextSpeed)) {
-            const comboResult = ComboDomain.increment(currentCombo, nextComboTimer);
-            newCombo = comboResult.combo;
-            newComboTimer2 = comboResult.timer;
-            if (comboResult.combo > 1) {
-              const comboScore = ScoringDomain.calcRampScore(nextSpeed, comboResult.combo);
-              scoreDeltaFromRamp = comboScore.base + comboScore.bonus;
-              shouldPlayCombo = true;
-              comboCountForAudio = comboResult.combo;
-              comboPopupText = `+${comboScore.base + comboScore.bonus} (${comboResult.combo}x)`;
+      // --- events を処理 ---
+      for (const event of result.events) {
+        switch (event.type) {
+          case 'AUDIO':
+            // コンボ音は 'combo:N' 形式
+            if (event.sound.startsWith('combo:')) {
+              const comboCount = parseInt(event.sound.slice(6), 10);
+              Audio.playCombo(comboCount);
             } else {
-              // combo=1 はポップアップなし（ベーススコアのみ加算）
-              scoreDeltaFromRamp = scoreResult.base;
+              Audio.play(event.sound);
             }
-          } else {
-            const reset = ComboDomain.reset();
-            newCombo = reset.combo;
-            newComboTimer2 = reset.timer;
-            scoreDeltaFromRamp = scoreResult.base;
-          }
-          newSpeedBonusDelta = SpeedDomain.getBonus(nextSpeed);
+            break;
+          case 'SPEED_RANK_CHANGED':
+            Audio.setSpeedRank(event.rank);
+            break;
+          case 'GOAL_REACHED':
+            handleClear();
+            break;
+          case 'PLAYER_DIED':
+            handleDeath(event.deathType);
+            break;
+          default:
+            break;
         }
       }
 
-      // 着地検出: 前フレームが空中で確定プレイヤーが接地に変化したとき
-      const wasOnGround = prevOnGroundRef.current;
-      const justLanded = !wasOnGround && afterTransitionPlayer.onGround;
-      prevOnGroundRef.current = afterTransitionPlayer.onGround;
-
-      // ── フェーズ2: 衝突処理 ──
-      // 遷移後のプレイヤー・ランプで衝突判定を行う（移動→遷移→衝突の順序を保持）
-      let finalPlayer = afterTransitionPlayer;
-      let collisionDied = false;
-      let collisionSlowed = false;
-      let newVxFromBounce: number | undefined;
-
-      // 衝突処理中に発生した副作用を収集するローカル変数
-      const audioEventsFromCollision: Array<() => void> = [];
-      let scoreDeltaFromCollision = 0;
-      let speedDeltaFromCollision = 0;
-      const particlesFromCollision: Array<{ x: number; y: number; color: string; count: number }> = [];
-      const popupsFromCollision: Array<{ x: number; y: number; text: string; color: string }> = [];
-      const nearMissFromCollision: Array<{ x: number; y: number }> = [];
-      let nearMissDeltaCount = 0;
-      let nearMissScoreDelta = 0;
-      let newEffectFromCollision: EffectState | undefined;
-      let hitstopFrames = 0;
-      let slowMoFrames = 0;
-      let slowMoFactor = 1;
-
-      // ニアミス専用ポップアップ（死亡時にも適用するため popupsFromCollision とは別管理）
-      const nearMissPopupsFromCollision: Array<{ x: number; y: number; text: string; color: string }> = [];
-
-      const collisionRamp = currentRamps[afterTransitionPlayer.ramp];
-      if (collisionRamp) {
-        // 衝突ハンドラのコールバックは副作用を収集するだけ（即時適用しない）
-        const handlers = createCollisionHandlers(
-          SpeedDomain.getRank(nextSpeed),
-          {
-            onDie: (type) => {
-              collisionDied = true;
-              // handleDeath は updater 外で呼ぶ（後述）
-              // type を記録するためにクロージャに保存
-              audioEventsFromCollision.push(() => handleDeath(type));
-            },
-            onScore: (ox) => {
-              audioEventsFromCollision.push(() => Audio.play('score'));
-              scoreDeltaFromCollision += Config.score.item;
-              particlesFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25, color: '#ffdd00', count: 6 });
-              popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY, text: `+${Config.score.item}`, color: '#ffdd00' });
-              hitstopFrames = Math.max(hitstopFrames, scaleFrames(Config.juice.hitstop.item, motionScaleRef.current));
-            },
-            onEffect: (type) => {
-              if (!type) return;
-              audioEventsFromCollision.push(() => Audio.play('hit'));
-              newEffectFromCollision = { type, timer: Config.effect.duration };
-            },
-            onEnemyKill: (ox) => {
-              audioEventsFromCollision.push(() => Audio.play('enemyKill'));
-              scoreDeltaFromCollision += Config.score.enemy;
-              speedDeltaFromCollision -= Config.combat.enemyKillSlowdown;
-              particlesFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25, color: '#ff8800', count: 10 });
-              popupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY, text: `+${Config.score.enemy}`, color: '#ff8800' });
-              hitstopFrames = Math.max(hitstopFrames, scaleFrames(Config.juice.hitstop.enemyKill, motionScaleRef.current));
-            },
-            onBounce: (vx) => {
-              audioEventsFromCollision.push(() => Audio.play('hit'));
-              newVxFromBounce = vx;
-            },
-          },
-          currentGodMode
-        );
-
-        for (const obstacle of collisionRamp.obs) {
-          if (!CollisionDomain.isActive(obstacle)) continue;
-          const ox = GeometryDomain.getObstacleX(obstacle, collisionRamp, W);
-          const col = CollisionDomain.check(afterTransitionPlayer.x, ox, afterTransitionPlayer.jumping, afterTransitionPlayer.y);
-          const obsId = `${afterTransitionPlayer.ramp}-${obstacle.pos}`;
-
-          if (CollisionDomain.isDangerous(obstacle.t) && col.nearMiss && !passedObs.current.has(obsId)) {
-            passedObs.current.add(obsId);
-            // ニアミス音は死亡に関わらず即時適用（旧挙動と一致）
-            Audio.play('nearMiss');
-            nearMissDeltaCount += 1;
-            nearMissScoreDelta += Config.score.nearMiss;
-            nearMissFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY + 25 });
-            // ニアミスポップアップは死亡時にも適用するため専用配列へ
-            nearMissPopupsFromCollision.push({ x: ox, y: afterTransitionPlayer.ramp * RAMP_H - currentCamY - 20, text: `NEAR MISS +${Config.score.nearMiss}`, color: '#44ffaa' });
-            slowMoFrames = Math.max(slowMoFrames, scaleFrames(Config.juice.slowMo.nearMissFrames, motionScaleRef.current));
-            slowMoFactor = Config.juice.slowMo.nearMissFactor;
-          }
-
-          const handler = handlers[obstacle.t];
-          if (handler) {
-            const result = handler(col, obstacle, ox, afterTransitionPlayer.x);
-            if (result === true) {
-              collisionDied = true;
-              break;
-            }
-            if (result === 'slow') {
-              collisionSlowed = true;
-              break;
-            }
-          }
-        }
+      // ゴール・死亡時はここで終了
+      if (result.isGoal || result.isDead) {
+        return;
       }
 
-      // 衝突結果をプレイヤーに適用
-      if (collisionSlowed) {
-        finalPlayer = { ...afterTransitionPlayer, vx: -afterTransitionPlayer.vx * Config.combat.bounceMultiplier };
-      } else if (newVxFromBounce !== undefined) {
-        finalPlayer = { ...afterTransitionPlayer, vx: newVxFromBounce };
+      // --- clockRef 更新 ---
+      if (result.hitstopFrames > 0) {
+        clockRef.current = triggerHitstop(clockRef.current, result.hitstopFrames);
+      }
+      if (result.slowMoFrames > 0) {
+        clockRef.current = triggerSlowMo(clockRef.current, result.slowMoFrames, result.slowMoFactor);
       }
 
-      // ── 副作用の適用（updater 外） ──
+      // --- state/ref の更新 ---
+      const w = result.world;
 
-      // ジャンプ音
-      if (didJump) {
-        Audio.play('jump');
+      // 速度
+      speedRef.current = w.speed;
+      setSpeed(w.speed);
+
+      // エフェクト
+      effectRef.current = w.effect;
+      setEffect(w.effect);
+
+      // コンボ
+      comboRef.current = w.combo.count;
+      setCombo(w.combo.count);
+      comboTimerRef.current = w.combo.timer;
+      setComboTimer(w.combo.timer);
+
+      // lastRamp（変化した場合のみ）
+      if (w.lastRamp !== lastRampRef.current) {
+        lastRampRef.current = w.lastRamp;
+        setLastRamp(w.lastRamp);
       }
 
-      // ランプ遷移の副作用
-      if (didRampChange && transition.player.ramp > currentLastRamp) {
-        lastRampRef.current = newLastRamp;
-        setLastRamp(newLastRamp);
-        comboRef.current = newCombo;
-        setCombo(newCombo);
-        comboTimerRef.current = newComboTimer2;
-        setComboTimer(newComboTimer2);
-        setScore(prev => prev + scoreDeltaFromRamp);
-        setSpeedBonus(prev => prev + newSpeedBonusDelta);
-        setTransitionEffect(1);
-        if (shouldPlayCombo) {
-          Audio.playCombo(comboCountForAudio);
-          addScorePopup(W / 2, 120, comboPopupText, '#ffaa00');
-        }
-        Audio.play('rampChange');
+      // プレイヤー
+      playerRef.current = w.player;
+      setPlayer(w.player);
+
+      // カメラ
+      camYRef.current = w.camY;
+      setCamY(w.camY);
+
+      // スコア差分を適用（processFrame は score=0 起点で計算した差分を返す）
+      if (w.score !== 0) {
+        setScore(prev => prev + w.score);
+      }
+      if (w.speedBonus !== 0) {
+        setSpeedBonus(prev => prev + w.speedBonus);
+      }
+      if (w.nearMissCount !== 0) {
+        setNearMissCount(prev => prev + w.nearMissCount);
       }
 
-      // 着地の副作用
-      if (justLanded) {
-        Audio.play('land');
-        if (motionScaleRef.current > 0) {
-          // 着地点の画面 Y 座標を計算して土煙を生成。
-          // camY は jetParticles/トレイルと同様に前フレーム相当だが、土煙は短命バーストのため許容範囲。
-          const dustGeo = GeometryDomain.getRampGeometry(afterTransitionRamp, W, RAMP_H);
-          const dustSlopeY = GeometryDomain.getSlopeY(afterTransitionPlayer.x, dustGeo, afterTransitionRamp.type);
-          const dustScreenY = afterTransitionPlayer.ramp * RAMP_H - currentCamY + dustSlopeY;
-          setParticles(prevParticles => [
-            ...prevParticles,
-            ...createDust(afterTransitionPlayer.x, dustScreenY, DUST_PARTICLE_COUNT),
-          ]);
-        }
+      // 危険レベル
+      setDangerLevel(w.dangerLevel);
+
+      // transitionEffect（processFrame が計算した値で上書き）
+      setTransitionEffect(result.ui.transitionEffect);
+
+      // ジェットパーティクル（processFrame が完全に管理）
+      if (result.ui.jetParticles.length > 0) {
+        setJetParticles(prev => [
+          ...ParticleSys.updateAndFilter(prev, ParticleSys.updateParticle),
+          ...result.ui.jetParticles,
+        ]);
       }
 
-      // 修正1: ニアミス副作用（スコア・カウント・エフェクト・ポップアップ・スローモー）は
-      // 死亡フラグに関わらず適用する（旧挙動と一致）。
-      // 衝突ループは死亡時に break するため、死亡した障害物より後のニアミスは
-      // 収集されない（= 旧挙動の「障害物を順に処理し、死亡で即ループ終了」と等価）
-      if (nearMissScoreDelta !== 0) {
-        setScore(prev => prev + nearMissScoreDelta);
-        setNearMissCount(prev => prev + nearMissDeltaCount);
-        for (const nm of nearMissFromCollision) {
-          setNearMissEffects(prev => [...prev, EntityFactory.createNearMissEffect(nm.x, nm.y)]);
-        }
-        for (const popup of nearMissPopupsFromCollision) {
-          addScorePopup(popup.x, popup.y, popup.text, popup.color);
-        }
-      }
-      if (slowMoFrames > 0) {
-        clockRef.current = triggerSlowMo(clockRef.current, slowMoFrames, slowMoFactor);
+      // 速度線（processFrame が管理）
+      speedLinesRef.current = result.ui.speedLines as SpeedLine[];
+      setSpeedLines(result.ui.speedLines as SpeedLine[]);
+
+      // プレイヤー残像トレイル（processFrame が管理）
+      playerTrailRef.current = result.ui.playerTrail as TrailSample[];
+      setPlayerTrail(result.ui.playerTrail as TrailSample[]);
+
+      // ニアミスエフェクト追記（processFrame から返ってきた新規生成分）
+      if (result.ui.nearMissEffects.length > 0) {
+        setNearMissEffects(prev => [...prev, ...result.ui.nearMissEffects as typeof prev]);
       }
 
-      // 衝突の副作用（死亡はこの中で handleDeath を呼ぶ）
-      if (!collisionDied) {
-        // 死亡していない場合のみスコア・エフェクト・パーティクルを適用
-        if (scoreDeltaFromCollision !== 0) {
-          setScore(prev => prev + scoreDeltaFromCollision);
-        }
-        if (speedDeltaFromCollision !== 0) {
-          const newSpd = Math.max(MIN_SPD, nextSpeed + speedDeltaFromCollision);
-          speedRef.current = newSpd;
-          setSpeed(newSpd);
-        }
-        for (const p of particlesFromCollision) {
-          addParticles(p.x, p.y, p.color, p.count);
-        }
-        for (const popup of popupsFromCollision) {
-          addScorePopup(popup.x, popup.y, popup.text, popup.color);
-        }
-        if (newEffectFromCollision) {
-          effectRef.current = newEffectFromCollision;
-          setEffect(newEffectFromCollision);
-        }
-        if (hitstopFrames > 0) {
-          clockRef.current = triggerHitstop(clockRef.current, hitstopFrames);
-        }
-
-        // 確定プレイヤーを ref + state に反映
-        playerRef.current = finalPlayer;
-        setPlayer(finalPlayer);
-      } else {
-        // 死亡: 副作用（handleDeath 呼び出しなど）を実行
-        for (const fn of audioEventsFromCollision) {
-          fn();
-        }
+      // スコアポップアップ追記（processFrame から返ってきた新規生成分）
+      if (result.ui.scorePopups.length > 0) {
+        setScorePopups(prev => [...prev, ...result.ui.scorePopups as typeof prev]);
       }
 
-      // --- カメラ更新 ---
-      // 修正3: カメラ目標は常に前フレームのプレイヤー ramp を使う（旧挙動と一致）
-      // 旧コードでは setCamY の updater 内で stale closure の player（前フレーム）を参照していた。
-      // 生存時・死亡時ともに currentPlayer（tick 開始時 = 前フレーム確定位置）を使用する。
-      const nextCamY = MathUtils.lerp(currentCamY, currentPlayer.ramp * RAMP_H - H / Config.camera.offsetDivisor, Config.camera.followRate);
-      camYRef.current = nextCamY;
-      setCamY(nextCamY);
+      // パーティクル追記（processFrame から返ってきた新規生成分: dust 等）
+      if (result.ui.particles.length > 0) {
+        setParticles(prev => [...prev, ...result.ui.particles as typeof prev]);
+      }
     }, 1000 / 60);
     return () => window.clearInterval(loop);
-  }, [state, W, H, MIN_SPD, RAMP_H, addParticles, addScorePopup, handleDeath, handleClear]);
+  }, [state, W, H, MIN_SPD, RAMP_H, handleDeath, handleClear]);
 
   // クリーンアップ
   useEffect(() => () => Audio.cleanup(), []);
@@ -912,7 +710,9 @@ export const useGameEngine = (
     clouds,
     shake,
     transitionEffect,
-  }), [particles, jetParticles, scorePopups, nearMissEffects, clouds, shake, transitionEffect]);
+    speedLines,
+    playerTrail,
+  }), [particles, jetParticles, scorePopups, nearMissEffects, clouds, shake, transitionEffect, speedLines, playerTrail]);
 
   return {
     gameState: state,

--- a/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
+++ b/src/features/non-brake-descent/presentation/hooks/use-game-engine.ts
@@ -167,6 +167,12 @@ export const useGameEngine = (
   const speedLinesRef = useRef<SpeedLine[]>([]);
   /** プレイヤー残像トレイルの ref（processFrame に渡すための最新値を保持） */
   const playerTrailRef = useRef<TrailSample[]>([]);
+  /**
+   * transitionEffect の ref（processFrame に渡すための最新値を保持）
+   * 旧挙動: 毎フレーム 0.1 ずつ減衰 → ランプ通過時に 1 をセット → 約10フレームで減衰。
+   * processFrame に最新値を渡すことで、減衰の持続が旧と一致する。
+   */
+  const transitionEffectRef = useRef<number>(0);
 
   const isMobile = useIsMobile();
   const handleCheat = useCheatCode('jinjinjin', () => {
@@ -213,6 +219,7 @@ export const useGameEngine = (
     setCombo(0);
     comboTimerRef.current = 0;
     setComboTimer(0);
+    transitionEffectRef.current = 0;
     setTransitionEffect(0);
     setDangerLevel(0);
     speedLinesRef.current = [];
@@ -533,7 +540,9 @@ export const useGameEngine = (
         nearMissEffects: [],
         clouds: [],
         shake: 0,
-        transitionEffect: 0,
+        // 修正1: transitionEffectRef.current を渡すことで減衰の持続が旧挙動と一致する。
+        // 旧挙動: 毎フレーム Math.max(0, current - 0.1) で減衰し、ランプ通過時に 1 をセット。
+        transitionEffect: transitionEffectRef.current,
         speedLines: speedLinesRef.current,
         playerTrail: playerTrailRef.current,
       };
@@ -546,10 +555,11 @@ export const useGameEngine = (
       // 既存のパーティクル更新はフック側の setXxx(prev => ...) で継続する。
 
       // --- パーティクル系の既存更新（純粋変換・processFrame 外で継続） ---
+      // 修正3: particles/scorePopups/nearMissEffects は毎フレーム更新する（旧挙動と一致）。
+      // 修正4: 雲の更新は processFrame 後に result.world.speed を使って行う（後述）。
       setParticles(current => ParticleSys.updateAndFilter(current, ParticleSys.updateParticle));
       setScorePopups(current => ParticleSys.updateAndFilter(current, ParticleSys.updatePopup));
       setNearMissEffects(current => ParticleSys.updateAndFilter(current, ParticleSys.updateNearMiss));
-      setClouds(current => ParticleSys.updateClouds(current, speedRef.current));
 
       // --- processFrame を呼び出す ---
       const result = processFrame(inputWorld, inputUI, input, ctx);
@@ -589,8 +599,16 @@ export const useGameEngine = (
         }
       }
 
-      // ゴール・死亡時はここで終了
-      if (result.isGoal || result.isDead) {
+      // ゴール時はここで終了
+      if (result.isGoal) {
+        return;
+      }
+
+      // 修正6: 死亡フレームでも旧挙動に合わせてカメラを更新する。
+      // 旧挙動: 衝突死亡後の else ブロックの外でカメラ更新が実行されていた。
+      if (result.isDead) {
+        camYRef.current = result.world.camY;
+        setCamY(result.world.camY);
         return;
       }
 
@@ -648,15 +666,22 @@ export const useGameEngine = (
       setDangerLevel(w.dangerLevel);
 
       // transitionEffect（processFrame が計算した値で上書き）
+      // 修正1: ref も同期して次フレームの processFrame に最新値を渡す。
+      transitionEffectRef.current = result.ui.transitionEffect;
       setTransitionEffect(result.ui.transitionEffect);
 
       // ジェットパーティクル（processFrame が完全に管理）
-      if (result.ui.jetParticles.length > 0) {
-        setJetParticles(prev => [
-          ...ParticleSys.updateAndFilter(prev, ParticleSys.updateParticle),
-          ...result.ui.jetParticles,
-        ]);
-      }
+      // 修正3: 生成のないフレームでも既存粒子を更新する（length > 0 ガード撤廃）。
+      // 旧挙動: 毎フレーム updateAndFilter を実行してから新規粒子を追加していた。
+      setJetParticles(prev => [
+        ...ParticleSys.updateAndFilter(prev, ParticleSys.updateParticle),
+        ...result.ui.jetParticles,
+      ]);
+
+      // 雲の更新（修正4: result.world.speed を使う）
+      // 旧挙動: setClouds(current => ParticleSys.updateClouds(current, nextSpeed)) で加速後速度を使用。
+      // 新: processFrame 後の result.world.speed を使うことで旧と同値になる。
+      setClouds(current => ParticleSys.updateClouds(current, result.world.speed));
 
       // 速度線（processFrame が管理）
       speedLinesRef.current = result.ui.speedLines as SpeedLine[];


### PR DESCRIPTION
## 概要
NBD の 735 行インラインゲームループ（`use-game-engine.ts`）を、純粋な `processFrame` 中心アーキテクチャへ**段階的に**リファクタする取り組みの第1弾（**S1+S2**）。B1 の安全網（PR #102）の上に実施。**既存挙動（ゲームフィール・スコア・当たり判定・P2-P5 演出）は不変**で、構造改善とテスタビリティ向上に限定。

## 背景
プロダクトレビューで「ライブループが `setState` updater 内で副作用多発（React 契約違反）」「ループ本体がテスト皆無」「正統な `application/game-loop` 層との二重化」が指摘されていた（高リスクのため別タスク推奨とされていた領域）。本 PR はその段階的解消の S1・S2。

## 変更内容
### S1: 副作用の分離
- `setState` updater 内の副作用（`Audio.play`/各 `setState`/`clockRef` 更新等）を**ループ外へ分離**（収集→適用パターン）。
- 動的値を ref に昇格し、ゲームループ `useEffect` の依存配列を `[state, ...]` に縮小（毎フレーム再登録を解消）。

### S2: `processFrame` 純粋関数の抽出
- `application/game-loop/frame-processor.ts` に **`processFrame(world, ui, input, ctx): FrameResult`** を新設（Audio/React/DOM 非依存の純粋関数）。1フレームの全計算を集約。
- フックは `processFrame` の結果を適用するだけに簡素化（`createCollisionHandlers` 等 411 行を削減）。
- **`frame-processor.test.ts`（13テスト）** を追加 — ループ本体が初めて単体テスト可能に。
- `UIState` に `speedLines`/`playerTrail` を追加、`SPEED_RANK_CHANGED` イベントを追加。

## 品質保証（重要）
ライブループ改変のため、各 Stage で **旧↔新の挙動同値レビュー**を実施し、発見した差異をすべて旧挙動に修正:
- S1: ニアミス+死亡同フレーム / コンボ最終フレーム / カメラ追従（3件修正）
- S2: transitionEffect 持続 / godMode 衝突 break / jetParticles 毎フレーム更新 / 雲速度 / ゴール時 jump 音 / 死亡時カメラ（6件修正）

## 残作業（本 PR スコープ外・別途）
- S3: `useReducer(GameWorld)` 集約 / S4: `useReducer(UIState)`+イベント化完成 / S5: 旧 `domains/` import 整理
- 計画: `.docs/nbd-20260610-01/plan-b2-refactor.md`

## テスト方法
- [x] `npm run ci` 全パス（lint:ci → typecheck → test → build）
- [x] NBD 374 テスト PASS（B1 統合テスト + 新規 processFrame 13 テスト含む）
- [ ] **マージ前に手動 playtest 推奨**（ヒットストップ/スローモー/コンボ/ニアミス/カメラ/着地/速度線/トレイル/BGM が S1 前と同じか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
