### PR TITLE
refactor: agile-quiz-sugoroku の公開 API を確立しインポートを一本化

### DIFF
--- a/src/features/agile-quiz-sugoroku/index.ts
+++ b/src/features/agile-quiz-sugoroku/index.ts
@@ -1,72 +1,62 @@
 /**
- * Agile Quiz Sugoroku - メインエクスポート
+ * Agile Quiz Sugoroku - 公開 API
+ *
+ * 外部(pages 等)はこのファイル経由でのみインポートする。
+ * Feature 内部のモジュール間参照は各モジュールを直接参照する(このファイルを経由しない)。
  */
 
 // 型定義
-export * from './domain/types';
+export type {
+  SprintSummary,
+  SaveState,
+  StoryEntry,
+  EndingEntry,
+  Difficulty,
+  AchievementDefinition,
+} from './domain/types';
 
 // 定数
-export * from './constants';
+export { CONFIG } from './constants';
 
-// クイズデータ
-export { QUESTIONS } from './questions';
+// ドメインロジック
+export { getDifficultyConfig, calculateGradeWithDifficulty } from './domain/scoring';
+export { checkAchievements } from './domain/achievement';
+export { classifyTeamType } from './team-classifier';
 
-// タグマスタ
-export { TAG_MASTER, VALID_TAG_IDS, TAG_MAP } from './questions/tag-master';
-export type { TagDefinition } from './questions/tag-master';
-
-// ゲームロジック
-export { createEvents, createSprintSummary } from './domain/game';
-export { pickQuestion, computeAnswerResult, computeDebtDelta, nextGameStats } from './domain/quiz';
-export type { AnswerInput } from './domain/quiz';
-export { shuffle, clamp, average, percentage } from '../../utils/math-utils';
-export { classifyTeamType, TEAM_TYPES } from './team-classifier';
-export { getComboColor } from './domain/quiz';
-
-// ジャンル別統計
-export { getTagColor, computeTagStatEntries, getWeakGenres, getWeakGenreIds } from './domain/quiz';
-export type { TagStatEntry } from './domain/quiz';
-
-// ゲーム結果保存
-export { GameResultRepository } from './infrastructure/storage/game-repository';
-
-// 履歴
-export { HistoryRepository, MAX_HISTORY_COUNT } from './infrastructure/storage/history-repository';
-
-// 実績
-export { ACHIEVEMENTS, checkAchievements } from './domain/achievement';
-export { AchievementRepository } from './infrastructure/storage/achievement-repository';
-
-// 難易度
-export { DIFFICULTY_CONFIGS, getDifficultyConfig, calculateGradeWithDifficulty } from './domain/scoring';
-
-// チャレンジモード
-export { ChallengeRepository } from './infrastructure/storage/challenge-repository';
-
-// デイリークイズ
-export * from './daily-quiz';
-
-// キャラクターナラティブ
-export * from './character-narrative';
-
-// セーブ/ロード
-export { SaveRepository } from './infrastructure/storage/save-repository';
-
-// ストーリーデータ
-export { STORY_ENTRIES, getStoriesForSprintCount } from './story-data';
-
-// エンディングストーリーデータ
-export { ENDING_COMMON, ENDING_EPILOGUES, getEndingStories } from './ending-data';
-
-// 勉強会モード
-export { buildStudyPool, countStudyQuestions } from './domain/quiz';
+// 静的データ
+export { getStoriesForSprintCount } from './story-data';
+export { getEndingStories } from './ending-data';
 
 // 音声
-export * from './audio/sound';
-export * from './audio/audio-actions';
+export { createDefaultAudioActions } from './audio/audio-actions';
 
 // フック
-export * from './hooks';
+export { useGame, useCountdown, useFade, useStudy, useChallenge } from './hooks';
 
-// コンポーネント
-export * from './components';
+// インフラストラクチャ(ストレージ)
+export { LocalStorageAdapter } from './infrastructure/storage/local-storage-adapter';
+export { GameResultRepository } from './infrastructure/storage/game-repository';
+export { SaveRepository } from './infrastructure/storage/save-repository';
+export { AchievementRepository } from './infrastructure/storage/achievement-repository';
+export { HistoryRepository } from './infrastructure/storage/history-repository';
+export { ChallengeRepository } from './infrastructure/storage/challenge-repository';
+
+// UI コンポーネント
+export {
+  TitleScreen,
+  SprintStartScreen,
+  QuizScreen,
+  RetrospectiveScreen,
+  ResultScreen,
+  StudySelectScreen,
+  StudyScreen,
+  StudyResultScreen,
+  GuideScreen,
+  StoryScreen,
+  AchievementScreen,
+  AchievementToast,
+  HistoryScreen,
+  ChallengeQuizScreen,
+  ChallengeResultScreen,
+  DailyQuizScreen,
+} from './components';

--- a/src/pages/AgileQuizSugorokuPage.tsx
+++ b/src/pages/AgileQuizSugorokuPage.tsx
@@ -3,36 +3,34 @@
  */
 import React, { useState, useMemo, useEffect } from 'react';
 
-// 型定義
-import type { SprintSummary, SaveState, StoryEntry, EndingEntry, Difficulty, AchievementDefinition } from '../features/agile-quiz-sugoroku/domain/types';
-
-// 定数
-import { CONFIG } from '../features/agile-quiz-sugoroku/constants';
-
-// ドメインロジック
-import { getDifficultyConfig, calculateGradeWithDifficulty } from '../features/agile-quiz-sugoroku/domain/scoring';
-import { checkAchievements } from '../features/agile-quiz-sugoroku/domain/achievement';
-import { classifyTeamType } from '../features/agile-quiz-sugoroku/team-classifier';
-import { getStoriesForSprintCount } from '../features/agile-quiz-sugoroku/story-data';
-import { getEndingStories } from '../features/agile-quiz-sugoroku/ending-data';
-
-// 音声
-import { createDefaultAudioActions } from '../features/agile-quiz-sugoroku/audio/audio-actions';
-
-// フック
-import { useGame, useCountdown, useFade, useStudy } from '../features/agile-quiz-sugoroku/hooks';
-import { useChallenge } from '../features/agile-quiz-sugoroku/hooks/useChallenge';
-
-// インフラストラクチャ（リポジトリ）
-import { LocalStorageAdapter } from '../features/agile-quiz-sugoroku/infrastructure/storage/local-storage-adapter';
-import { GameResultRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/game-repository';
-import { SaveRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/save-repository';
-import { AchievementRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/achievement-repository';
-import { HistoryRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/history-repository';
-import { ChallengeRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/challenge-repository';
-
-// UIコンポーネント
+import type {
+  SprintSummary,
+  SaveState,
+  StoryEntry,
+  EndingEntry,
+  Difficulty,
+  AchievementDefinition,
+} from '../features/agile-quiz-sugoroku';
 import {
+  CONFIG,
+  getDifficultyConfig,
+  calculateGradeWithDifficulty,
+  checkAchievements,
+  classifyTeamType,
+  getStoriesForSprintCount,
+  getEndingStories,
+  createDefaultAudioActions,
+  useGame,
+  useCountdown,
+  useFade,
+  useStudy,
+  useChallenge,
+  LocalStorageAdapter,
+  GameResultRepository,
+  SaveRepository,
+  AchievementRepository,
+  HistoryRepository,
+  ChallengeRepository,
   TitleScreen,
   SprintStartScreen,
   QuizScreen,
@@ -49,7 +47,7 @@ import {
   ChallengeQuizScreen,
   ChallengeResultScreen,
   DailyQuizScreen,
-} from '../features/agile-quiz-sugoroku/components';
+} from '../features/agile-quiz-sugoroku';
 
 /** 有効な難易度値 */
 const VALID_DIFFICULTIES: readonly Difficulty[] = ['easy', 'normal', 'hard', 'extreme'] as const;


### PR DESCRIPTION
## 概要
agile-quiz-sugoroku の構造統一リファクタリング(全 4 PR)の 1 本目。公開 API を index.ts に確立し、外部境界を凍結する。
スペック: docs/superpowers/specs/2026-06-11-agile-quiz-sugoroku-refactoring-design.md

## 変更内容
- index.ts を名前付きエクスポートのみの公開 API に整理（export * 全廃、外部未使用シンボルの公開停止）
- AgileQuizSugorokuPage の深いインポート 17 箇所を index.ts 経由に一本化

## テスト方法
- [x] npm run ci（lint:ci / typecheck / test / build）ローカル全パス
- [x] 本番バンドルの AgileQuizSugorokuPage チャンクが main とバイト単位一致を確認
- [ ] GitHub CI（E2E 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)