### PR TITLE
feat: AQS ブラッシュアップ Phase1（サウンド設定・アクセシビリティ・トークン統一）

### DIFF
--- a/docs/superpowers/plans/2026-06-13-aqs-enhancement-phase1-foundation.md
+++ b/docs/superpowers/plans/2026-06-13-aqs-enhancement-phase1-foundation.md
@@ -1,0 +1,641 @@
+# AQS ブラッシュアップ Phase 1（基盤）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** デザイントークン統一・アクセシビリティ強化・サウンド設定の横断基盤を整え、後続フェーズの土台を作る。
+
+**Architecture:** 既存の `Repository + StoragePort` パターンで `SettingsRepository` を新設。サウンドは `sound.ts` のモジュールレベルフラグでゲート。アクセシビリティは既存コンポーネントへ `aria-*`/`role`/`:focus-visible` を追加。デザイントークンは既存 `DESIGN_TOKENS` への参照置換のみ（styled-components 全面移行はしない）。
+
+**Tech Stack:** React 19 + TypeScript + styled-components + Jotai / Jest 30 + @testing-library/react / Tone.js
+
+**対象ディレクトリ:** `src/features/agile-quiz-sugoroku/`（以降のパスはこのディレクトリ起点）
+
+**共通コマンド:**
+- 単体テスト: `npm test -- <テストファイルパス>`
+- 型チェック: `npm run typecheck`
+- Lint: `npm run lint`
+- 全 CI: `npm run ci`
+
+---
+
+### Task 1: SettingsRepository（サウンド設定の永続化）
+
+**Files:**
+- Create: `src/features/agile-quiz-sugoroku/infrastructure/storage/settings-repository.ts`
+- Test: `src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/settings-repository.test.ts`
+- Modify: `src/features/agile-quiz-sugoroku/domain/types/index.ts`（`AppSettings` 型を再エクスポート。下記 Step 3 参照）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/settings-repository.test.ts`:
+
+```typescript
+import { SettingsRepository } from '../settings-repository';
+import { InMemoryStorageAdapter } from '../in-memory-storage-adapter';
+
+describe('SettingsRepository', () => {
+  it('デフォルトでは soundEnabled が true', () => {
+    const repo = new SettingsRepository(new InMemoryStorageAdapter());
+    expect(repo.load().soundEnabled).toBe(true);
+  });
+
+  it('soundEnabled を保存して読み込める', () => {
+    const storage = new InMemoryStorageAdapter();
+    const repo = new SettingsRepository(storage);
+    repo.setSoundEnabled(false);
+    expect(repo.load().soundEnabled).toBe(false);
+    // 別インスタンスでも永続値を読める
+    expect(new SettingsRepository(storage).load().soundEnabled).toBe(false);
+  });
+
+  it('壊れたデータが入っていてもデフォルトに復帰する', () => {
+    const storage = new InMemoryStorageAdapter();
+    storage.set('aqs_settings', 'not-an-object');
+    const repo = new SettingsRepository(storage);
+    expect(repo.load().soundEnabled).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- settings-repository.test.ts`
+Expected: FAIL（`Cannot find module '../settings-repository'`）
+
+- [ ] **Step 3: 型を追加**
+
+`src/features/agile-quiz-sugoroku/domain/types/` に `app-settings-types.ts` を新規作成:
+
+```typescript
+/**
+ * アプリ設定に関するドメイン型定義
+ */
+
+/** アプリ全体の設定 */
+export interface AppSettings {
+  /** 効果音・BGM を再生するか */
+  soundEnabled: boolean;
+}
+
+/** 設定のデフォルト値 */
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  soundEnabled: true,
+};
+```
+
+`src/features/agile-quiz-sugoroku/domain/types/index.ts` に再エクスポートを追記（既存の `export * from './xxx-types';` 群の末尾に）:
+
+```typescript
+export * from './app-settings-types';
+```
+
+- [ ] **Step 4: SettingsRepository を実装**
+
+`src/features/agile-quiz-sugoroku/infrastructure/storage/settings-repository.ts`:
+
+```typescript
+/**
+ * 設定リポジトリ
+ *
+ * サウンド ON/OFF などのアプリ設定を永続化する。
+ */
+import { AppSettings, DEFAULT_APP_SETTINGS } from '../../domain/types';
+import { StoragePort } from './storage-port';
+
+const SETTINGS_KEY = 'aqs_settings';
+
+export class SettingsRepository {
+  constructor(private readonly storage: StoragePort) {}
+
+  /** 設定を読み込む（壊れている/未保存ならデフォルト） */
+  load(): AppSettings {
+    const data = this.storage.get<Partial<AppSettings>>(SETTINGS_KEY);
+    if (!data || typeof data !== 'object') {
+      return { ...DEFAULT_APP_SETTINGS };
+    }
+    return {
+      soundEnabled:
+        typeof data.soundEnabled === 'boolean'
+          ? data.soundEnabled
+          : DEFAULT_APP_SETTINGS.soundEnabled,
+    };
+  }
+
+  /** 設定を保存する */
+  save(settings: AppSettings): void {
+    this.storage.set(SETTINGS_KEY, settings);
+  }
+
+  /** soundEnabled だけ更新する */
+  setSoundEnabled(enabled: boolean): void {
+    const current = this.load();
+    this.save({ ...current, soundEnabled: enabled });
+  }
+}
+```
+
+- [ ] **Step 5: テストを実行して成功を確認**
+
+Run: `npm test -- settings-repository.test.ts`
+Expected: PASS（3 件）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/infrastructure/storage/settings-repository.ts \
+        src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/settings-repository.test.ts \
+        src/features/agile-quiz-sugoroku/domain/types/app-settings-types.ts \
+        src/features/agile-quiz-sugoroku/domain/types/index.ts
+git commit -m "feat: AQS サウンド設定の永続化リポジトリを追加"
+```
+
+---
+
+### Task 2: サウンドのミュートゲート（sound.ts）
+
+`sound.ts` の全 `playXxx`/`playBgm` は副作用関数。モジュールレベルの `soundEnabled` フラグを追加し、無効時は early return する。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/infrastructure/audio/sound.ts`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts`:
+
+```typescript
+import { setSoundEnabled, isSoundEnabled } from '../infrastructure/audio/sound';
+
+describe('sound mute gate', () => {
+  afterEach(() => setSoundEnabled(true)); // 後始末
+
+  it('デフォルトは有効', () => {
+    expect(isSoundEnabled()).toBe(true);
+  });
+
+  it('setSoundEnabled で状態を切り替えられる', () => {
+    setSoundEnabled(false);
+    expect(isSoundEnabled()).toBe(false);
+    setSoundEnabled(true);
+    expect(isSoundEnabled()).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- sound-mute.test.ts`
+Expected: FAIL（`setSoundEnabled` が export されていない）
+
+- [ ] **Step 3: sound.ts にフラグとゲートを追加**
+
+`sound.ts` の先頭付近（`let isAudioInitialized = false;` の近く）に追加:
+
+```typescript
+/** サウンド全体の有効フラグ。false の間は全再生をスキップする */
+let soundEnabled = true;
+
+/** サウンドの有効/無効を設定する */
+export function setSoundEnabled(enabled: boolean): void {
+  soundEnabled = enabled;
+  if (!enabled) {
+    stopBgm();
+  }
+}
+
+/** サウンドが有効かどうかを返す */
+export function isSoundEnabled(): boolean {
+  return soundEnabled;
+}
+```
+
+各再生関数の本体先頭に early return を追加する。対象は `playBgm` / `playSfxCorrect` / `playSfxIncorrect` / `playSfxTick` / `playSfxStart` / `playSfxResult` / `playSfxCombo` / `playSfxComboBreak` / `playSfxDrumroll` / `playSfxFanfare` / `playSfxAchievement` / `playSfxTickUrgent`。各関数の最初の行に:
+
+```typescript
+  if (!soundEnabled) return;
+```
+
+`stopBgm` には**追加しない**（ミュート時に停止できなくなるため）。`initAudio` にも追加しない（初期化は許可）。
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- sound-mute.test.ts`
+Expected: PASS（2 件）
+
+- [ ] **Step 5: 既存サウンド関連テストの回帰確認**
+
+Run: `npm test -- sound`
+Expected: 既存 `sound-extensions.test.ts` 含め全 PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/infrastructure/audio/sound.ts \
+        src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts
+git commit -m "feat: AQS サウンドのミュートゲートを sound.ts に追加"
+```
+
+---
+
+### Task 3: 設定 → サウンド初期化の結線 + タイトル画面トグル UI
+
+アプリ起動時に `SettingsRepository` を読み、`setSoundEnabled` を呼ぶ。タイトル画面にトグルボタンを置く。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/screens/TitleScreen.tsx`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/title-sound-toggle.test.tsx`
+
+> **調査メモ:** `TitleScreen.tsx:30-31` で `new GameResultRepository(new LocalStorageAdapter())` 等をモジュールスコープで生成済み。同パターンで `settingsRepo` を追加する。トグルボタンの配置先は `TitleScreen` 内の適切な位置（既存の設定系 UI がなければ画面下部）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/title-sound-toggle.test.tsx`:
+
+```typescript
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TitleScreen } from '../presentation/components/screens/TitleScreen';
+import { SettingsRepository } from '../infrastructure/storage/settings-repository';
+import { LocalStorageAdapter } from '../infrastructure/storage/local-storage-adapter';
+
+// TitleScreen が要求する最小 props はコンポーネント定義に合わせて補完する
+const noop = () => undefined;
+
+describe('TitleScreen サウンドトグル', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('サウンドトグルボタンが表示され、押すと設定が反転する', () => {
+    render(
+      <TitleScreen
+        onNewGame={noop}
+        navigation={{}}
+        /* 他の必須 props はコンポーネント定義に合わせて追加 */
+      />
+    );
+    const toggle = screen.getByRole('button', { name: /サウンド/ });
+    expect(toggle).toBeInTheDocument();
+    fireEvent.click(toggle);
+    const repo = new SettingsRepository(new LocalStorageAdapter());
+    expect(repo.load().soundEnabled).toBe(false);
+  });
+});
+```
+
+> 実行者向け注: `TitleScreen` の実際の必須 props（`saveState`/`formatSaveDate` 等）はファイル冒頭の Props 型を読んで補完すること。props が多い場合はテスト内にヘルパー `renderTitle(overrides)` を作る。
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- title-sound-toggle.test.tsx`
+Expected: FAIL（トグルボタンが見つからない）
+
+- [ ] **Step 3: TitleScreen にトグルを実装**
+
+`TitleScreen.tsx` のモジュールスコープ（既存 repo 生成の隣）に追加:
+
+```typescript
+import { SettingsRepository } from '../../../infrastructure/storage/settings-repository';
+import { setSoundEnabled, isSoundEnabled } from '../../../infrastructure/audio/sound';
+
+const settingsRepo = new SettingsRepository(new LocalStorageAdapter());
+```
+
+コンポーネント本体に状態とハンドラを追加:
+
+```typescript
+  const [soundOn, setSoundOn] = React.useState<boolean>(() => settingsRepo.load().soundEnabled);
+
+  const handleToggleSound = React.useCallback(() => {
+    const next = !soundOn;
+    setSoundOn(next);
+    settingsRepo.setSoundEnabled(next);
+    setSoundEnabled(next);
+  }, [soundOn]);
+```
+
+画面下部にトグルボタンを描画（既存 `Button` スタイルを使用）:
+
+```tsx
+  <button
+    type="button"
+    onClick={handleToggleSound}
+    aria-pressed={soundOn}
+    aria-label={`サウンド ${soundOn ? 'オン' : 'オフ'}`}
+    style={{
+      marginTop: DESIGN_TOKENS.spacing.md,
+      background: 'transparent',
+      border: `1px solid ${DESIGN_TOKENS.colors.textMuted}`,
+      borderRadius: DESIGN_TOKENS.borderRadius.md,
+      color: DESIGN_TOKENS.colors.textPrimary,
+      padding: `${DESIGN_TOKENS.spacing.xs} ${DESIGN_TOKENS.spacing.md}`,
+      cursor: 'pointer',
+      fontSize: DESIGN_TOKENS.fontSize.sm,
+    }}
+  >
+    {soundOn ? '🔊 サウンド: オン' : '🔇 サウンド: オフ'}
+  </button>
+```
+
+`DESIGN_TOKENS` を import（未 import の場合）:
+
+```typescript
+import { DESIGN_TOKENS } from '../../styles/design-tokens';
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- title-sound-toggle.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: アプリ初期化時に設定を反映**
+
+`src/features/agile-quiz-sugoroku/pages` ではなく Feature の起動点が `presentation/hooks/useGame.ts` の `init`（`dispatch({ type: 'INIT' })` の `useEffect`）にある。`useGame.ts` 冒頭に import を追加:
+
+```typescript
+import { SettingsRepository } from '../../infrastructure/storage/settings-repository';
+import { LocalStorageAdapter } from '../../infrastructure/storage/local-storage-adapter';
+import { setSoundEnabled } from '../../infrastructure/audio/sound';
+```
+
+INIT 用の `useEffect`（`dispatch({ type: 'INIT' })` を呼んでいる箇所）に、初回マウント時の設定反映を追加:
+
+```typescript
+  useEffect(() => {
+    const settings = new SettingsRepository(new LocalStorageAdapter()).load();
+    setSoundEnabled(settings.soundEnabled);
+  }, []);
+```
+
+> 注: 既存の INIT effect がある場合はそこへ 1 行追記でもよい。`AgileQuizSugorokuPage` が `useGame()` を呼ぶため、ここが起動点として確実。
+
+- [ ] **Step 6: 型チェックと回帰テスト**
+
+Run: `npm run typecheck && npm test -- useGame.test.ts title-sound-toggle.test.tsx`
+Expected: PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/components/screens/TitleScreen.tsx \
+        src/features/agile-quiz-sugoroku/presentation/hooks/useGame.ts \
+        src/features/agile-quiz-sugoroku/__tests__/title-sound-toggle.test.tsx
+git commit -m "feat: AQS タイトル画面にサウンド ON/OFF トグルを追加し起動時に設定を復元"
+```
+
+---
+
+### Task 4: アクセシビリティ — クイズ選択肢
+
+選択肢パネルに `role`/`aria-label`、回答確定後の結果を `aria-live` で通知する。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/OptionsPanel.tsx`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/options-panel-a11y.test.tsx`
+
+> **調査メモ:** 実装前に `OptionsPanel.tsx` を読み、props（選択肢配列・選択状態・onSelect・answered など）の実名を確認すること。以下のコードは props 名を仮定しているので実体に合わせる。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/options-panel-a11y.test.tsx`:
+
+```typescript
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OptionsPanel } from '../presentation/components/screens/QuizScreen/OptionsPanel';
+
+describe('OptionsPanel アクセシビリティ', () => {
+  it('選択肢グループが radiogroup ロールを持つ', () => {
+    render(
+      <OptionsPanel
+        options={['A', 'B', 'C', 'D']}
+        /* 実 props に合わせて補完（selected, answered, onSelect 等） */
+        onSelect={() => undefined}
+      />
+    );
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    // 4 つの選択肢が radio として公開される
+    expect(screen.getAllByRole('radio')).toHaveLength(4);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- options-panel-a11y.test.tsx`
+Expected: FAIL（radiogroup が見つからない）
+
+- [ ] **Step 3: OptionsPanel に role/aria を付与**
+
+選択肢コンテナに `role="radiogroup"` と `aria-label="回答の選択肢"` を付与。各選択肢ボタンに:
+
+```tsx
+role="radio"
+aria-checked={selected === index}
+aria-label={`選択肢 ${String.fromCharCode(65 + index)}: ${option}`}
+```
+
+確定後フィードバック用に、パネル末尾へ視覚的に隠した live 領域を追加:
+
+```tsx
+<div
+  aria-live="polite"
+  style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}
+>
+  {answered ? (isCorrect ? '正解です' : '不正解です') : ''}
+</div>
+```
+
+> `answered`/`isCorrect` に相当する props/状態名は実体に合わせる。なければ親（QuizScreen）から受け取る。
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- options-panel-a11y.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: 既存コンポーネントテストの回帰確認**
+
+Run: `npm test -- components.test.tsx phase1-components.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/OptionsPanel.tsx \
+        src/features/agile-quiz-sugoroku/__tests__/options-panel-a11y.test.tsx
+git commit -m "feat: AQS クイズ選択肢に radiogroup ロールと aria-live フィードバックを追加"
+```
+
+---
+
+### Task 5: アクセシビリティ — タイマー/スコア + focus-visible
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/TimerDisplay.tsx`
+- Modify: `src/features/agile-quiz-sugoroku/presentation/styles/common.ts`（`Button` 等に `:focus-visible`）
+- Test: `src/features/agile-quiz-sugoroku/__tests__/timer-a11y.test.tsx`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/timer-a11y.test.tsx`:
+
+```typescript
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TimerDisplay } from '../presentation/components/screens/QuizScreen/TimerDisplay';
+
+describe('TimerDisplay アクセシビリティ', () => {
+  it('残り時間が timer ロールと aria-live を持つ', () => {
+    render(<TimerDisplay remaining={5} total={15} /* 実 props に合わせる */ />);
+    const timer = screen.getByRole('timer');
+    expect(timer).toHaveAttribute('aria-live');
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- timer-a11y.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: TimerDisplay に role/aria-live を付与**
+
+タイマー表示要素に:
+
+```tsx
+role="timer"
+aria-live="polite"
+aria-atomic="true"
+aria-label={`残り ${remaining} 秒`}
+```
+
+過剰読み上げを避けるため、`aria-live` 領域に表示する文字列は残り 10/5/0 秒など区切りのみ更新する設計とする（数値表示自体は毎秒でよいが、live テキストは下記のように区切り判定）:
+
+```tsx
+const liveText =
+  remaining === 10 || remaining === 5 || remaining === 0 ? `残り ${remaining} 秒` : '';
+```
+
+別途、視覚非表示の live 領域に `liveText` を出す。視覚要素は `role="timer"` のみ付与し `aria-hidden` は付けない。
+
+- [ ] **Step 4: `:focus-visible` を共通スタイルに追加**
+
+`presentation/styles/common.ts` の `Button` 定義（styled-components）へ追記:
+
+```typescript
+  &:focus-visible {
+    outline: 2px solid ${DESIGN_TOKENS.colors.primary};
+    outline-offset: 2px;
+  }
+```
+
+`DESIGN_TOKENS` が未 import なら追加。`COLORS.accent` を直接使っても可（既存様式に合わせる）。
+
+- [ ] **Step 5: テストを実行して成功を確認**
+
+Run: `npm test -- timer-a11y.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: 回帰テスト + Lint**
+
+Run: `npm test -- QuizScreen quiz && npm run lint`
+Expected: PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/TimerDisplay.tsx \
+        src/features/agile-quiz-sugoroku/presentation/styles/common.ts \
+        src/features/agile-quiz-sugoroku/__tests__/timer-a11y.test.tsx
+git commit -m "feat: AQS タイマーに timer ロール/aria-live とフォーカスリング可視化を追加"
+```
+
+---
+
+### Task 6: デザイントークン統一（IncorrectReview ほか）
+
+インライン `style` のマジックナンバー・色リテラルを `DESIGN_TOKENS` 参照に置換する。視覚は変えない。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/IncorrectReview.tsx`
+- Modify: 同様にトークン未使用のコンポーネント（grep で特定）
+- Test: 既存 `components.test.tsx` 等で視覚回帰がないことを確認（新規テストは不要）
+
+- [ ] **Step 1: トークン未使用箇所を洗い出す**
+
+Run:
+```bash
+cd src/features/agile-quiz-sugoroku
+grep -rln "style={{" presentation/components | xargs grep -L "DESIGN_TOKENS" 2>/dev/null
+```
+Expected: トークン未使用でインライン style を使うファイル一覧が出る。`IncorrectReview.tsx` を起点に、上位 3〜5 ファイルを本タスクの対象とする（残りは Phase 3 の視覚洗練でも継続）。
+
+- [ ] **Step 2: IncorrectReview をトークン化**
+
+`IncorrectReview.tsx` の `import` に追加:
+
+```typescript
+import { DESIGN_TOKENS } from '../styles/design-tokens';
+```
+
+インライン style の数値・色リテラルをトークンへ置換。例（既存 → 置換後）:
+
+```tsx
+// 置換前
+style={{ padding: '10px 12px', borderRadius: 8, border: `1px solid ${COLORS.red}18` }}
+// 置換後（視覚を変えない範囲で近いトークンに寄せる）
+style={{
+  padding: `${DESIGN_TOKENS.spacing.sm} ${DESIGN_TOKENS.spacing.md}`,
+  borderRadius: DESIGN_TOKENS.borderRadius.md,
+  border: `1px solid ${DESIGN_TOKENS.colors.danger}18`,
+}}
+```
+
+`fontSize: 12` → `DESIGN_TOKENS.fontSize.xs`、`fontSize: 11` は近似がないため数値のまま残してよい（無理にトークン化しない）。`gap: 10` 等は最寄り（`spacing.sm`=8 か独自値）に寄せるか、視覚維持を優先して残す。**判断基準: トークンに 1:1 近い値があるものだけ置換し、視覚を変えない。**
+
+- [ ] **Step 3: 同様に Step 1 で挙がった上位ファイルを置換**
+
+各ファイルで同じ方針（トークン 1:1 近似のみ置換、視覚維持）。1 ファイルずつ編集する。
+
+- [ ] **Step 4: 視覚回帰がないことをテストで確認**
+
+Run: `npm test -- components.test.tsx phase1-components.test.tsx phase2-components.test.tsx`
+Expected: PASS（DOM 構造・テキストは不変のため通る）
+
+- [ ] **Step 5: 型チェックと Lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/components/
+git commit -m "refactor: AQS インライン style を DESIGN_TOKENS 参照に統一（視覚不変）"
+```
+
+---
+
+### Task 7: Phase 1 全体検証
+
+- [ ] **Step 1: 全 CI を実行**
+
+Run: `npm run ci`
+Expected: lint:ci → typecheck → test:coverage → build が全 PASS
+
+- [ ] **Step 2: ドキュメント追記**
+
+`src/features/agile-quiz-sugoroku/doc/effects-and-ui.md` に「サウンド設定」「アクセシビリティ方針（radiogroup/timer/aria-live/focus-visible）」「デザイントークン統一方針」の節を追記。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/doc/effects-and-ui.md
+git commit -m "docs: AQS Phase1（サウンド設定・a11y・トークン統一）をドキュメントに反映"
+```
+
+---
+
+## Self-Review チェック（Phase 1）
+
+- **Spec coverage:** 1-A（Task 6）/ 1-B（Task 4,5）/ 1-C（Task 1,2,3）を網羅 ✅
+- **型整合:** `AppSettings`/`DEFAULT_APP_SETTINGS`（Task 1）、`setSoundEnabled`/`isSoundEnabled`（Task 2）を Task 3 で正しく参照 ✅
+- **プレースホルダ:** props 名の実体確認を「調査メモ」で明示。コードは実在パターンに準拠 ✅

--- a/docs/superpowers/plans/2026-06-13-aqs-enhancement-phase2-content.md
+++ b/docs/superpowers/plans/2026-06-13-aqs-enhancement-phase2-content.md
@@ -1,0 +1,499 @@
+# AQS ブラッシュアップ Phase 2（コンテンツ）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** クイズの下位タグを底上げして出題バランスを是正し（約 +79 問）、解説に関連タグチップを表示して学習導線を強化する。
+
+**Architecture:** 問題は既存 JSON（`data/questions/*.json`）へ追記。検証は既存 `__tests__/questions.test.ts` に「下位タグの最小問題数」テストを追加して TDD 化。関連タグチップは新規 presentation コンポーネントとして切り出し、既存の解説表示箇所へ差し込む。
+
+**Tech Stack:** TypeScript / JSON / Jest 30 + @testing-library/react
+
+**対象ディレクトリ:** `src/features/agile-quiz-sugoroku/`
+
+**前提:** Phase 1 完了後のブランチから派生（`feature/aqs-content` 等）。Phase 1 未完でも問題追加（Task 1〜5）は独立して着手可能。Task 6 の関連タグチップは Phase 1 のトークンを使うと綺麗。
+
+**タグ別の追加目標（合計 +79）:**
+
+| タグ(id) | 現状 | 目標 | 追加 | 投入先 |
+|----------|------|------|------|--------|
+| design-patterns | 8 | 25 | +17 | impl1.json / impl2.json |
+| agile | 10 | 25 | +15 | planning.json |
+| ci-cd | 11 | 25 | +14 | test1.json / test2.json |
+| data-structures | 14 | 24 | +10 | impl1.json / impl2.json |
+| estimation | 15 | 24 | +9 | planning.json |
+| programming | 17 | 24 | +7 | impl1.json / impl2.json |
+| refactoring | 17 | 24 | +7 | refinement.json |
+
+**問題フォーマット（厳守）:** `{ "question": string, "options": string[4], "answer": 0-3, "tags": string[], "explanation": string }`。`answer` は正解選択肢のインデックス。タグ id は `data/questions/tag-master.ts` の `VALID_TAG_IDS` のもの。
+
+---
+
+### Task 1: 下位タグ最小問題数の検証テストを追加（TDD の Red）
+
+問題を足す前に「下位タグが目標数に達している」テストを追加し、失敗させる。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/__tests__/questions.test.ts`
+
+- [ ] **Step 1: 失敗するテストを追記**
+
+`questions.test.ts` の `describe('タグ検証', ...)` 内に追加:
+
+```typescript
+    it('下位タグが最小問題数を満たす（出題バランス）', () => {
+      const MIN_COUNT: Record<string, number> = {
+        'design-patterns': 25,
+        agile: 25,
+        'ci-cd': 25,
+        'data-structures': 24,
+        estimation: 24,
+        programming: 24,
+        refactoring: 24,
+      };
+      const counts: Record<string, number> = {};
+      expectedCategories.forEach((category) => {
+        QUESTIONS[category].forEach((q) => {
+          q.tags?.forEach((tag) => {
+            counts[tag] = (counts[tag] ?? 0) + 1;
+          });
+        });
+      });
+      Object.entries(MIN_COUNT).forEach(([tag, min]) => {
+        expect(counts[tag] ?? 0).toBeGreaterThanOrEqual(min);
+      });
+    });
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- questions.test.ts`
+Expected: FAIL（`design-patterns` などが目標未満）
+
+- [ ] **Step 3: コミット（Red を記録）**
+
+```bash
+git add src/features/agile-quiz-sugoroku/__tests__/questions.test.ts
+git commit -m "test: AQS 下位タグの最小問題数検証を追加（Red）"
+```
+
+---
+
+### Task 2: agile / estimation を planning.json に追加（+24）
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/data/questions/planning.json`
+
+- [ ] **Step 1: agile タグ問題を +15 追加**
+
+`planning.json` の配列末尾（最後の `}` の後、`]` の前）に追記。重複しない論点で 15 問。例（同じ形式で 15 問用意する）:
+
+```json
+  {
+    "question": "アジャイルソフトウェア開発宣言が最も重視する価値はどれか？",
+    "options": [
+      "包括的なドキュメントよりも動くソフトウェア",
+      "個人よりもプロセスとツール",
+      "顧客との協調よりも契約交渉",
+      "変化への対応よりも計画に従うこと"
+    ],
+    "answer": 0,
+    "tags": ["agile"],
+    "explanation": "アジャイル宣言は『動くソフトウェアを』『顧客との協調を』『変化への対応を』より価値あるものとする。左記の価値も認めつつ右記をより重視する。"
+  },
+  {
+    "question": "アジャイルの『反復（イテレーション）』の主な狙いは？",
+    "options": [
+      "短い周期で動くものを作りフィードバックを得る",
+      "一度の計画で全工程を確定する",
+      "ドキュメントを完全にしてから実装する",
+      "テストを最後にまとめて行う"
+    ],
+    "answer": 0,
+    "tags": ["agile"],
+    "explanation": "反復ごとに動作する成果物を作り、早期かつ頻繁なフィードバックで方向修正する。"
+  }
+```
+
+> 実行者向け: 残り 13 問も同形式で作成。論点候補（重複回避の観点）: 自己組織化チーム / 持続可能なペース / YAGNI とアジャイルの関係 / カンバンとの違い / インクリメンタル開発 / 経験主義 / フィードバックループ / ふりかえりの目的 / MVP / 適応的計画 / アジャイルメトリクス（ベロシティの正しい使い方）/ アジャイルにおける失敗の扱い / スウォーミング。各問 `tags: ["agile"]`、解説は「なぜ正解か」を 1〜2 文。
+
+- [ ] **Step 2: estimation タグ問題を +9 追加**
+
+同じく `planning.json` 末尾に 9 問。例:
+
+```json
+  {
+    "question": "プランニングポーカーで見積もりが大きく割れたとき、まず行うべきは？",
+    "options": [
+      "高い人と低い人の認識の違いを議論する",
+      "平均値を採用する",
+      "最も高い見積もりを採用する",
+      "多数決で決める"
+    ],
+    "answer": 0,
+    "tags": ["estimation"],
+    "explanation": "数値の差は理解の差。議論で前提のズレを解消することが見積もりの本質的価値。"
+  }
+```
+
+> 実行者向け: 残り 8 問。論点候補: ストーリーポイントと工数の違い / 相対見積もり / 三点見積もり / プランニングポーカーの目的 / ベロシティによる予測 / 見積もりの不確実性コーン / Tシャツサイズ見積もり / アフィニティ見積もり / #NoEstimates の考え方。各問 `tags: ["estimation"]`。
+
+- [ ] **Step 3: JSON 妥当性と問題テストを実行**
+
+Run: `npm test -- questions.test.ts`
+Expected: agile/estimation 部分は改善（まだ他タグ未達で全体は FAIL のまま）。少なくとも JSON パースエラーがないこと、スキーマ・answer 範囲テストが PASS することを確認。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/data/questions/planning.json
+git commit -m "feat: AQS planning に agile/estimation 問題を追加（+24）"
+```
+
+---
+
+### Task 3: design-patterns / data-structures / programming を impl1・impl2 に追加（+34）
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/data/questions/impl1.json`
+- Modify: `src/features/agile-quiz-sugoroku/data/questions/impl2.json`
+
+配分目安: impl1 と impl2 におおよそ半分ずつ振り分ける（各ファイルが極端に偏らないように）。
+
+- [ ] **Step 1: design-patterns を +17 追加（impl1 に 9・impl2 に 8）**
+
+例:
+
+```json
+  {
+    "question": "Strategy パターンの主な目的は？",
+    "options": [
+      "アルゴリズムを交換可能にしてクライアントから独立させる",
+      "オブジェクト生成をサブクラスに委ねる",
+      "1つのインスタンスのみ存在を保証する",
+      "オブジェクトに責務を動的に追加する"
+    ],
+    "answer": 0,
+    "tags": ["design-patterns"],
+    "explanation": "Strategy は振る舞い（アルゴリズム）をカプセル化し実行時に差し替え可能にする。"
+  }
+```
+
+> 論点候補: Singleton / Factory Method / Observer / Decorator / Adapter / Facade / Template Method / Command / State / Strategy / Composite / Proxy / Builder / Iterator / DI / Null Object / Repository。各問 `tags: ["design-patterns"]`。
+
+- [ ] **Step 2: data-structures を +10 追加（impl1 に 5・impl2 に 5）**
+
+例:
+
+```json
+  {
+    "question": "ハッシュテーブルの平均的な検索計算量は？",
+    "options": ["O(1)", "O(log n)", "O(n)", "O(n log n)"],
+    "answer": 0,
+    "tags": ["data-structures"],
+    "explanation": "衝突が少なければハッシュテーブルの検索・挿入・削除は平均 O(1)。"
+  }
+```
+
+> 論点候補: 配列 vs 連結リスト / スタックとキュー / 二分探索木 / ハッシュ衝突 / ヒープ / 計算量の比較 / 集合(Set) / 木の走査 / グラフ表現 / 動的配列の償却計算量。各問 `tags: ["data-structures"]`。
+
+- [ ] **Step 3: programming を +7 追加（impl1 に 4・impl2 に 3）**
+
+例:
+
+```json
+  {
+    "question": "純粋関数（pure function）の特徴として正しいのは？",
+    "options": [
+      "同じ入力に対し常に同じ出力を返し副作用がない",
+      "グローバル変数を変更する",
+      "実行ごとに異なる結果を返す",
+      "必ず非同期で実行される"
+    ],
+    "answer": 0,
+    "tags": ["programming"],
+    "explanation": "純粋関数は参照透過性を持ち、副作用がないためテスト・推論が容易。"
+  }
+```
+
+> 論点候補: 純粋関数 / イミュータビリティ / 再帰 / 例外処理 / 早期 return / ガード節 / 短絡評価 / null 安全 / 型システムの利点。各問 `tags: ["programming"]`。
+
+- [ ] **Step 4: 問題テストを実行**
+
+Run: `npm test -- questions.test.ts`
+Expected: design-patterns/data-structures/programming が目標到達。JSON パース・スキーマ PASS。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/data/questions/impl1.json \
+        src/features/agile-quiz-sugoroku/data/questions/impl2.json
+git commit -m "feat: AQS impl1/impl2 に design-patterns/data-structures/programming 問題を追加（+34）"
+```
+
+---
+
+### Task 4: ci-cd を test1・test2 に追加（+14）
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/data/questions/test1.json`
+- Modify: `src/features/agile-quiz-sugoroku/data/questions/test2.json`
+
+- [ ] **Step 1: ci-cd を +14 追加（test1 に 7・test2 に 7）**
+
+例:
+
+```json
+  {
+    "question": "継続的インテグレーション（CI）の最も重要な実践は？",
+    "options": [
+      "頻繁にメインブランチへ統合し自動ビルド・テストを回す",
+      "リリース直前にまとめて統合する",
+      "手動でビルドを確認する",
+      "テストは週次でまとめて実行する"
+    ],
+    "answer": 0,
+    "tags": ["ci-cd"],
+    "explanation": "CI は小さな変更を頻繁に統合し自動テストで早期に問題を検出する。"
+  }
+```
+
+> 論点候補: CI と CD の違い / 継続的デプロイ vs 継続的デリバリー / パイプライン / ビルドの再現性 / フィーチャーフラグ / ブルーグリーンデプロイ / カナリアリリース / アーティファクト / 自動ロールバック / デプロイ頻度（DORA メトリクス）/ trunk-based development / 環境のコード化(IaC) / シークレット管理 / ビルド時間短縮。各問 `tags: ["ci-cd"]`。
+
+- [ ] **Step 2: 問題テストを実行**
+
+Run: `npm test -- questions.test.ts`
+Expected: ci-cd が目標到達。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/data/questions/test1.json \
+        src/features/agile-quiz-sugoroku/data/questions/test2.json
+git commit -m "feat: AQS test1/test2 に ci-cd 問題を追加（+14）"
+```
+
+---
+
+### Task 5: refactoring を refinement.json に追加（+7）+ Green 確認
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/data/questions/refinement.json`
+
+- [ ] **Step 1: refactoring を +7 追加**
+
+例:
+
+```json
+  {
+    "question": "リファクタリングの定義として最も正しいのは？",
+    "options": [
+      "外部から見た振る舞いを変えずに内部構造を改善する",
+      "新機能を追加する",
+      "バグを修正する",
+      "パフォーマンスのために仕様を変更する"
+    ],
+    "answer": 0,
+    "tags": ["refactoring"],
+    "explanation": "リファクタリングは振る舞いを保ったままコードの内部品質を高める作業。"
+  }
+```
+
+> 論点候補: リファクタリングの定義 / コードの臭い（重複・長いメソッド・大きなクラス）/ メソッド抽出 / 名前の改善 / リファクタリング前のテスト整備 / ボーイスカウトルール / 技術的負債との関係 / 小さなステップ。各問 `tags: ["refactoring"]`。
+
+- [ ] **Step 2: 問題テスト（Task 1 のテストが Green になる）**
+
+Run: `npm test -- questions.test.ts`
+Expected: PASS（「下位タグの最小問題数」含む全テスト）
+
+- [ ] **Step 3: 全タグ分布を再集計して確認**
+
+Run:
+```bash
+cd src/features/agile-quiz-sugoroku
+cat data/questions/*.json | grep -o '"[a-z-]*"' | grep -E 'design-patterns|agile|ci-cd|data-structures|estimation|programming|refactoring' | sort | uniq -c
+```
+Expected: 各タグが目標数以上。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/data/questions/refinement.json
+git commit -m "feat: AQS refinement に refactoring 問題を追加（+7）— 下位タグ底上げ完了"
+```
+
+---
+
+### Task 6: 関連タグチップコンポーネント（解説の充実）
+
+解説の下にその問題の `tags` をチップ表示する。外部 URL は追加しない。
+
+**Files:**
+- Create: `src/features/agile-quiz-sugoroku/presentation/components/RelatedTags.tsx`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/related-tags.test.tsx`
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/IncorrectReview.tsx`（チップを差し込む）
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/index.ts`（エクスポート追加）
+
+> **調査メモ:** `data/questions/tag-master.ts` の `TAG_MAP` がタグ id → 表示名を持つ（`IncorrectReview` で import 済み）。表示名はこれを使う。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/related-tags.test.tsx`:
+
+```typescript
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RelatedTags } from '../presentation/components/RelatedTags';
+
+describe('RelatedTags', () => {
+  it('タグの表示名をチップとして描画する', () => {
+    render(<RelatedTags tags={['scrum', 'agile']} />);
+    // TAG_MAP に基づく表示名（例: 'スクラム'）が出る
+    expect(screen.getByText('スクラム')).toBeInTheDocument();
+    expect(screen.getByText('アジャイル')).toBeInTheDocument();
+  });
+
+  it('タグが空なら何も描画しない', () => {
+    const { container } = render(<RelatedTags tags={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('onTagClick が指定されるとチップがボタンになり、クリックで id を返す', () => {
+    const handler = jest.fn();
+    render(<RelatedTags tags={['scrum']} onTagClick={handler} />);
+    screen.getByRole('button', { name: /スクラム/ }).click();
+    expect(handler).toHaveBeenCalledWith('scrum');
+  });
+});
+```
+
+> 注: `TAG_MAP` のキー名・表示名は `tag-master.ts` を読んで実値に合わせる（'スクラム' 等が違えば修正）。
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- related-tags.test.tsx`
+Expected: FAIL（モジュール未作成）
+
+- [ ] **Step 3: RelatedTags を実装**
+
+`src/features/agile-quiz-sugoroku/presentation/components/RelatedTags.tsx`:
+
+```tsx
+/**
+ * 関連タグチップ
+ *
+ * 問題の tags を表示名チップで表示する。onTagClick 指定時はクリック可能。
+ */
+import React from 'react';
+import { TAG_MAP } from '../../data/questions/tag-master';
+import { DESIGN_TOKENS } from '../styles/design-tokens';
+
+interface RelatedTagsProps {
+  tags: string[];
+  /** チップクリック時に tag id を返す（指定時のみクリック可能） */
+  onTagClick?: (tagId: string) => void;
+}
+
+/** 問題の関連タグをチップ表示する */
+export const RelatedTags: React.FC<RelatedTagsProps> = ({ tags, onTagClick }) => {
+  if (tags.length === 0) return null;
+
+  const chipStyle: React.CSSProperties = {
+    display: 'inline-block',
+    padding: `2px ${DESIGN_TOKENS.spacing.sm}`,
+    borderRadius: DESIGN_TOKENS.borderRadius.lg,
+    background: `${DESIGN_TOKENS.colors.primary}1A`,
+    color: DESIGN_TOKENS.colors.primary,
+    fontSize: DESIGN_TOKENS.fontSize.xs,
+    border: 'none',
+    cursor: onTagClick ? 'pointer' : 'default',
+  };
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: DESIGN_TOKENS.spacing.xs, marginTop: DESIGN_TOKENS.spacing.xs }}>
+      {tags.map((tagId) => {
+        const label = TAG_MAP[tagId]?.name ?? tagId;
+        return onTagClick ? (
+          <button key={tagId} type="button" style={chipStyle} onClick={() => onTagClick(tagId)}>
+            #{label}
+          </button>
+        ) : (
+          <span key={tagId} style={chipStyle}>#{label}</span>
+        );
+      })}
+    </div>
+  );
+};
+```
+
+> 注: `TAG_MAP[tagId]?.name` の構造は `tag-master.ts` の実体に合わせる（`.label` 等なら修正）。
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- related-tags.test.tsx`
+Expected: PASS（3 件）
+
+- [ ] **Step 5: IncorrectReview に差し込み + エクスポート**
+
+`IncorrectReview.tsx` の各問題ブロック内、解説テキストの直後に追加:
+
+```tsx
+import { RelatedTags } from './RelatedTags';
+// ...解説表示の直後
+<RelatedTags tags={q.tags} />
+```
+
+`presentation/components/index.ts` に追加:
+
+```typescript
+export { RelatedTags } from './RelatedTags';
+```
+
+- [ ] **Step 6: 回帰テスト**
+
+Run: `npm test -- related-tags.test.tsx components.test.tsx`
+Expected: PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/components/RelatedTags.tsx \
+        src/features/agile-quiz-sugoroku/presentation/components/IncorrectReview.tsx \
+        src/features/agile-quiz-sugoroku/presentation/components/index.ts \
+        src/features/agile-quiz-sugoroku/__tests__/related-tags.test.tsx
+git commit -m "feat: AQS 解説に関連タグチップ（RelatedTags）を追加"
+```
+
+---
+
+### Task 7: ドキュメント更新 + Phase 2 全体検証
+
+- [ ] **Step 1: quiz-content.md の数値を更新**
+
+`src/features/agile-quiz-sugoroku/doc/quiz-content.md` の「全306問」と「カテゴリ別問題数」テーブル、各タグ問題数を実数に更新する。実数は次で取得:
+
+```bash
+cd src/features/agile-quiz-sugoroku
+for f in data/questions/*.json; do echo -n "$(basename $f): "; grep -c '"question"' "$f"; done
+echo -n "合計: "; cat data/questions/*.json | grep -c '"question"'
+```
+
+- [ ] **Step 2: 全 CI を実行**
+
+Run: `npm run ci`
+Expected: 全 PASS
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/doc/quiz-content.md
+git commit -m "docs: AQS 問題総数・タグ別問題数を実数に更新"
+```
+
+---
+
+## Self-Review チェック（Phase 2）
+
+- **Spec coverage:** 2-A 問題追加（Task 2〜5、合計 15+9+17+10+7+14+7 = 79）✅ / 2-B 関連タグ表示（Task 6）✅ / 解説本文補強は新規 79 問で「なぜ」を必須化（各 Task の品質基準）✅
+- **TDD:** Task 1 で先に検証テストを Red にし、Task 5 で Green にする ✅
+- **型整合:** `RelatedTags` の props（`tags`/`onTagClick`）は Phase 3 のタグ別復習で再利用 ✅
+- **プレースホルダ:** 問題文は代表例 + 論点リストで提示（実際の 79 問は実行時に作成）。`TAG_MAP` 構造の実体確認を明示 ✅

--- a/docs/superpowers/plans/2026-06-13-aqs-enhancement-phase3-features.md
+++ b/docs/superpowers/plans/2026-06-13-aqs-enhancement-phase3-features.md
@@ -1,0 +1,971 @@
+# AQS ブラッシュアップ Phase 3（機能・演出）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 誤答・ブックマークを蓄積してタイマーなしで再出題する「復習モード」を新設し、主要画面のレスポンシブ対応と視覚的洗練を行う。
+
+**Architecture:** 問題の同定は `id` 一括付与を避け、ドメインの `makeQuestionKey(question)`（問題文ベース）で行う。誤答/ブックマークは `WrongAnswerRepository` / `BookmarkRepository`（既存 `Repository + StoragePort` パターン）にスナップショットで永続化。復習出題は新規 `review-question-pool` で組み立て、UI は既存の勉強会モード（`StudyScreen`/`useStudy`）の仕組みを再利用する。`GamePhase` に `review-select`/`review` を追加。
+
+**Tech Stack:** React 19 + TypeScript + Jotai / Jest 30 + @testing-library/react
+
+**対象ディレクトリ:** `src/features/agile-quiz-sugoroku/`
+
+**前提:** Phase 1・2 完了後のブランチから派生（`feature/aqs-review-mode` 等）。Task 1〜4（ドメイン/インフラ）は Phase 1・2 と独立に着手可能。
+
+**重要な調査済み事実:**
+- `GamePhase` 定義: `domain/types/game-types.ts:8`
+- 画面分岐: `pages/AgileQuizSugorokuPage.tsx` の `game.phase === '...'` 群（`study-select` は 544 行付近）
+- 勉強会フック: `presentation/hooks/useStudy.ts`（`init(selectedTags, limit)` で問題プールを受け取る形ではなく内部で `buildStudyPool` を呼ぶ → 復習では問題配列を直接渡せるよう拡張する）
+- ナビゲーション: `presentation/components/TitleButtons.tsx` の `TitleNavigation`（optional コールバック群）
+
+---
+
+### Task 1: makeQuestionKey（問題の同定キー）
+
+**Files:**
+- Create: `src/features/agile-quiz-sugoroku/domain/quiz/question-key.ts`
+- Modify: `src/features/agile-quiz-sugoroku/domain/quiz/index.ts`（再エクスポート）
+- Test: `src/features/agile-quiz-sugoroku/__tests__/question-key.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/question-key.test.ts`:
+
+```typescript
+import { makeQuestionKey } from '../domain/quiz/question-key';
+import type { Question } from '../domain/types';
+
+const q = (question: string): Question => ({
+  question,
+  options: ['a', 'b', 'c', 'd'],
+  answer: 0,
+});
+
+describe('makeQuestionKey', () => {
+  it('同じ問題文には同じキーを返す', () => {
+    expect(makeQuestionKey(q('テスト問題'))).toBe(makeQuestionKey(q('テスト問題')));
+  });
+
+  it('問題文が違えば異なるキーを返す', () => {
+    expect(makeQuestionKey(q('問題A'))).not.toBe(makeQuestionKey(q('問題B')));
+  });
+
+  it('前後の空白に依存しない', () => {
+    expect(makeQuestionKey(q('  問題  '))).toBe(makeQuestionKey(q('問題')));
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- question-key.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 実装**
+
+`src/features/agile-quiz-sugoroku/domain/quiz/question-key.ts`:
+
+```typescript
+/**
+ * 問題の同定キー生成
+ *
+ * Question 型に id がないため、問題文を正規化したものを安定キーとする。
+ * 将来 id 導入時はここだけ差し替えればよい。
+ */
+import type { Question } from '../types';
+
+/** 問題から安定した同定キーを生成する */
+export function makeQuestionKey(question: Question): string {
+  return question.question.trim();
+}
+```
+
+`domain/quiz/index.ts` に追記:
+
+```typescript
+export { makeQuestionKey } from './question-key';
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- question-key.test.ts`
+Expected: PASS（3 件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/domain/quiz/question-key.ts \
+        src/features/agile-quiz-sugoroku/domain/quiz/index.ts \
+        src/features/agile-quiz-sugoroku/__tests__/question-key.test.ts
+git commit -m "feat: AQS 問題同定キー makeQuestionKey を追加"
+```
+
+---
+
+### Task 2: 復習エントリ型 + WrongAnswerRepository
+
+**Files:**
+- Create: `src/features/agile-quiz-sugoroku/domain/types/review-types.ts`
+- Modify: `src/features/agile-quiz-sugoroku/domain/types/index.ts`
+- Create: `src/features/agile-quiz-sugoroku/infrastructure/storage/wrong-answer-repository.ts`
+- Test: `src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/wrong-answer-repository.test.ts`
+
+- [ ] **Step 1: 型を定義**
+
+`src/features/agile-quiz-sugoroku/domain/types/review-types.ts`:
+
+```typescript
+/**
+ * 復習機能に関するドメイン型定義
+ */
+import type { Question } from './quiz-types';
+
+/**
+ * 復習エントリ（問題のスナップショット）。
+ * 問題データの後日改変に影響されないよう参照ではなくコピーで保持する。
+ */
+export interface ReviewEntry {
+  /** 同定キー（makeQuestionKey の結果） */
+  key: string;
+  /** 問題のスナップショット */
+  question: Question;
+  /** 記録時刻（ミリ秒。テスト容易性のため呼び出し側から渡す） */
+  recordedAt: number;
+}
+```
+
+`domain/types/index.ts` に追記:
+
+```typescript
+export * from './review-types';
+```
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/wrong-answer-repository.test.ts`:
+
+```typescript
+import { WrongAnswerRepository } from '../wrong-answer-repository';
+import { InMemoryStorageAdapter } from '../in-memory-storage-adapter';
+import type { Question } from '../../../domain/types';
+
+const q = (text: string): Question => ({
+  question: text,
+  options: ['a', 'b', 'c', 'd'],
+  answer: 0,
+  tags: ['scrum'],
+});
+
+describe('WrongAnswerRepository', () => {
+  it('誤答を記録して読み出せる', () => {
+    const repo = new WrongAnswerRepository(new InMemoryStorageAdapter());
+    repo.record(q('問題A'), 1000);
+    const all = repo.loadAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].question.question).toBe('問題A');
+  });
+
+  it('同じ問題を複数回記録しても重複しない（キーで一意）', () => {
+    const repo = new WrongAnswerRepository(new InMemoryStorageAdapter());
+    repo.record(q('問題A'), 1000);
+    repo.record(q('問題A'), 2000);
+    expect(repo.loadAll()).toHaveLength(1);
+  });
+
+  it('正解したら誤答リストから除去できる', () => {
+    const repo = new WrongAnswerRepository(new InMemoryStorageAdapter());
+    repo.record(q('問題A'), 1000);
+    repo.remove(q('問題A'));
+    expect(repo.loadAll()).toHaveLength(0);
+  });
+
+  it('上限件数を超えたら古いものから削除する', () => {
+    const repo = new WrongAnswerRepository(new InMemoryStorageAdapter());
+    for (let i = 0; i < 60; i++) repo.record(q(`問題${i}`), i);
+    expect(repo.loadAll().length).toBeLessThanOrEqual(50);
+    // 最新が残る
+    expect(repo.loadAll().some((e) => e.question.question === '問題59')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+Run: `npm test -- wrong-answer-repository.test.ts`
+Expected: FAIL（モジュール未作成）
+
+- [ ] **Step 4: 実装**
+
+`src/features/agile-quiz-sugoroku/infrastructure/storage/wrong-answer-repository.ts`:
+
+```typescript
+/**
+ * 誤答リポジトリ
+ *
+ * 復習モード用に、誤答した問題のスナップショットを永続化する。
+ * 問題同定は makeQuestionKey（問題文ベース）。正解で除去する。
+ */
+import type { Question, ReviewEntry } from '../../domain/types';
+import { makeQuestionKey } from '../../domain/quiz';
+import { StoragePort } from './storage-port';
+
+const WRONG_KEY = 'aqs_wrong_answers';
+
+/** 保持する最大件数 */
+export const MAX_WRONG_COUNT = 50;
+
+export class WrongAnswerRepository {
+  constructor(private readonly storage: StoragePort) {}
+
+  /** 全件読み込む */
+  loadAll(): ReviewEntry[] {
+    const data = this.storage.get<ReviewEntry[]>(WRONG_KEY);
+    if (!data || !Array.isArray(data)) return [];
+    return data;
+  }
+
+  /** 誤答を記録する（同一キーは最新で上書き、上限超過で古いものを削除） */
+  record(question: Question, recordedAt: number): void {
+    const key = makeQuestionKey(question);
+    const list = this.loadAll().filter((e) => e.key !== key);
+    list.push({ key, question, recordedAt });
+    while (list.length > MAX_WRONG_COUNT) list.shift();
+    this.storage.set(WRONG_KEY, list);
+  }
+
+  /** 正解した問題を誤答リストから除去する */
+  remove(question: Question): void {
+    const key = makeQuestionKey(question);
+    this.storage.set(WRONG_KEY, this.loadAll().filter((e) => e.key !== key));
+  }
+
+  /** 全削除 */
+  clear(): void {
+    this.storage.remove(WRONG_KEY);
+  }
+}
+```
+
+- [ ] **Step 5: テストを実行して成功を確認**
+
+Run: `npm test -- wrong-answer-repository.test.ts`
+Expected: PASS（4 件）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/domain/types/review-types.ts \
+        src/features/agile-quiz-sugoroku/domain/types/index.ts \
+        src/features/agile-quiz-sugoroku/infrastructure/storage/wrong-answer-repository.ts \
+        src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/wrong-answer-repository.test.ts
+git commit -m "feat: AQS 誤答リポジトリ（WrongAnswerRepository）と復習エントリ型を追加"
+```
+
+---
+
+### Task 3: BookmarkRepository
+
+**Files:**
+- Create: `src/features/agile-quiz-sugoroku/infrastructure/storage/bookmark-repository.ts`
+- Test: `src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/bookmark-repository.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/bookmark-repository.test.ts`:
+
+```typescript
+import { BookmarkRepository } from '../bookmark-repository';
+import { InMemoryStorageAdapter } from '../in-memory-storage-adapter';
+import type { Question } from '../../../domain/types';
+
+const q = (text: string): Question => ({ question: text, options: ['a','b','c','d'], answer: 0, tags: ['scrum'] });
+
+describe('BookmarkRepository', () => {
+  it('toggle で追加・削除を切り替える', () => {
+    const repo = new BookmarkRepository(new InMemoryStorageAdapter());
+    expect(repo.isBookmarked(q('問題A'))).toBe(false);
+    repo.toggle(q('問題A'), 1000);
+    expect(repo.isBookmarked(q('問題A'))).toBe(true);
+    repo.toggle(q('問題A'), 2000);
+    expect(repo.isBookmarked(q('問題A'))).toBe(false);
+  });
+
+  it('loadAll でブックマーク済みを返す', () => {
+    const repo = new BookmarkRepository(new InMemoryStorageAdapter());
+    repo.toggle(q('問題A'), 1000);
+    expect(repo.loadAll()).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- bookmark-repository.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 実装**
+
+`src/features/agile-quiz-sugoroku/infrastructure/storage/bookmark-repository.ts`:
+
+```typescript
+/**
+ * ブックマークリポジトリ
+ *
+ * 復習モード用に、ブックマークした問題のスナップショットを永続化する。
+ */
+import type { Question, ReviewEntry } from '../../domain/types';
+import { makeQuestionKey } from '../../domain/quiz';
+import { StoragePort } from './storage-port';
+
+const BOOKMARK_KEY = 'aqs_bookmarks';
+
+export class BookmarkRepository {
+  constructor(private readonly storage: StoragePort) {}
+
+  loadAll(): ReviewEntry[] {
+    const data = this.storage.get<ReviewEntry[]>(BOOKMARK_KEY);
+    if (!data || !Array.isArray(data)) return [];
+    return data;
+  }
+
+  isBookmarked(question: Question): boolean {
+    const key = makeQuestionKey(question);
+    return this.loadAll().some((e) => e.key === key);
+  }
+
+  /** ブックマークを切り替える（なければ追加、あれば削除） */
+  toggle(question: Question, recordedAt: number): void {
+    const key = makeQuestionKey(question);
+    const list = this.loadAll();
+    const exists = list.some((e) => e.key === key);
+    const next = exists
+      ? list.filter((e) => e.key !== key)
+      : [...list, { key, question, recordedAt }];
+    this.storage.set(BOOKMARK_KEY, next);
+  }
+
+  clear(): void {
+    this.storage.remove(BOOKMARK_KEY);
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- bookmark-repository.test.ts`
+Expected: PASS（2 件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/infrastructure/storage/bookmark-repository.ts \
+        src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/bookmark-repository.test.ts
+git commit -m "feat: AQS ブックマークリポジトリ（BookmarkRepository）を追加"
+```
+
+---
+
+### Task 4: review-question-pool（復習出題プール）
+
+誤答/ブックマーク/タグ別 の 3 ソースから復習問題配列を組み立てる。
+
+**Files:**
+- Create: `src/features/agile-quiz-sugoroku/domain/quiz/review-question-pool.ts`
+- Modify: `src/features/agile-quiz-sugoroku/domain/quiz/index.ts`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/review-question-pool.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/review-question-pool.test.ts`:
+
+```typescript
+import { buildReviewPool } from '../domain/quiz/review-question-pool';
+import type { Question, ReviewEntry } from '../domain/types';
+
+const q = (text: string, tags: string[]): Question => ({ question: text, options: ['a','b','c','d'], answer: 0, tags });
+const entry = (text: string, tags: string[]): ReviewEntry => ({ key: text, question: q(text, tags), recordedAt: 0 });
+
+describe('buildReviewPool', () => {
+  it('source=wrong は誤答エントリの問題を返す', () => {
+    const pool = buildReviewPool({ source: 'wrong', wrong: [entry('A', ['scrum'])], bookmarks: [], allByTag: {} });
+    expect(pool.map((p) => p.question)).toEqual(['A']);
+  });
+
+  it('source=bookmark はブックマークの問題を返す', () => {
+    const pool = buildReviewPool({ source: 'bookmark', wrong: [], bookmarks: [entry('B', ['agile'])], allByTag: {} });
+    expect(pool.map((p) => p.question)).toEqual(['B']);
+  });
+
+  it('source=tag は指定タグの全問題を返す', () => {
+    const allByTag = { scrum: [q('C', ['scrum']), q('D', ['scrum'])] };
+    const pool = buildReviewPool({ source: 'tag', tagId: 'scrum', wrong: [], bookmarks: [], allByTag });
+    expect(pool.map((p) => p.question).sort()).toEqual(['C', 'D']);
+  });
+
+  it('該当なしなら空配列', () => {
+    expect(buildReviewPool({ source: 'wrong', wrong: [], bookmarks: [], allByTag: {} })).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- review-question-pool.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 実装**
+
+`src/features/agile-quiz-sugoroku/domain/quiz/review-question-pool.ts`:
+
+```typescript
+/**
+ * 復習出題プールの組み立て
+ *
+ * 誤答 / ブックマーク / タグ別 の 3 ソースから復習問題配列を作る。
+ */
+import type { Question, ReviewEntry } from '../types';
+
+/** 復習ソース種別 */
+export type ReviewSource = 'wrong' | 'bookmark' | 'tag';
+
+/** buildReviewPool の入力 */
+export interface ReviewPoolInput {
+  source: ReviewSource;
+  /** source=tag のときの対象タグ */
+  tagId?: string;
+  wrong: ReviewEntry[];
+  bookmarks: ReviewEntry[];
+  /** タグ id → そのタグを含む全問題 */
+  allByTag: Record<string, Question[]>;
+}
+
+/** 復習問題プールを組み立てる */
+export function buildReviewPool(input: ReviewPoolInput): Question[] {
+  switch (input.source) {
+    case 'wrong':
+      return input.wrong.map((e) => e.question);
+    case 'bookmark':
+      return input.bookmarks.map((e) => e.question);
+    case 'tag':
+      return input.tagId ? input.allByTag[input.tagId] ?? [] : [];
+    default:
+      return [];
+  }
+}
+```
+
+`domain/quiz/index.ts` に追記:
+
+```typescript
+export { buildReviewPool } from './review-question-pool';
+export type { ReviewSource, ReviewPoolInput } from './review-question-pool';
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- review-question-pool.test.ts`
+Expected: PASS（4 件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/domain/quiz/review-question-pool.ts \
+        src/features/agile-quiz-sugoroku/domain/quiz/index.ts \
+        src/features/agile-quiz-sugoroku/__tests__/review-question-pool.test.ts
+git commit -m "feat: AQS 復習出題プール buildReviewPool を追加"
+```
+
+---
+
+### Task 5: GamePhase 追加 + ReviewSelectScreen
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/domain/types/game-types.ts:8`（GamePhase 拡張）
+- Create: `src/features/agile-quiz-sugoroku/presentation/components/screens/ReviewSelectScreen.tsx`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/review-select-screen.test.tsx`
+- Modify: `src/features/agile-quiz-sugoroku/__tests__/architecture.test.ts`（presentation 許可リストに新パスを追記。必要時のみ）
+
+- [ ] **Step 1: GamePhase を拡張**
+
+`domain/types/game-types.ts:8` の `GamePhase` union に追加:
+
+```typescript
+export type GamePhase = 'title' | 'story' | 'sprint-start' | 'game' | 'retro' | 'ending' | 'result' | 'guide' | 'study-select' | 'study' | 'achievements' | 'history' | 'challenge' | 'challenge-result' | 'daily-quiz' | 'review-select' | 'review';
+```
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`src/features/agile-quiz-sugoroku/__tests__/review-select-screen.test.tsx`:
+
+```typescript
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReviewSelectScreen } from '../presentation/components/screens/ReviewSelectScreen';
+
+describe('ReviewSelectScreen', () => {
+  it('誤答件数とブックマーク件数を表示し、各ソースを選べる', () => {
+    const onSelect = jest.fn();
+    render(
+      <ReviewSelectScreen
+        wrongCount={3}
+        bookmarkCount={2}
+        onSelectSource={onSelect}
+        onBack={() => undefined}
+      />
+    );
+    expect(screen.getByText(/誤答から復習/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /誤答から復習/ }));
+    expect(onSelect).toHaveBeenCalledWith('wrong');
+  });
+
+  it('誤答が0件のとき誤答ボタンは無効', () => {
+    render(
+      <ReviewSelectScreen wrongCount={0} bookmarkCount={0} onSelectSource={() => undefined} onBack={() => undefined} />
+    );
+    expect(screen.getByRole('button', { name: /誤答から復習/ })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+Run: `npm test -- review-select-screen.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 4: ReviewSelectScreen を実装**
+
+`src/features/agile-quiz-sugoroku/presentation/components/screens/ReviewSelectScreen.tsx`:
+
+```tsx
+/**
+ * 復習選択画面
+ *
+ * 誤答 / ブックマーク から復習を開始する入口。タグ別はタグチップ経由で開始する。
+ */
+import React from 'react';
+import { ReviewSource } from '../../../domain/quiz';
+import { DESIGN_TOKENS } from '../../styles/design-tokens';
+import { Button } from '../../styles';
+
+interface ReviewSelectScreenProps {
+  wrongCount: number;
+  bookmarkCount: number;
+  onSelectSource: (source: ReviewSource) => void;
+  onBack: () => void;
+}
+
+/** 復習ソースを選ぶ画面 */
+export const ReviewSelectScreen: React.FC<ReviewSelectScreenProps> = ({
+  wrongCount, bookmarkCount, onSelectSource, onBack,
+}) => (
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: DESIGN_TOKENS.spacing.md, padding: DESIGN_TOKENS.spacing.lg }}>
+    <h2 style={{ color: DESIGN_TOKENS.colors.textPrimary, fontSize: DESIGN_TOKENS.fontSize.xl }}>復習モード</h2>
+    <Button $color={DESIGN_TOKENS.colors.danger} onClick={() => onSelectSource('wrong')} disabled={wrongCount === 0}>
+      誤答から復習（{wrongCount}）
+    </Button>
+    <Button $color={DESIGN_TOKENS.colors.warning} onClick={() => onSelectSource('bookmark')} disabled={bookmarkCount === 0}>
+      ブックマークから復習（{bookmarkCount}）
+    </Button>
+    <Button $color={DESIGN_TOKENS.colors.textMuted} onClick={onBack}>タイトルへ戻る</Button>
+  </div>
+);
+```
+
+> 注: `Button` の props（`$color`/`disabled`）は `presentation/styles` の実体に合わせる。`disabled` 非対応なら styled に追加するか `aria-disabled` + ガードで代替。
+
+- [ ] **Step 5: テストを実行して成功を確認**
+
+Run: `npm test -- review-select-screen.test.tsx`
+Expected: PASS（2 件）
+
+- [ ] **Step 6: アーキテクチャテストの回帰確認**
+
+Run: `npm test -- architecture.test.ts`
+Expected: PASS（新パスが許可リストで弾かれる場合のみ `architecture.test.ts` の presentation 許可リストへ追記して再実行）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/domain/types/game-types.ts \
+        src/features/agile-quiz-sugoroku/presentation/components/screens/ReviewSelectScreen.tsx \
+        src/features/agile-quiz-sugoroku/__tests__/review-select-screen.test.tsx \
+        src/features/agile-quiz-sugoroku/__tests__/architecture.test.ts
+git commit -m "feat: AQS 復習選択画面と review-select/review フェーズを追加"
+```
+
+---
+
+### Task 6: useStudy を任意問題プール対応に拡張 + 復習画面の結線
+
+復習は勉強会 UI（`StudyScreen`）を再利用する。`useStudy` を「問題配列を直接受け取れる」よう拡張する。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/presentation/hooks/useStudy.ts`
+- Modify: `src/features/agile-quiz-sugoroku/pages/AgileQuizSugorokuPage.tsx`
+- Test: `src/features/agile-quiz-sugoroku/__tests__/useStudy.test.ts`（既存に追記）
+
+> **調査メモ:** 実装前に `useStudy.ts` の `init(selectedTags, limit)` 実装を読む。内部で `buildStudyPool(selectedTags, limit)` を呼んでいる。これに加えて `initWithQuestions(questions: Question[])` を追加し、外部プール（復習）をそのまま使えるようにする。
+
+- [ ] **Step 1: 失敗するテストを追記**
+
+`useStudy.test.ts` に追加:
+
+```typescript
+  it('initWithQuestions で外部の問題配列をそのまま使う', () => {
+    const { result } = renderHook(() => useStudy());
+    const questions = [
+      { question: 'Q1', options: ['a','b','c','d'], answer: 0, tags: ['scrum'] },
+    ];
+    act(() => result.current.initWithQuestions(questions));
+    expect(result.current.questions).toHaveLength(1);
+    expect(result.current.currentQuestion?.question).toBe('Q1');
+  });
+```
+
+> `renderHook`/`act` の import は既存テスト冒頭に合わせる。
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `npm test -- useStudy.test.ts`
+Expected: FAIL（`initWithQuestions` がない）
+
+- [ ] **Step 3: useStudy に initWithQuestions を追加**
+
+`UseStudyReturn` インターフェースに追加:
+
+```typescript
+  /** 外部の問題配列で学習を初期化（復習モード用） */
+  initWithQuestions: (questions: Question[]) => void;
+```
+
+フック本体で、既存 `init` と同様に状態を初期化する関数を追加（`buildStudyPool` を通さず受け取った配列をそのまま `setQuestions`）:
+
+```typescript
+  const initWithQuestions = useCallback((qs: Question[]) => {
+    setQuestions(qs);
+    setCurrentIndex(0);
+    setSelectedAnswer(null);
+    setAnswered(false);
+    setTagStats({});
+    setIncorrectQuestions([]);
+    setTotalCorrect(0);
+    setTotalAnswered(0);
+    setFinished(false);
+  }, []);
+```
+
+return オブジェクトに `initWithQuestions` を追加。
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `npm test -- useStudy.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Page に復習フローを結線**
+
+`pages/AgileQuizSugorokuPage.tsx` に以下を追加する。
+
+(a) リポジトリ生成（ファイル上部の他 repo 生成の隣、なければコンポーネント外）:
+
+```typescript
+import { WrongAnswerRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/wrong-answer-repository';
+import { BookmarkRepository } from '../features/agile-quiz-sugoroku/infrastructure/storage/bookmark-repository';
+import { buildReviewPool, ReviewSource } from '../features/agile-quiz-sugoroku/domain/quiz';
+import { ReviewSelectScreen } from '../features/agile-quiz-sugoroku/presentation/components/screens/ReviewSelectScreen';
+```
+
+> 注: 当ページの既存 import 形式（`index.ts` 経由か深いパスか）に合わせる。AQS は公開 API を `index.ts` に集約しているため、`ReviewSelectScreen`/`buildReviewPool`/各 Repository を `src/features/agile-quiz-sugoroku/index.ts` から re-export し、ページはそこから import するのが規約に沿う（Task 8 で index.ts 更新）。
+
+(b) ハンドラ:
+
+```typescript
+  const wrongRepo = useMemo(() => new WrongAnswerRepository(new LocalStorageAdapter()), []);
+  const bookmarkRepo = useMemo(() => new BookmarkRepository(new LocalStorageAdapter()), []);
+
+  const handleStartReview = useCallback((source: ReviewSource) => {
+    const pool = buildReviewPool({
+      source,
+      wrong: wrongRepo.loadAll(),
+      bookmarks: bookmarkRepo.loadAll(),
+      allByTag: {}, // タグ別は Task 7 のタグチップ経由で別途渡す
+    });
+    study.initWithQuestions(pool);
+    game.setPhase('review');
+  }, [study, game, wrongRepo, bookmarkRepo]);
+```
+
+(c) フェーズ分岐（`study-select` 分岐の近く）に追加:
+
+```tsx
+      {game.phase === 'review-select' && (
+        <ReviewSelectScreen
+          wrongCount={wrongRepo.loadAll().length}
+          bookmarkCount={bookmarkRepo.loadAll().length}
+          onSelectSource={handleStartReview}
+          onBack={() => game.setPhase('title')}
+        />
+      )}
+      {game.phase === 'review' && !study.finished && study.currentQuestion && (
+        /* StudyScreen を再利用。study-select→study と同じ props 構成に合わせる */
+        <StudyScreen /* 既存 study 画面と同じ props */ />
+      )}
+      {game.phase === 'review' && study.finished && (
+        <StudyResultScreen /* 既存 study 結果と同じ props。戻り先は title */ />
+      )}
+```
+
+> 注: `StudyScreen`/`StudyResultScreen` の props は既存 `study` フェーズの描画箇所（551・564 行付近）をコピーして合わせる。`review` は `study` とほぼ同一描画で、戻り先のみ `title` にする。
+
+(d) TitleButtons へ復習導線（`TitleNavigation` に `onReview?` を追加し、TitleScreen 経由で `() => game.setPhase('review-select')` を渡す）。`TitleButtons.tsx` の `TitleNavigation` に `onReview?: () => void;` を追加し、ボタンを 1 つ描画。
+
+- [ ] **Step 6: 型チェック + 関連テスト**
+
+Run: `npm run typecheck && npm test -- useStudy.test.ts review-select-screen.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/hooks/useStudy.ts \
+        src/features/agile-quiz-sugoroku/presentation/components/TitleButtons.tsx \
+        src/features/agile-quiz-sugoroku/pages/AgileQuizSugorokuPage.tsx \
+        src/features/agile-quiz-sugoroku/__tests__/useStudy.test.ts
+git commit -m "feat: AQS 復習モードの画面遷移を結線（useStudy 拡張 + Page/Title 導線）"
+```
+
+> ※ `pages/` は AQS feature 外の可能性あり。実体パスは `git status` で確認し、コミット対象に含める。
+
+---
+
+### Task 7: 誤答記録フック + ブックマークボタン + タグ別復習
+
+クイズ回答時に誤答を記録し、結果画面・クイズ画面でブックマークを切り替え、関連タグチップから「タグ別復習」を開始する。
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/presentation/hooks/useGame.ts` または回答評価箇所（誤答記録）
+- Modify: `src/features/agile-quiz-sugoroku/presentation/components/IncorrectReview.tsx`（ブックマークボタン + タグチップを `onTagClick` 付きに）
+- Test: `src/features/agile-quiz-sugoroku/__tests__/wrong-answer-recording.test.ts`
+
+> **調査メモ:** 回答の正誤確定箇所を特定する（`useGame.ts` の answer 処理、または `domain/quiz/answer-evaluator.ts` 呼び出し元）。誤答時に `wrongRepo.record(question, Date.now())`、正解時に `wrongRepo.remove(question)` を呼ぶ。`Date.now()` は呼び出し側（presentation）で取得して渡す（ドメインは時刻を持たない）。
+
+- [ ] **Step 1: 失敗するテストを書く（記録ロジックの単体化）**
+
+誤答記録は副作用を伴うため、純粋な「記録すべきか」の判定をドメイン関数に切り出してテストする。
+`src/features/agile-quiz-sugoroku/__tests__/wrong-answer-recording.test.ts`:
+
+```typescript
+import { WrongAnswerRepository } from '../infrastructure/storage/wrong-answer-repository';
+import { InMemoryStorageAdapter } from '../infrastructure/storage/in-memory-storage-adapter';
+import type { Question } from '../domain/types';
+
+const q: Question = { question: '記録対象', options: ['a','b','c','d'], answer: 0, tags: ['scrum'] };
+
+describe('誤答記録の振る舞い', () => {
+  it('誤答 record→正解 remove で誤答リストが空になる', () => {
+    const repo = new WrongAnswerRepository(new InMemoryStorageAdapter());
+    repo.record(q, 1000);
+    expect(repo.loadAll()).toHaveLength(1);
+    repo.remove(q);
+    expect(repo.loadAll()).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して確認**
+
+Run: `npm test -- wrong-answer-recording.test.ts`
+Expected: PASS（Task 2 の実装で既に通る。記録/除去の契約を固定する回帰テスト）
+
+- [ ] **Step 3: 回答評価箇所に誤答記録を結線**
+
+回答確定処理（`useGame.ts` の answer 系コールバック、またはクイズ画面の確定ハンドラ）に、`WrongAnswerRepository` をモジュールスコープで生成し:
+
+```typescript
+import { WrongAnswerRepository } from '../../infrastructure/storage/wrong-answer-repository';
+import { LocalStorageAdapter } from '../../infrastructure/storage/local-storage-adapter';
+const wrongRepo = new WrongAnswerRepository(new LocalStorageAdapter());
+```
+
+正誤確定時に:
+
+```typescript
+if (isCorrect) {
+  wrongRepo.remove(currentQuestion);
+} else {
+  wrongRepo.record(currentQuestion, Date.now());
+}
+```
+
+> 通常/チャレンジ/デイリーの各回答箇所に同様に差し込む（重複を避けるため、共通の `useQuizFeedback` 等があればそこに 1 箇所で実装）。
+
+- [ ] **Step 4: ブックマークボタンを IncorrectReview に追加**
+
+`IncorrectReview.tsx` の各問題ブロックに、`BookmarkRepository` を使ったトグルボタンを追加:
+
+```tsx
+<button
+  type="button"
+  aria-pressed={bookmarked}
+  aria-label={bookmarked ? 'ブックマーク解除' : 'ブックマークに追加'}
+  onClick={() => { bookmarkRepo.toggle(reconstructedQuestion, Date.now()); /* 再描画用 state 更新 */ }}
+  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: DESIGN_TOKENS.fontSize.md }}
+>
+  {bookmarked ? '★' : '☆'}
+</button>
+```
+
+> `IncorrectReview` が持つのは `AnswerResultWithDetail`（`questionText`/`options`/`tags` 等）。`Question` 形へ再構成（`{ question: q.questionText, options: q.options, answer: q.correctAnswer, tags: q.tags, explanation: q.explanation }`）してから repo に渡す。`bookmarked` 状態はマウント時に `bookmarkRepo.isBookmarked` で初期化し、ローカル state で管理。
+
+- [ ] **Step 5: タグ別復習を RelatedTags の onTagClick に結線**
+
+`IncorrectReview` の `<RelatedTags tags={q.tags} />`（Phase 2 Task 6 で追加）に `onTagClick` を渡し、Page 側で `allByTag` を構築して `buildReviewPool({ source: 'tag', tagId, ... })` → `study.initWithQuestions` → `review` フェーズへ。`allByTag` は全 `QUESTIONS` を走査してタグ→問題配列に集約するヘルパー（`domain/quiz` に `groupQuestionsByTag(QUESTIONS)` を追加してもよい）。
+
+> このステップは結線が深いので、最小実装として「結果画面のタグチップは表示のみ（onTagClick なし）」に留め、タグ別復習は復習選択画面の拡張として後続課題にしてもよい（YAGNI 判断可）。実装するかは実行時に判断し、しない場合は plan のこの Step を skip としてログに残す。
+
+- [ ] **Step 6: 回帰テスト + Lint**
+
+Run: `npm test -- IncorrectReview wrong-answer related-tags && npm run lint`
+Expected: PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add -A src/features/agile-quiz-sugoroku/
+git commit -m "feat: AQS 誤答自動記録とブックマーク機能を追加"
+```
+
+---
+
+### Task 8: 公開 API（index.ts）更新
+
+**Files:**
+- Modify: `src/features/agile-quiz-sugoroku/index.ts`
+
+- [ ] **Step 1: 新規シンボルを公開**
+
+`index.ts` に、ページから参照する新規シンボルを名前付きエクスポートで追加:
+
+```typescript
+export { ReviewSelectScreen } from './presentation/components/screens/ReviewSelectScreen';
+export { WrongAnswerRepository } from './infrastructure/storage/wrong-answer-repository';
+export { BookmarkRepository } from './infrastructure/storage/bookmark-repository';
+export { SettingsRepository } from './infrastructure/storage/settings-repository';
+export { buildReviewPool, makeQuestionKey } from './domain/quiz';
+export type { ReviewSource } from './domain/quiz';
+```
+
+> 既存のエクスポート様式（グルーピング・コメント）に合わせる。Page 側の import を `index.ts` 経由に統一し、深いインポート禁止ガード（`architecture.test.ts`）に適合させる。
+
+- [ ] **Step 2: 型チェック + アーキテクチャテスト**
+
+Run: `npm run typecheck && npm test -- architecture.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/index.ts
+git commit -m "feat: AQS 復習・設定関連シンボルを公開 API に追加"
+```
+
+---
+
+### Task 9: レスポンシブ / モバイル対応
+
+**Files:**
+- Modify: 主要画面コンポーネント（Title / Quiz / Result / Story）
+- Test: 視覚回帰は既存テストで担保（新規テスト不要）
+
+- [ ] **Step 1: 現状のブレークポイント方針を確認**
+
+Run:
+```bash
+cd src/features/agile-quiz-sugoroku
+grep -rn "@media" presentation/styles presentation/components | grep -v prefers-reduced-motion | head
+```
+Expected: 既存のビューポート系メディアクエリの有無と書式を把握。なければ新規にブレークポイント定数（例 480px）を `presentation/styles/design-tokens.ts` に追加:
+
+```typescript
+  /** ブレークポイント */
+  breakpoints: Object.freeze({
+    mobile: '480px',
+  }),
+```
+
+- [ ] **Step 2: TitleScreen をモバイル対応**
+
+ボタン群（`TitleButtons`）のタップ領域を最低 44px に。`@media (max-width: 480px)` でフォントサイズ・padding・ボタン折り返しを調整。`flex-wrap: wrap` は既存にあるため、はみ出しと文字潰れを中心に修正。
+
+- [ ] **Step 3: QuizScreen をモバイル対応**
+
+選択肢ボタンを縦積み・タップ領域 44px 以上に。すごろくボード（`SugorokuBoard`）の縮尺を `@media` で縮小。タイマー・スコアの配置崩れを修正。
+
+- [ ] **Step 4: ResultScreen / StoryScreen をモバイル対応**
+
+チャート類（`RadarChart`/`BarChart`/`LineChart`）の幅を `max-width: 100%` に。Story のテキストボックスを画面幅に追従させる。
+
+- [ ] **Step 5: 視覚回帰テスト + ビルド**
+
+Run: `npm test -- components.test.tsx phase1-components.test.tsx phase2-components.test.tsx && npm run build`
+Expected: PASS（DOM 不変のため通る。ビルドも成功）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/presentation/
+git commit -m "feat: AQS 主要画面のレスポンシブ/モバイル対応を追加"
+```
+
+---
+
+### Task 10: 視覚的洗練 + Phase 3 全体検証 + ドキュメント
+
+**Files:**
+- Modify: 各 presentation コンポーネント・styles
+- Modify: `src/features/agile-quiz-sugoroku/doc/game-design.md`, `doc/effects-and-ui.md`, `README.md`
+
+- [ ] **Step 1: 余白・タイポをトークンに統一（残り）**
+
+Phase 1 Task 6 で残したインライン style を `spacing`/`fontSize` トークンへ寄せる。grep で残箇所を確認:
+
+```bash
+cd src/features/agile-quiz-sugoroku
+grep -rln "style={{" presentation/components | xargs grep -L "DESIGN_TOKENS" 2>/dev/null
+```
+
+- [ ] **Step 2: ホバー/遷移マイクロインタラクションを磨く**
+
+`Button` 等の `:hover` に `transition: DESIGN_TOKENS.transition.fast` と軽い `transform`/`opacity` 変化を追加。`@media (prefers-reduced-motion: reduce)` で動きを無効化（既存方針を踏襲）。
+
+- [ ] **Step 3: 配色 60-30-10 点検**
+
+主要画面で背景(60)/サーフェス(30)/アクセント(10)の比率を点検し、アクセント過多な箇所をトーンダウン。コントラスト比 4.5:1 以上を確認（Phase 1 の a11y とあわせて）。
+
+- [ ] **Step 4: ドキュメント更新**
+
+- `doc/game-design.md`: モード一覧に「復習モード」追加、`GamePhase` 表に `review-select`/`review` 追加、サウンド設定を追記
+- `doc/effects-and-ui.md`: レスポンシブ方針・マイクロインタラクション方針を追記
+- `README.md`: モード一覧を更新
+
+- [ ] **Step 5: Phase 3 全体 CI**
+
+Run: `npm run ci`
+Expected: lint:ci → typecheck → test:coverage → build が全 PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/agile-quiz-sugoroku/
+git commit -m "feat: AQS 視覚的洗練（マイクロインタラクション/配色点検）とドキュメント更新"
+```
+
+---
+
+## Self-Review チェック（Phase 3）
+
+- **Spec coverage:** 3-A 復習モード（Task 1〜8）/ 3-B レスポンシブ（Task 9）/ 3-C 視覚的洗練（Task 10）を網羅 ✅
+- **型整合:** `ReviewEntry`（Task 2）→ `WrongAnswerRepository`/`BookmarkRepository`（Task 2,3）→ `buildReviewPool`（Task 4）→ Page 結線（Task 6）で型名・シグネチャ一貫 ✅。`ReviewSource` を ReviewSelectScreen/buildReviewPool/Page で統一 ✅。`makeQuestionKey`（Task 1）を両 Repository が使用 ✅
+- **同定キー設計:** spec 2.2（問題文ベース・スナップショット保持）に準拠 ✅
+- **プレースホルダ:** StudyScreen 再利用の props は「既存 study フェーズからコピー」と明示。深い結線（タグ別復習 Task7 Step5）は YAGNI 判断可と明記 ✅
+- **アーキテクチャ規約:** 新規シンボルを index.ts 公開（Task 8）、深いインポート禁止ガードに適合 ✅
+- **時刻の扱い:** `Date.now()` は presentation 側で取得しドメイン/repo に引数で渡す（ドメインは時刻非依存）✅

--- a/docs/superpowers/specs/2026-06-13-agile-quiz-sugoroku-enhancement-design.md
+++ b/docs/superpowers/specs/2026-06-13-agile-quiz-sugoroku-enhancement-design.md
@@ -1,0 +1,195 @@
+# Agile Quiz Sugoroku ブラッシュアップ 設計ドキュメント
+
+- 作成日: 2026-06-13
+- 対象: `src/features/agile-quiz-sugoroku/`
+- 種別: 機能追加・コンテンツ拡充・UI/UX 品質向上（挙動変更を含む）
+- 進め方: 3 領域を 1 spec に統合し、基盤 → コンテンツ → 機能・演出 の 3 フェーズで実装
+
+## 1. 背景と目的
+
+AQS は 2026-06 の構造統一リファクタリング（PR #105〜#110）で
+`domain / infrastructure / presentation` の 3 層構造が確立した。
+土台が整ったため、本 spec ではプロダクト価値の向上に取り組む。目的は 3 つ。
+
+1. **問題追加** — クイズコンテンツのタグ分布の偏りを是正し、学習価値と出題バランスを高める
+2. **機能ブラッシュアップ** — 学習ゲームとして不足している機能（復習・サウンド設定・アクセシビリティ・解説）を補う
+3. **UI/UX 品質向上** — デザイントークン統一・レスポンシブ・視覚的洗練・画面間の一貫性
+
+### 現状の課題（調査結果）
+
+- **タグ分布の偏り**: 全 366 問中、`testing` 79 / `scrum` 54 / `backlog` 48 に対し、
+  `design-patterns` 8 / `agile` 10 / `ci-cd` 11 / `data-structures` 14 / `estimation` 15 と下位タグが手薄
+  （※ `doc/quiz-content.md` には「306 問」とあり実データと乖離。本対応で更新する）
+- **復習導線の欠如**: 誤答は結果画面の `IncorrectReview` で表示されるのみ。再出題・ブックマークがない
+- **サウンド設定の欠如**: タイマーのティック音等があるが、ユーザーがミュートする UI がない
+  （`prefers-reduced-motion` は 7 コンポーネントで尊重済み）
+- **アクセシビリティが薄い**: 51 個の tsx 中 `aria-`/`role` 使用は 5 ファイルのみ
+- **インライン style の多用**: `DESIGN_TOKENS` が整備済みにもかかわらず `style={{...}}` 直書きが多く一貫性が崩れている
+- **レスポンシブが部分的**: `@media` 使用は 51 tsx 中 7 ファイルのみ
+
+## 2. 設計方針と前提
+
+### 2.1 既存パターンの踏襲
+
+- ストレージは `Repository + StoragePort` パターン（`HistoryRepository` 等）に揃える
+- 公開 API は `index.ts` の名前付きエクスポートのみ。新規シンボルもここから公開
+- 依存方向は `domain → なし` / `infrastructure → ports` / `presentation → domain・infrastructure` を厳守
+- `architecture.test.ts` の 4 ガード（ルート直下許可リスト・旧パス禁止・Page の深いインポート禁止・presentation 直下構造）を維持。新パスは許可リストへ追記
+
+### 2.2 重要な設計判断：問題の同定キー
+
+`Question` 型に `id` フィールドは存在しない（`question/options/answer/tags?/explanation?` のみ）。
+366 問への一括 `id` 付与は大規模・高リスクなため、**復習・ブックマークの永続化は問題文ベースの安定キーを採用する**。
+
+- 同定キー = 問題文文字列（`question`）。`makeQuestionKey(question: Question): string` をドメインに置き、将来差し替え可能にする
+- 永続データは「キー + 表示用メタ（問題文・選択肢・正解・タグ・解説）」のスナップショットを保持し、
+  問題データの後日改変に対しても表示が壊れないようにする（参照ではなくコピーで持つ）
+
+## 3. Phase 1：基盤（横断作業）
+
+後続フェーズが乗る土台を最初に固める。視覚的挙動は原則変えない（1-C のトグル追加を除く）。
+
+### 3.1 デザイントークン統一（1-A）
+
+- 対象: インライン `style={{...}}` 直書きで `DESIGN_TOKENS` を使っていないコンポーネント（`IncorrectReview` 他）
+- 方針: `spacing` / `borderRadius` / `fontSize` / `colors` / `transition` トークンへの参照に置換
+- styled-components への全面移行は**スコープ外**（YAGNI）。既存の混在スタイル様式は維持し、値だけトークンに寄せる
+- 完了基準: 対象コンポーネントのマジックナンバー（px・色リテラル）がトークン参照に置換され、視覚回帰がない
+
+### 3.2 アクセシビリティ強化（1-B）
+
+| 対象 | 対応 |
+|------|------|
+| 選択肢ボタン | `role="radiogroup"` / 各選択肢に `aria-label`、正誤確定後の状態を `aria-live="polite"` で通知 |
+| タイマー | 残り時間を `aria-live` で通知（毎秒ではなく区切り＝残り 10/5/0 秒等のみ。過剰読み上げ回避） |
+| スコア・コンボ | 更新を `aria-live="polite"` 領域で通知 |
+| フォーカス | `:focus-visible` でフォーカスリングを可視化。キーボード操作可能要素を網羅 |
+
+- WCAG 2.1 AA を目標。コントラスト比は視覚的洗練（3-C）の 60-30-10 点検とあわせて確認
+- 既存のキーボード操作（A/B/C/D・1/2/3/4・Enter/Space）の動作は維持
+
+### 3.3 サウンド設定（1-C）
+
+- **新規 `SettingsRepository`**（`infrastructure/storage/settings-repository.ts`）
+  - キー: `aqs_settings`、型: `{ soundEnabled: boolean }`（デフォルト `true`）
+  - `load()` / `save(settings)` / `setSoundEnabled(enabled)` を提供
+- **audio-port 層でゲート**: `soundEnabled=false` のとき発音をスキップ（既存 `silent-audio-adapter` の仕組みを活用、もしくは port 実装内で early return）
+- **UI**: タイトル画面にサウンド ON/OFF トグルを追加。状態は永続化し起動時に復元
+- 音量スライダーは**スコープ外**（ON/OFF のみ。Tone.js の音量制御は将来課題）
+
+## 4. Phase 2：コンテンツ
+
+### 4.1 問題追加（2-A）
+
+下位タグを底上げし、約 +79 問を追加する。各タグは対応する工程カテゴリのファイルへ投入。
+
+| タグ | 現状 | 目標 | 追加 | 投入先ファイル |
+|------|------|------|------|----------------|
+| design-patterns | 8 | 25 | +17 | impl1 / impl2 |
+| agile | 10 | 25 | +15 | planning |
+| ci-cd | 11 | 25 | +14 | test1 / test2 |
+| data-structures | 14 | 24 | +10 | impl1 / impl2 |
+| estimation | 15 | 24 | +9 | planning |
+| programming | 17 | 24 | +7 | impl1 / impl2 |
+| refactoring | 17 | 24 | +7 | refinement |
+
+- 既存 JSON フォーマット（`question` / `options`（4 択） / `answer`（0-3） / `tags` / `explanation`）に準拠
+- 工程とジャンルの対応（`doc/quiz-content.md`）を尊重して投入先を決める
+- 品質基準: 1 問 = 1 論点、選択肢は紛らわしすぎない、解説は「なぜ正解か」を含む
+- 完了基準: `questions.test.ts` の検証（配列・スキーマ・`answer` 範囲・タグ妥当性・重複チェック）を全通過
+
+### 4.2 解説の充実（2-B、関連タグ表示のみ）
+
+- 解説の下に、その問題の `tags` を**関連タグチップ**として表示（外部 URL は追加しない）
+- 表示箇所: 結果画面の `IncorrectReview`、勉強会モード、復習モード（3-A）
+- チップはクリックでそのタグの復習へ繋ぐ導線にする（3-A と接続。Phase 3 で結線）
+- 解説が 1 文のみで「なぜ」が弱い問題を 2〜4 文へ補強（データ修正。新規 +79 問および既存の手薄な解説が対象）
+- タグ表示名は既存 `TAG_MAP`（`tag-master.ts`）を使用
+
+## 5. Phase 3：機能・演出
+
+### 5.1 復習モード（3-A、新フィーチャー）
+
+学習ゲームとして最大の伸びしろ。誤答とブックマークを蓄積し、タイマーなしで再出題する。
+
+#### データ層
+
+- **新規 `WrongAnswerRepository`**（`aqs_wrong_answers`）
+  - 誤答問題のスナップショット（キー + 問題文・選択肢・正解・タグ・解説）を保存
+  - 回答評価フロー（クイズ・チャレンジ・デイリー）で誤答時に記録
+  - 正解で該当エントリを除去（克服の可視化）。上限件数を設け古いものから削除
+- **新規 `BookmarkRepository`**（`aqs_bookmarks`）
+  - 問題のブックマークをスナップショットで保存。トグルで追加・削除
+
+#### ドメイン層
+
+- `makeQuestionKey(question)` — 同定キー生成（2.2）
+- 復習対象の問題プールを組み立てるロジック（誤答 / ブックマーク / タグ別）。
+  既存の `study-question-pool.ts` の構造を参考に `review-question-pool.ts` を追加
+
+#### プレゼンテーション層
+
+- `GamePhase` に `'review-select' | 'review'` を追加
+- **復習選択画面**（`ReviewSelectScreen`）: 「誤答から復習」「ブックマークから復習」「タグ別復習」を選択
+- **復習画面**: タイマーなしで再出題し即時解説。勉強会モード（`StudyScreen` / `useStudy`）の仕組みを再利用
+- クイズ画面・結果画面に**ブックマークボタン**を追加
+- タイトル画面に復習モードへの入口を追加
+
+#### 状態遷移
+
+```
+title → review-select → review → (結果/タイトルへ戻る)
+```
+
+### 5.2 レスポンシブ / モバイル（3-B）
+
+- 対象: Title / Quiz / Result / Story を中心に主要画面
+- スマホ幅（〜480px）で検証し `@media` を追加。タップ領域 44px 以上、文字サイズとすごろくボード縮尺を調整
+- 既存の `@media (prefers-reduced-motion)` 群とは別軸（ビューポート幅）の追加
+
+### 5.3 視覚的洗練（3-C）
+
+- 配色の 60-30-10 ルール点検（背景 60 / サーフェス・主要 30 / アクセント 10）
+- 余白リズムを `spacing` トークンに統一（1-A の成果を活用）
+- ホバー・遷移のマイクロインタラクションを磨く。`prefers-reduced-motion` 尊重は維持
+- タイポグラフィスケールを `fontSize` トークンに揃える
+
+## 6. テスト・検証戦略
+
+### 6.1 TDD
+
+- 各 Repository（Settings / WrongAnswer / Bookmark）はテスト先行。`in-memory-storage-adapter` を用いた単体テスト
+- ドメインロジック（`makeQuestionKey`・`review-question-pool`）はテスト先行
+- 問題追加は `questions.test.ts` で保証（スキーマ・重複・タグ妥当性）
+- 新規コンポーネントは `@testing-library/react` でレンダリング・操作テスト
+
+### 6.2 ガードレール
+
+- `architecture.test.ts` の 4 ガードを維持。新規 presentation パスは許可リストへ追記
+- アクセシビリティは可能な範囲で `jest-axe` 相当の検証、または `getByRole` ベースのテストで担保
+
+### 6.3 各フェーズ完了時
+
+- `npm run ci`（lint:ci → typecheck → test:coverage → build）を全通過
+- カバレッジ目標: 新規コード 80%+、ドメインロジック 90%+
+
+### 6.4 PR 分割
+
+- フェーズ単位で 3 PR を想定（Phase 1 基盤 / Phase 2 コンテンツ / Phase 3 機能・演出）
+- 各 PR は単独で CI を通せる単位
+
+## 7. スコープ外（明示）
+
+- 問題への `id` フィールド一括付与（同定キーで代替）
+- styled-components への全面移行（値のトークン化に留める）
+- 音量スライダー（ON/OFF トグルのみ）
+- 解説への外部 URL・参考リンク追加（関連タグ表示のみ）
+- 上位タグ（testing/scrum 等）の問題削減・再分類
+- 新ゲームモードの追加（復習モードは既存学習モードの仕組みを再利用）
+
+## 8. ドキュメント更新
+
+- `doc/quiz-content.md`: 問題総数（306 → 実数）とカテゴリ別・タグ別問題数を更新
+- `doc/game-design.md`: 復習モード・サウンド設定を追記、`GamePhase` 表に新フェーズ追加
+- `doc/effects-and-ui.md`: デザイントークン統一・アクセシビリティ方針を追記
+- `README.md`: 必要に応じてモード一覧を更新

--- a/src/features/agile-quiz-sugoroku/__tests__/options-panel-a11y.test.tsx
+++ b/src/features/agile-quiz-sugoroku/__tests__/options-panel-a11y.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * OptionsPanel アクセシビリティテスト
+ * radiogroup ロール・radio ロール・aria-live フィードバックを検証する
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OptionsPanel } from '../presentation/components/screens/QuizScreen/OptionsPanel';
+import type { Question } from '../domain/types';
+
+/** テスト用クイズデータ */
+const mockQuiz: Question = {
+  question: 'スクラムマスターの主な役割は？',
+  options: ['プロジェクト管理', 'サーバント・リーダー', 'コード作成', '予算管理'],
+  answer: 1,
+};
+
+/** 選択肢の並び順（0〜3のインデックス） */
+const mockOptions = [0, 1, 2, 3];
+
+describe('OptionsPanel アクセシビリティ', () => {
+  it('選択肢グループが radiogroup ロールを持ち、選択肢が radio として公開される', () => {
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={null}
+        onAnswer={jest.fn()}
+      />
+    );
+    // radiogroup が存在すること
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    // 4つの radio ボタンが存在すること
+    expect(screen.getAllByRole('radio')).toHaveLength(4);
+  });
+
+  it('各 radio ボタンに aria-label が設定される', () => {
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={null}
+        onAnswer={jest.fn()}
+      />
+    );
+    // 選択肢 A: プロジェクト管理
+    expect(screen.getByRole('radio', { name: /選択肢 A: プロジェクト管理/ })).toBeInTheDocument();
+    // 選択肢 B: サーバント・リーダー
+    expect(screen.getByRole('radio', { name: /選択肢 B: サーバント・リーダー/ })).toBeInTheDocument();
+  });
+
+  it('未回答時は aria-checked がすべて false', () => {
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={null}
+        onAnswer={jest.fn()}
+      />
+    );
+    const radios = screen.getAllByRole('radio');
+    radios.forEach((radio) => {
+      expect(radio).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  it('回答選択後、選択した radio の aria-checked が true になる', () => {
+    // selectedAnswer=1 （インデックス1のオプション、options[1]=1）
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={1}
+        onAnswer={jest.fn()}
+      />
+    );
+    // options[1] = 1 なので、2番目の radio が選択状態
+    const radios = screen.getAllByRole('radio');
+    expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+    expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('正解を選択後、aria-live リージョンに「正解です」が表示される', () => {
+    // answer=1、selectedAnswer=1 → 正解
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={1}
+        onAnswer={jest.fn()}
+      />
+    );
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveTextContent('正解です');
+  });
+
+  it('不正解を選択後、aria-live リージョンに「不正解です」が表示される', () => {
+    // answer=1、selectedAnswer=0 → 不正解
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={0}
+        onAnswer={jest.fn()}
+      />
+    );
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveTextContent('不正解です');
+  });
+
+  it('未回答時、aria-live リージョンは空', () => {
+    render(
+      <OptionsPanel
+        quiz={mockQuiz}
+        options={mockOptions}
+        selectedAnswer={null}
+        onAnswer={jest.fn()}
+      />
+    );
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveTextContent('');
+  });
+});

--- a/src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts
+++ b/src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts
@@ -1,0 +1,43 @@
+/**
+ * サウンドのミュートゲートに関するテスト
+ */
+jest.mock('tone', () => ({
+  Synth: jest.fn().mockImplementation(() => ({
+    toDestination: jest.fn().mockReturnThis(),
+    triggerAttackRelease: jest.fn(),
+  })),
+  PolySynth: jest.fn().mockImplementation(() => ({
+    toDestination: jest.fn().mockReturnThis(),
+    triggerAttackRelease: jest.fn(),
+  })),
+  Loop: jest.fn().mockImplementation(() => ({
+    start: jest.fn().mockReturnThis(),
+    stop: jest.fn(),
+    dispose: jest.fn(),
+  })),
+  Transport: {
+    bpm: { value: 120 },
+    start: jest.fn(),
+    stop: jest.fn(),
+    cancel: jest.fn(),
+  },
+  start: jest.fn(),
+  now: jest.fn().mockReturnValue(0),
+}));
+
+import { setSoundEnabled, isSoundEnabled } from '../infrastructure/audio/sound';
+
+describe('sound mute gate', () => {
+  afterEach(() => setSoundEnabled(true)); // 後始末
+
+  it('デフォルトは有効', () => {
+    expect(isSoundEnabled()).toBe(true);
+  });
+
+  it('setSoundEnabled で状態を切り替えられる', () => {
+    setSoundEnabled(false);
+    expect(isSoundEnabled()).toBe(false);
+    setSoundEnabled(true);
+    expect(isSoundEnabled()).toBe(true);
+  });
+});

--- a/src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts
+++ b/src/features/agile-quiz-sugoroku/__tests__/sound-mute.test.ts
@@ -25,7 +25,8 @@ jest.mock('tone', () => ({
   now: jest.fn().mockReturnValue(0),
 }));
 
-import { setSoundEnabled, isSoundEnabled } from '../infrastructure/audio/sound';
+import * as Tone from 'tone';
+import { setSoundEnabled, isSoundEnabled, initAudio, playSfxCorrect } from '../infrastructure/audio/sound';
 
 describe('sound mute gate', () => {
   afterEach(() => setSoundEnabled(true)); // 後始末
@@ -39,5 +40,48 @@ describe('sound mute gate', () => {
     expect(isSoundEnabled()).toBe(false);
     setSoundEnabled(true);
     expect(isSoundEnabled()).toBe(true);
+  });
+
+  describe('ミュートゲートの実効性', () => {
+    // initAudio() はモジュールスコープの isAudioInitialized フラグにより 1 度しか実行されない。
+    // beforeAll で呼び出してシンセを生成しておき、各テストでモック呼び出し履歴をリセットする。
+    beforeAll(() => {
+      initAudio();
+    });
+
+    beforeEach(() => {
+      // Synth は initAudio 内で sfxSynth（results[0]）と tickSynth（results[1]）の順に生成される。
+      // mock.results[n].value が実際に返されたオブジェクト（toDestination 適用後の同一参照）。
+      const synthResults = (Tone.Synth as unknown as jest.Mock).mock.results;
+      synthResults.forEach((result) => {
+        if (result.type === 'return') {
+          (result.value.triggerAttackRelease as jest.Mock).mockClear();
+        }
+      });
+    });
+
+    it('ミュート中は playSfxCorrect が Synth.triggerAttackRelease を呼び出さない', () => {
+      // Arrange: ミュートを有効にする
+      setSoundEnabled(false);
+
+      // Act
+      playSfxCorrect();
+
+      // Assert: sfxSynth（Synth の 1 番目の返却値）が呼ばれていないこと
+      const sfxSynthMock = (Tone.Synth as unknown as jest.Mock).mock.results[0].value;
+      expect(sfxSynthMock.triggerAttackRelease).not.toHaveBeenCalled();
+    });
+
+    it('ミュート解除後は playSfxCorrect が Synth.triggerAttackRelease を呼び出す', () => {
+      // Arrange: サウンドを有効にする
+      setSoundEnabled(true);
+
+      // Act
+      playSfxCorrect();
+
+      // Assert: sfxSynth（Synth の 1 番目の返却値）が呼ばれていること
+      const sfxSynthMock = (Tone.Synth as unknown as jest.Mock).mock.results[0].value;
+      expect(sfxSynthMock.triggerAttackRelease).toHaveBeenCalled();
+    });
   });
 });

--- a/src/features/agile-quiz-sugoroku/__tests__/timer-a11y.test.tsx
+++ b/src/features/agile-quiz-sugoroku/__tests__/timer-a11y.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * TimerDisplay アクセシビリティテスト
+ * WCAG 2.1 AA: role="timer" + aria-live によるスクリーンリーダー通知
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TimerDisplay } from '../presentation/components/screens/QuizScreen/TimerDisplay';
+
+describe('TimerDisplay アクセシビリティ', () => {
+  it('残り時間が timer ロールと aria-live を持つ', () => {
+    render(<TimerDisplay timer={5} answered={false} />);
+    const timer = screen.getByRole('timer');
+    expect(timer).toHaveAttribute('aria-live');
+  });
+
+  it('回答済みの場合は何もレンダリングしない', () => {
+    const { container } = render(<TimerDisplay timer={5} answered={true} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('残り時間が閾値（5秒）のとき aria-live リージョンにテキストが表示される', () => {
+    render(<TimerDisplay timer={5} answered={false} />);
+    // SR 専用リージョンに「残り 5 秒」が含まれる
+    expect(screen.getByText('残り 5 秒')).toBeInTheDocument();
+  });
+
+  it('残り時間が非閾値のとき aria-live リージョンのテキストは空', () => {
+    render(<TimerDisplay timer={8} answered={false} />);
+    // 閾値外なので live text は空（timer ロール要素内の数値「8」は別途表示）
+    const timer = screen.getByRole('timer');
+    expect(timer).toBeInTheDocument();
+  });
+});

--- a/src/features/agile-quiz-sugoroku/__tests__/title-sound-toggle.test.tsx
+++ b/src/features/agile-quiz-sugoroku/__tests__/title-sound-toggle.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * TitleScreen サウンドトグル機能のテスト
+ *
+ * タイトル画面にサウンド ON/OFF ボタンが表示され、
+ * 押すたびに設定が反転して LocalStorage に永続化されることを検証する。
+ */
+
+// tone モジュールのモック（ESM パッケージのため Jest で変換できない）
+jest.mock('tone', () => ({
+  Synth: jest.fn().mockImplementation(() => ({
+    toDestination: jest.fn().mockReturnThis(),
+    triggerAttackRelease: jest.fn(),
+  })),
+  PolySynth: jest.fn().mockImplementation(() => ({
+    toDestination: jest.fn().mockReturnThis(),
+    triggerAttackRelease: jest.fn(),
+  })),
+  NoiseSynth: jest.fn().mockImplementation(() => ({
+    toDestination: jest.fn().mockReturnThis(),
+    triggerAttackRelease: jest.fn(),
+  })),
+  Loop: jest.fn().mockImplementation(() => ({
+    start: jest.fn().mockReturnThis(),
+    stop: jest.fn(),
+    dispose: jest.fn(),
+  })),
+  Transport: {
+    bpm: { value: 120 },
+    start: jest.fn(),
+    stop: jest.fn(),
+    cancel: jest.fn(),
+  },
+  start: jest.fn(),
+  now: jest.fn().mockReturnValue(0),
+}));
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TitleScreen } from '../presentation/components/screens/TitleScreen';
+import { SettingsRepository } from '../infrastructure/storage/settings-repository';
+import { LocalStorageAdapter } from '../infrastructure/storage/local-storage-adapter';
+
+/** TitleScreen を必須 props のみで描画するヘルパー */
+function renderTitle(overrides: Partial<React.ComponentProps<typeof TitleScreen>> = {}) {
+  return render(
+    <TitleScreen
+      onStart={jest.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('TitleScreen サウンドトグル', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('サウンドトグルボタンが表示される', () => {
+    renderTitle();
+    const toggle = screen.getByRole('button', { name: /サウンド/ });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it('サウンドトグルボタンを押すと設定が反転する（オン→オフ）', () => {
+    renderTitle();
+    const toggle = screen.getByRole('button', { name: /サウンド/ });
+    // 初期値は soundEnabled: true
+    fireEvent.click(toggle);
+    const repo = new SettingsRepository(new LocalStorageAdapter());
+    expect(repo.load().soundEnabled).toBe(false);
+  });
+
+  it('サウンドトグルボタンを2回押すと設定が元に戻る（オフ→オン）', () => {
+    renderTitle();
+    const toggle = screen.getByRole('button', { name: /サウンド/ });
+    fireEvent.click(toggle); // オン→オフ
+    fireEvent.click(toggle); // オフ→オン
+    const repo = new SettingsRepository(new LocalStorageAdapter());
+    expect(repo.load().soundEnabled).toBe(true);
+  });
+});

--- a/src/features/agile-quiz-sugoroku/doc/effects-and-ui.md
+++ b/src/features/agile-quiz-sugoroku/doc/effects-and-ui.md
@@ -50,3 +50,27 @@
 | total-correct-100 | 百問道場 | 累計100問正解 | Silver |
 | total-correct-500 | 知識の泉 | 累計500問正解 | Gold |
 | improving | 成長の証 | 過去3回の平均より正答率10%以上向上 | Silver |
+
+## Phase 1 追加機能
+
+### サウンド設定
+
+タイトル画面に「サウンド ON/OFF」トグルボタンを追加。設定は `SettingsRepository`（`infrastructure/settings-repository.ts`）が `localStorage` の `aqs_settings` キーに永続化し、起動時に `useGame` フックが読み込んで復元する。
+
+サウンドの有効/無効は `presentation/sounds/sound.ts` のミュートゲートで制御する。`setSoundEnabled(false)` を呼ぶと内部フラグがオフになり、以降すべての再生関数（SE・BGM）が呼び出しをスキップする。`isSoundEnabled()` で現在の状態を参照できる。
+
+### アクセシビリティ（a11y）
+
+クイズ選択肢のセマンティクスを強化した。
+
+- 選択肢コンテナに `role="radiogroup"`、各選択肢に `role="radio"` + `aria-checked` + `aria-label` を付与
+- 回答後に `aria-live` 領域で正解/不正解フィードバックをスクリーンリーダーに通知
+- タイマー表示に `role="timer"` を設定し、残り 10 秒・5 秒・0 秒の閾値でスクリーンリーダー向けの残り時間通知を行う
+- `Button` コンポーネントに `:focus-visible` フォーカスリングを追加（マウス操作では非表示、キーボード操作時のみ表示）
+- 視覚的に隠しつつスクリーンリーダーには読ませる共通スタイル `SR_ONLY_STYLE` を `presentation/styles/sr-only.ts` に定義。各コンポーネントで再利用する
+
+### デザイントークン統一
+
+インライン `style` に散在していた色・余白・角丸・フォントサイズの生値を `DESIGN_TOKENS`（`presentation/styles/design-tokens.ts` の `colors` / `spacing` / `borderRadius` / `fontSize`）へ置き換えた。
+
+置き換えの方針: トークン値と生値が 1:1 で一致するもののみ機械的に置換し、視覚的な変化はゼロに保つ。対応する値がないもの（中間サイズ等）は据え置きとし、段階的に移行する。

--- a/src/features/agile-quiz-sugoroku/doc/effects-and-ui.md
+++ b/src/features/agile-quiz-sugoroku/doc/effects-and-ui.md
@@ -55,9 +55,9 @@
 
 ### サウンド設定
 
-タイトル画面に「サウンド ON/OFF」トグルボタンを追加。設定は `SettingsRepository`（`infrastructure/settings-repository.ts`）が `localStorage` の `aqs_settings` キーに永続化し、起動時に `useGame` フックが読み込んで復元する。
+タイトル画面に「サウンド ON/OFF」トグルボタンを追加。設定は `SettingsRepository`（`infrastructure/storage/settings-repository.ts`）が `localStorage` の `aqs_settings` キーに永続化し、起動時に `useGame` フックが読み込んで復元する。
 
-サウンドの有効/無効は `presentation/sounds/sound.ts` のミュートゲートで制御する。`setSoundEnabled(false)` を呼ぶと内部フラグがオフになり、以降すべての再生関数（SE・BGM）が呼び出しをスキップする。`isSoundEnabled()` で現在の状態を参照できる。
+サウンドの有効/無効は `infrastructure/audio/sound.ts` のミュートゲートで制御する。`setSoundEnabled(false)` を呼ぶと内部フラグがオフになり、以降すべての再生関数（SE・BGM）が呼び出しをスキップする。`isSoundEnabled()` で現在の状態を参照できる。
 
 ### アクセシビリティ（a11y）
 
@@ -66,7 +66,7 @@
 - 選択肢コンテナに `role="radiogroup"`、各選択肢に `role="radio"` + `aria-checked` + `aria-label` を付与
 - 回答後に `aria-live` 領域で正解/不正解フィードバックをスクリーンリーダーに通知
 - タイマー表示に `role="timer"` を設定し、残り 10 秒・5 秒・0 秒の閾値でスクリーンリーダー向けの残り時間通知を行う
-- `Button` コンポーネントに `:focus-visible` フォーカスリングを追加（マウス操作では非表示、キーボード操作時のみ表示）
+- `Button` コンポーネントの `:focus-visible` フォーカスリング（`presentation/styles/common.ts` および `presentation/styles/quiz.ts` に既存定義）を Phase 1 の a11y 強化で活用・検証済み（マウス操作では非表示、キーボード操作時のみ表示）
 - 視覚的に隠しつつスクリーンリーダーには読ませる共通スタイル `SR_ONLY_STYLE` を `presentation/styles/sr-only.ts` に定義。各コンポーネントで再利用する
 
 ### デザイントークン統一

--- a/src/features/agile-quiz-sugoroku/domain/types/app-settings-types.ts
+++ b/src/features/agile-quiz-sugoroku/domain/types/app-settings-types.ts
@@ -1,0 +1,14 @@
+/**
+ * アプリ設定に関するドメイン型定義
+ */
+
+/** アプリ全体の設定 */
+export interface AppSettings {
+  /** 効果音・BGM を再生するか */
+  soundEnabled: boolean;
+}
+
+/** 設定のデフォルト値 */
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  soundEnabled: true,
+};

--- a/src/features/agile-quiz-sugoroku/domain/types/index.ts
+++ b/src/features/agile-quiz-sugoroku/domain/types/index.ts
@@ -52,3 +52,6 @@ export type {
   DifficultyConfig,
   ChallengeResult,
 } from './scoring-types';
+
+export type { AppSettings } from './app-settings-types';
+export { DEFAULT_APP_SETTINGS } from './app-settings-types';

--- a/src/features/agile-quiz-sugoroku/infrastructure/audio/sound.ts
+++ b/src/features/agile-quiz-sugoroku/infrastructure/audio/sound.ts
@@ -7,6 +7,22 @@ import * as Tone from 'tone';
 /** 音声システムの初期化状態 */
 let isAudioInitialized = false;
 
+/** サウンド全体の有効フラグ。false の間は全再生をスキップする */
+let soundEnabled = true;
+
+/** サウンドの有効/無効を設定する */
+export function setSoundEnabled(enabled: boolean): void {
+  soundEnabled = enabled;
+  if (!enabled) {
+    stopBgm();
+  }
+}
+
+/** サウンドが有効かどうかを返す */
+export function isSoundEnabled(): boolean {
+  return soundEnabled;
+}
+
 /** シンセサイザーインスタンス */
 let bgmSynth: Tone.PolySynth | null = null;
 let sfxSynth: Tone.Synth | null = null;
@@ -76,6 +92,7 @@ const BGM_NOTES: [string, string][] = [
  * BGMを再生開始
  */
 export function playBgm(): void {
+  if (!soundEnabled) return;
   if (!isAudioInitialized) return;
   stopBgm();
 
@@ -109,6 +126,7 @@ export function stopBgm(): void {
  * 正解効果音を再生
  */
 export function playSfxCorrect(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   sfxSynth.triggerAttackRelease('C5', '16n', time);
@@ -120,6 +138,7 @@ export function playSfxCorrect(): void {
  * 不正解効果音を再生
  */
 export function playSfxIncorrect(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   sfxSynth.triggerAttackRelease('C3', '8n', time);
@@ -130,6 +149,7 @@ export function playSfxIncorrect(): void {
  * タイマーティック音を再生
  */
 export function playSfxTick(): void {
+  if (!soundEnabled) return;
   if (tickSynth) {
     tickSynth.triggerAttackRelease('A5', '32n', Tone.now());
   }
@@ -139,6 +159,7 @@ export function playSfxTick(): void {
  * ゲーム開始効果音を再生
  */
 export function playSfxStart(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   sfxSynth.triggerAttackRelease('C4', '16n', time);
@@ -151,6 +172,7 @@ export function playSfxStart(): void {
  * 結果表示効果音を再生
  */
 export function playSfxResult(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   const notes = ['C4', 'E4', 'G4', 'C5', 'E5', 'G5'];
@@ -161,6 +183,7 @@ export function playSfxResult(): void {
 
 /** 実績獲得効果音 */
 export function playSfxAchievement(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   const notes = ['E5', 'G5', 'B5', 'E6'];
@@ -173,6 +196,7 @@ export function playSfxAchievement(): void {
  * コンボ効果音を再生
  */
 export function playSfxCombo(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   sfxSynth.triggerAttackRelease('E5', '16n', time);
@@ -185,6 +209,7 @@ export function playSfxCombo(): void {
  * 下降するトーンでコンボ途切れを演出
  */
 export function playSfxComboBreak(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   sfxSynth.triggerAttackRelease('E4', '16n', time);
@@ -202,6 +227,7 @@ const DRUMROLL_TICK_COUNT = 8;
  * 連続するティック音で緊張感を演出
  */
 export function playSfxDrumroll(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   for (let i = 0; i < DRUMROLL_TICK_COUNT; i++) {
@@ -219,6 +245,7 @@ const FANFARE_NOTE_INTERVAL = 0.1;
  * 上昇するアルペジオでSランク演出
  */
 export function playSfxFanfare(): void {
+  if (!soundEnabled) return;
   if (!sfxSynth) return;
   const time = Tone.now();
   FANFARE_NOTES.forEach((note, i) => {
@@ -238,6 +265,7 @@ const URGENT_THRESHOLD = 5;
  * 残り時間が少ないほど高い音になる
  */
 export function playSfxTickUrgent(remaining: number): void {
+  if (!soundEnabled) return;
   if (!tickSynth) return;
   const pitchBoost =
     remaining <= URGENT_THRESHOLD

--- a/src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/settings-repository.test.ts
+++ b/src/features/agile-quiz-sugoroku/infrastructure/storage/__tests__/settings-repository.test.ts
@@ -1,0 +1,24 @@
+import { SettingsRepository } from '../settings-repository';
+import { InMemoryStorageAdapter } from '../in-memory-storage-adapter';
+
+describe('SettingsRepository', () => {
+  it('デフォルトでは soundEnabled が true', () => {
+    const repo = new SettingsRepository(new InMemoryStorageAdapter());
+    expect(repo.load().soundEnabled).toBe(true);
+  });
+
+  it('soundEnabled を保存して読み込める', () => {
+    const storage = new InMemoryStorageAdapter();
+    const repo = new SettingsRepository(storage);
+    repo.setSoundEnabled(false);
+    expect(repo.load().soundEnabled).toBe(false);
+    expect(new SettingsRepository(storage).load().soundEnabled).toBe(false);
+  });
+
+  it('壊れたデータが入っていてもデフォルトに復帰する', () => {
+    const storage = new InMemoryStorageAdapter();
+    storage.set('aqs_settings', 'not-an-object');
+    const repo = new SettingsRepository(storage);
+    expect(repo.load().soundEnabled).toBe(true);
+  });
+});

--- a/src/features/agile-quiz-sugoroku/infrastructure/storage/settings-repository.ts
+++ b/src/features/agile-quiz-sugoroku/infrastructure/storage/settings-repository.ts
@@ -1,0 +1,38 @@
+/**
+ * 設定リポジトリ
+ *
+ * サウンド ON/OFF などのアプリ設定を永続化する。
+ */
+import { AppSettings, DEFAULT_APP_SETTINGS } from '../../domain/types';
+import { StoragePort } from './storage-port';
+
+const SETTINGS_KEY = 'aqs_settings';
+
+export class SettingsRepository {
+  constructor(private readonly storage: StoragePort) {}
+
+  /** 設定を読み込む（壊れている/未保存ならデフォルト） */
+  load(): AppSettings {
+    const data = this.storage.get<Partial<AppSettings>>(SETTINGS_KEY);
+    if (!data || typeof data !== 'object') {
+      return { ...DEFAULT_APP_SETTINGS };
+    }
+    return {
+      soundEnabled:
+        typeof data.soundEnabled === 'boolean'
+          ? data.soundEnabled
+          : DEFAULT_APP_SETTINGS.soundEnabled,
+    };
+  }
+
+  /** 設定を保存する */
+  save(settings: AppSettings): void {
+    this.storage.set(SETTINGS_KEY, settings);
+  }
+
+  /** soundEnabled だけ更新する */
+  setSoundEnabled(enabled: boolean): void {
+    const current = this.load();
+    this.save({ ...current, soundEnabled: enabled });
+  }
+}

--- a/src/features/agile-quiz-sugoroku/presentation/components/IncorrectReview.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/IncorrectReview.tsx
@@ -3,9 +3,9 @@
  */
 import React from 'react';
 import { AnswerResultWithDetail } from '../../domain/types';
-import { COLORS } from '../../constants';
 import { TAG_MAP } from '../../data/questions/tag-master';
 import { SectionBox, SectionTitle } from '../styles';
+import { DESIGN_TOKENS } from '../styles/design-tokens';
 
 interface IncorrectReviewProps {
   questions: AnswerResultWithDetail[];
@@ -24,22 +24,22 @@ export const IncorrectReview: React.FC<IncorrectReviewProps> = ({ questions }) =
             key={`${q.questionText.slice(0, 20)}-${i}`}
             style={{
               padding: '10px 12px',
-              background: `${COLORS.red}08`,
-              borderRadius: 8,
-              border: `1px solid ${COLORS.red}18`,
+              background: `${DESIGN_TOKENS.colors.danger}08`,
+              borderRadius: DESIGN_TOKENS.borderRadius.md,
+              border: `1px solid ${DESIGN_TOKENS.colors.danger}18`,
             }}
           >
-            <div style={{ fontSize: 12, color: COLORS.text, marginBottom: 6, lineHeight: 1.6 }}>
+            <div style={{ fontSize: DESIGN_TOKENS.fontSize.xs, color: DESIGN_TOKENS.colors.textPrimary, marginBottom: 6, lineHeight: 1.6 }}>
               {q.questionText}
             </div>
-            <div style={{ fontSize: 11, color: COLORS.red, marginBottom: 2 }}>
+            <div style={{ fontSize: 11, color: DESIGN_TOKENS.colors.danger, marginBottom: 2 }}>
               ✗ あなたの回答: {q.options[q.selectedAnswer] ?? 'TIME UP'}
             </div>
-            <div style={{ fontSize: 11, color: COLORS.green, marginBottom: 4 }}>
+            <div style={{ fontSize: 11, color: DESIGN_TOKENS.colors.secondary, marginBottom: 4 }}>
               ✓ 正解: {q.options[q.correctAnswer]}
             </div>
             {q.explanation && (
-              <div style={{ fontSize: 11, color: COLORS.muted, lineHeight: 1.6 }}>
+              <div style={{ fontSize: 11, color: DESIGN_TOKENS.colors.textMuted, lineHeight: 1.6 }}>
                 💡 {q.explanation}
               </div>
             )}
@@ -54,8 +54,8 @@ export const IncorrectReview: React.FC<IncorrectReviewProps> = ({ questions }) =
                         fontSize: 9,
                         padding: '1px 6px',
                         borderRadius: 3,
-                        background: `${tag?.color ?? COLORS.accent}15`,
-                        color: tag?.color ?? COLORS.accent,
+                        background: `${tag?.color ?? DESIGN_TOKENS.colors.primary}15`,
+                        color: tag?.color ?? DESIGN_TOKENS.colors.primary,
                       }}
                     >
                       {tag?.name ?? tagId}

--- a/src/features/agile-quiz-sugoroku/presentation/components/NarrativeComment.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/NarrativeComment.tsx
@@ -3,7 +3,7 @@
  * SprintStartScreen / RetrospectiveScreen で共用
  */
 import React from 'react';
-import { COLORS } from '../../constants';
+import { DESIGN_TOKENS } from '../styles/design-tokens';
 
 interface NarrativeCommentProps {
   /** キャラクター画像の URL */
@@ -22,9 +22,9 @@ export const NarrativeComment: React.FC<NarrativeCommentProps> = ({ characterIma
     gap: 10,
     padding: '10px 14px',
     marginBottom: 14,
-    background: `${COLORS.accent}08`,
-    borderRadius: 8,
-    border: `1px solid ${COLORS.accent}18`,
+    background: `${DESIGN_TOKENS.colors.primary}08`,
+    borderRadius: DESIGN_TOKENS.borderRadius.md,
+    border: `1px solid ${DESIGN_TOKENS.colors.primary}18`,
   }}>
     {characterImage ? (
       <img
@@ -33,7 +33,7 @@ export const NarrativeComment: React.FC<NarrativeCommentProps> = ({ characterIma
         style={{
           width: 40,
           height: 40,
-          borderRadius: '50%',
+          borderRadius: DESIGN_TOKENS.borderRadius.round,
           objectFit: 'cover',
           flexShrink: 0,
         }}
@@ -42,8 +42,8 @@ export const NarrativeComment: React.FC<NarrativeCommentProps> = ({ characterIma
       <div style={{
         width: 40,
         height: 40,
-        borderRadius: '50%',
-        background: `${COLORS.accent}15`,
+        borderRadius: DESIGN_TOKENS.borderRadius.round,
+        background: `${DESIGN_TOKENS.colors.primary}15`,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -54,8 +54,8 @@ export const NarrativeComment: React.FC<NarrativeCommentProps> = ({ characterIma
       </div>
     )}
     <div style={{
-      fontSize: 12,
-      color: COLORS.text,
+      fontSize: DESIGN_TOKENS.fontSize.xs,
+      color: DESIGN_TOKENS.colors.textPrimary,
       lineHeight: 1.5,
     }}>
       {text}

--- a/src/features/agile-quiz-sugoroku/presentation/components/SaveToast.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/SaveToast.tsx
@@ -2,7 +2,7 @@
  * 保存完了トーストコンポーネント
  */
 import React from 'react';
-import { COLORS } from '../../constants';
+import { DESIGN_TOKENS } from '../styles/design-tokens';
 
 interface SaveToastProps {
   visible: boolean;
@@ -15,13 +15,13 @@ export const SaveToast: React.FC<SaveToastProps> = ({ visible }) => {
   return (
     <div style={{
       position: 'fixed',
-      bottom: 24,
+      bottom: DESIGN_TOKENS.spacing.lg,
       left: '50%',
       transform: 'translateX(-50%)',
-      background: COLORS.green,
+      background: DESIGN_TOKENS.colors.secondary,
       color: '#fff',
       padding: '10px 24px',
-      borderRadius: 8,
+      borderRadius: DESIGN_TOKENS.borderRadius.md,
       fontSize: 13,
       fontWeight: 700,
       zIndex: 1000,

--- a/src/features/agile-quiz-sugoroku/presentation/components/TitleButtons.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/TitleButtons.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { COLORS } from '../../constants';
+import { DESIGN_TOKENS } from '../styles/design-tokens';
 import type { SaveState } from '../../domain/types';
 import { Button, HotkeyHint } from '../styles';
 
@@ -29,7 +30,7 @@ export const TitleButtons: React.FC<TitleButtonsProps> = ({
 }) => {
   const { onResume, onStudy, onGuide, onAchievements, onHistory, onChallenge, onDailyQuiz } = navigation;
   return (
-  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, marginTop: 4 }}>
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, marginTop: DESIGN_TOKENS.spacing.xs }}>
     {saveState && onResume && (
       <Button
         $color={COLORS.yellow}
@@ -48,7 +49,7 @@ export const TitleButtons: React.FC<TitleButtonsProps> = ({
       ▶ Sprint Start
       <HotkeyHint>[Enter]</HotkeyHint>
     </Button>
-    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+    <div style={{ display: 'flex', gap: DESIGN_TOKENS.spacing.sm, flexWrap: 'wrap', justifyContent: 'center' }}>
       {onChallenge && (
         <Button $color={COLORS.red} onClick={onChallenge} style={{ padding: '10px 32px', fontSize: 12 }}>
           Challenge
@@ -60,7 +61,7 @@ export const TitleButtons: React.FC<TitleButtonsProps> = ({
         </Button>
       )}
     </div>
-    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+    <div style={{ display: 'flex', gap: DESIGN_TOKENS.spacing.sm, flexWrap: 'wrap', justifyContent: 'center' }}>
       {onStudy && (
         <Button $color={COLORS.accent} onClick={onStudy} style={{ padding: '10px 20px', fontSize: 12 }}>
           勉強会モード

--- a/src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/OptionsPanel.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/OptionsPanel.tsx
@@ -12,6 +12,7 @@ import {
   OptionText,
   OptionIcon,
 } from '../../../styles';
+import { SR_ONLY_STYLE } from '../../../styles/sr-only';
 
 interface OptionsPanelProps {
   /** 問題データ */
@@ -23,16 +24,6 @@ interface OptionsPanelProps {
   /** 回答時のコールバック */
   onAnswer: (optionIndex: number) => void;
 }
-
-/** aria-live リージョンをビジュアル非表示にするスタイル（スクリーンリーダーには読まれる） */
-const srOnlyStyle: React.CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  overflow: 'hidden',
-  clip: 'rect(0 0 0 0)',
-  whiteSpace: 'nowrap',
-};
 
 /**
  * 選択肢パネル
@@ -56,7 +47,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
   return (
     <>
       {/* スクリーンリーダー向け回答フィードバック */}
-      <div role="status" aria-live="polite" style={srOnlyStyle}>
+      <div role="status" aria-live="polite" style={SR_ONLY_STYLE}>
         {feedbackMessage}
       </div>
       <OptionsContainer role="radiogroup" aria-label="回答の選択肢">

--- a/src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/OptionsPanel.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/OptionsPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * 選択肢パネルコンポーネント
- * 4つの選択肢ボタンを表示
+ * 4つの選択肢ボタンを表示し、スクリーンリーダー向けの ARIA セマンティクスを提供する
  */
 import React, { useState } from 'react';
 import type { Question } from '../../../../domain/types';
@@ -24,8 +24,19 @@ interface OptionsPanelProps {
   onAnswer: (optionIndex: number) => void;
 }
 
+/** aria-live リージョンをビジュアル非表示にするスタイル（スクリーンリーダーには読まれる） */
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};
+
 /**
  * 選択肢パネル
+ * WCAG 2.1 AA 準拠: radiogroup ロール・radio ロール・aria-live フィードバック
  */
 export const OptionsPanel: React.FC<OptionsPanelProps> = ({
   quiz,
@@ -35,39 +46,55 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 }) => {
   const [hoveredOption, setHoveredOption] = useState<number | null>(null);
   const answered = selectedAnswer !== null;
+  // 回答後のフィードバックメッセージ（aria-live リージョン用）
+  const feedbackMessage = (() => {
+    if (!answered) return '';
+    const isCorrect = selectedAnswer === quiz.answer;
+    return isCorrect ? '正解です' : '不正解です';
+  })();
 
   return (
-    <OptionsContainer>
-      {options.map((optionIndex, i) => {
-        const isCorrect = optionIndex === quiz.answer;
-        const isSelected = selectedAnswer !== null && selectedAnswer === optionIndex;
-        const hovered = hoveredOption === i;
+    <>
+      {/* スクリーンリーダー向け回答フィードバック */}
+      <div role="status" aria-live="polite" style={srOnlyStyle}>
+        {feedbackMessage}
+      </div>
+      <OptionsContainer role="radiogroup" aria-label="回答の選択肢">
+        {options.map((optionIndex, i) => {
+          const isCorrect = optionIndex === quiz.answer;
+          const isSelected = selectedAnswer !== null && selectedAnswer === optionIndex;
+          const hovered = hoveredOption === i;
+          const optionText = quiz.options[optionIndex];
 
-        return (
-          <OptionButton
-            key={optionIndex}
-            $answered={answered}
-            $isCorrect={isCorrect}
-            $isSelected={isSelected}
-            $hovered={hovered}
-            disabled={answered}
-            onClick={() => onAnswer(optionIndex)}
-            onMouseEnter={() => setHoveredOption(i)}
-            onMouseLeave={() => setHoveredOption(null)}
-          >
-            <OptionLabel
+          return (
+            <OptionButton
+              key={optionIndex}
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={`選択肢 ${OPTION_LABELS[i]}: ${optionText}`}
               $answered={answered}
               $isCorrect={isCorrect}
               $isSelected={isSelected}
+              $hovered={hovered}
+              disabled={answered}
+              onClick={() => onAnswer(optionIndex)}
+              onMouseEnter={() => setHoveredOption(i)}
+              onMouseLeave={() => setHoveredOption(null)}
             >
-              {OPTION_LABELS[i]}
-            </OptionLabel>
-            <OptionText>{quiz.options[optionIndex]}</OptionText>
-            {answered && isCorrect && <OptionIcon>✓</OptionIcon>}
-            {answered && isSelected && !isCorrect && <OptionIcon>✗</OptionIcon>}
-          </OptionButton>
-        );
-      })}
-    </OptionsContainer>
+              <OptionLabel
+                $answered={answered}
+                $isCorrect={isCorrect}
+                $isSelected={isSelected}
+              >
+                {OPTION_LABELS[i]}
+              </OptionLabel>
+              <OptionText>{optionText}</OptionText>
+              {answered && isCorrect && <OptionIcon>✓</OptionIcon>}
+              {answered && isSelected && !isCorrect && <OptionIcon>✗</OptionIcon>}
+            </OptionButton>
+          );
+        })}
+      </OptionsContainer>
+    </>
   );
 };

--- a/src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/TimerDisplay.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/screens/QuizScreen/TimerDisplay.tsx
@@ -1,6 +1,7 @@
 /**
  * タイマー表示コンポーネント
  * 残り時間バーとカウントダウン数値を表示
+ * WCAG 2.1 AA: role="timer" + aria-live で残り時間を AT に伝える
  */
 import React from 'react';
 import { CONFIG, COLORS } from '../../../../constants';
@@ -10,6 +11,7 @@ import {
   TimerBar,
   TimerProgress,
 } from '../../../styles';
+import { SR_ONLY_STYLE } from '../../../styles/sr-only';
 
 interface TimerDisplayProps {
   /** 残り時間（秒） */
@@ -27,12 +29,24 @@ function getTimerColor(timer: number): string {
 }
 
 /**
+ * 閾値（10秒・5秒・0秒）のときのみ読み上げテキストを生成する。
+ * 毎秒アナウンスすると AT ユーザーに過負荷をかけるため、重要な節目のみ通知。
+ */
+function getLiveText(timer: number): string {
+  if (timer === 10 || timer === 5 || timer === 0) {
+    return `残り ${timer} 秒`;
+  }
+  return '';
+}
+
+/**
  * タイマー表示（回答前のみ表示）
  */
 export const TimerDisplay: React.FC<TimerDisplayProps> = ({ timer, answered }) => {
   if (answered) return null;
 
   const timerColor = getTimerColor(timer);
+  const liveText = getLiveText(timer);
 
   return (
     <>
@@ -51,8 +65,17 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({ timer, answered }) =
         />
       )}
 
+      {/* スクリーンリーダー向け閾値通知（過度な読み上げを避けるため節目のみ） */}
+      <div aria-live="polite" style={SR_ONLY_STYLE}>
+        {liveText}
+      </div>
+
       <TimerContainer>
         <TimerValue
+          role="timer"
+          aria-live="off"
+          aria-atomic="true"
+          aria-label={`残り ${timer} 秒`}
           $color={timerColor}
           $pulse={timer <= 5 && timer > 0}
           $shake={timer <= 3 && timer > 0}

--- a/src/features/agile-quiz-sugoroku/presentation/components/screens/TitleScreen.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/screens/TitleScreen.tsx
@@ -1,13 +1,16 @@
 /**
  * タイトル画面コンポーネント
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useKeys } from '../../hooks';
 import { CONFIG, COLORS, FONTS } from '../../../constants';
 import { AQS_IMAGES } from '../../../data/images';
 import { GameResultRepository } from '../../../infrastructure/storage/game-repository';
 import { SaveRepository } from '../../../infrastructure/storage/save-repository';
+import { SettingsRepository } from '../../../infrastructure/storage/settings-repository';
 import { LocalStorageAdapter } from '../../../infrastructure/storage/local-storage-adapter';
+import { setSoundEnabled } from '../../../infrastructure/audio/sound';
+import { DESIGN_TOKENS } from '../../styles/design-tokens';
 import type { SaveState, Difficulty } from '../../../domain/types';
 import { ParticleEffect } from '../ParticleEffect';
 import { DifficultySelector } from '../DifficultySelector';
@@ -29,6 +32,7 @@ import {
 
 const gameResultRepo = new GameResultRepository(new LocalStorageAdapter());
 const saveRepo = new SaveRepository(new LocalStorageAdapter());
+const settingsRepo = new SettingsRepository(new LocalStorageAdapter());
 
 interface TitleScreenProps {
   onStart: (sprintCount: number, difficulty?: string) => void;
@@ -63,10 +67,20 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
   const [sprintCount, setSprintCount] = useState<number>(CONFIG.sprintCount);
   const [difficulty, setDifficulty] = useState<Difficulty>('normal');
   const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
+  /** サウンド有効フラグ（保存済み設定から初期化） */
+  const [soundOn, setSoundOn] = useState<boolean>(() => settingsRepo.load().soundEnabled);
 
   const lastResult = useMemo(() => gameResultRepo.load(), []);
   const saveState = useMemo(() => saveRepo.load(), []);
   const features = useMemo(() => makeFeatures(sprintCount), [sprintCount]);
+
+  /** サウンドの ON/OFF を切り替えて永続化する */
+  const handleToggleSound = useCallback(() => {
+    const next = !soundOn;
+    setSoundOn(next);
+    settingsRepo.setSoundEnabled(next);
+    setSoundEnabled(next);
+  }, [soundOn]);
 
   const handleResume = () => {
     if (saveState && onResume) {
@@ -169,6 +183,27 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
             onDailyQuiz,
           }}
         />
+
+        {/* サウンド ON/OFF トグル */}
+        <div style={{ textAlign: 'center', marginTop: DESIGN_TOKENS.spacing.md }}>
+          <button
+            type="button"
+            onClick={handleToggleSound}
+            aria-pressed={soundOn}
+            aria-label={`サウンド ${soundOn ? 'オン' : 'オフ'}`}
+            style={{
+              background: 'transparent',
+              border: `1px solid ${DESIGN_TOKENS.colors.textMuted}`,
+              borderRadius: DESIGN_TOKENS.borderRadius.md,
+              color: DESIGN_TOKENS.colors.textPrimary,
+              padding: `${DESIGN_TOKENS.spacing.xs} ${DESIGN_TOKENS.spacing.md}`,
+              cursor: 'pointer',
+              fontSize: DESIGN_TOKENS.fontSize.sm,
+            }}
+          >
+            {soundOn ? '🔊 サウンド: オン' : '🔇 サウンド: オフ'}
+          </button>
+        </div>
 
         {showOverwriteConfirm && (
           <OverwriteConfirmDialog

--- a/src/features/agile-quiz-sugoroku/presentation/components/screens/TitleScreen.tsx
+++ b/src/features/agile-quiz-sugoroku/presentation/components/screens/TitleScreen.tsx
@@ -68,7 +68,7 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
   const [difficulty, setDifficulty] = useState<Difficulty>('normal');
   const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
   /** サウンド有効フラグ（保存済み設定から初期化） */
-  const [soundOn, setSoundOn] = useState<boolean>(() => settingsRepo.load().soundEnabled);
+  const [isSoundOn, setIsSoundOn] = useState<boolean>(() => settingsRepo.load().soundEnabled);
 
   const lastResult = useMemo(() => gameResultRepo.load(), []);
   const saveState = useMemo(() => saveRepo.load(), []);
@@ -76,11 +76,11 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
 
   /** サウンドの ON/OFF を切り替えて永続化する */
   const handleToggleSound = useCallback(() => {
-    const next = !soundOn;
-    setSoundOn(next);
+    const next = !isSoundOn;
+    setIsSoundOn(next);
     settingsRepo.setSoundEnabled(next);
     setSoundEnabled(next);
-  }, [soundOn]);
+  }, [isSoundOn]);
 
   const handleResume = () => {
     if (saveState && onResume) {
@@ -189,8 +189,8 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
           <button
             type="button"
             onClick={handleToggleSound}
-            aria-pressed={soundOn}
-            aria-label={`サウンド ${soundOn ? 'オン' : 'オフ'}`}
+            aria-pressed={isSoundOn}
+            aria-label={`サウンド ${isSoundOn ? 'オン' : 'オフ'}`}
             style={{
               background: 'transparent',
               border: `1px solid ${DESIGN_TOKENS.colors.textMuted}`,
@@ -201,7 +201,7 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
               fontSize: DESIGN_TOKENS.fontSize.sm,
             }}
           >
-            {soundOn ? '🔊 サウンド: オン' : '🔇 サウンド: オフ'}
+            {isSoundOn ? '🔊 サウンド: オン' : '🔇 サウンド: オフ'}
           </button>
         </div>
 

--- a/src/features/agile-quiz-sugoroku/presentation/hooks/useGame.ts
+++ b/src/features/agile-quiz-sugoroku/presentation/hooks/useGame.ts
@@ -24,6 +24,9 @@ import { createEvents, createSprintSummary } from '../../domain/game';
 import { QUESTIONS } from '../../data/questions';
 import { gameReducer, createInitialGameState } from './useGameReducer';
 
+/** 設定リポジトリ（モジュールスコープシングルトン） */
+const settingsRepo = new SettingsRepository(new LocalStorageAdapter());
+
 export interface UseGameReturn {
   /** 現在のフェーズ */
   phase: GamePhase;
@@ -117,7 +120,7 @@ export function useGame(audio?: AudioActions): UseGameReturn {
 
   // マウント時に保存済みサウンド設定を音声システムに反映する
   useEffect(() => {
-    const settings = new SettingsRepository(new LocalStorageAdapter()).load();
+    const settings = settingsRepo.load();
     setSoundEnabled(settings.soundEnabled);
   }, []);
 

--- a/src/features/agile-quiz-sugoroku/presentation/hooks/useGame.ts
+++ b/src/features/agile-quiz-sugoroku/presentation/hooks/useGame.ts
@@ -15,6 +15,9 @@ import type {
   SaveState,
 } from '../../domain/types';
 import { AudioActions, createDefaultAudioActions } from '../../infrastructure/audio/audio-actions';
+import { SettingsRepository } from '../../infrastructure/storage/settings-repository';
+import { LocalStorageAdapter } from '../../infrastructure/storage/local-storage-adapter';
+import { setSoundEnabled } from '../../infrastructure/audio/sound';
 import { shuffle, average, percentage, clamp } from '../../../../utils/math-utils';
 import { pickQuestion } from '../../domain/quiz';
 import { createEvents, createSprintSummary } from '../../domain/game';
@@ -111,6 +114,12 @@ export function useGame(audio?: AudioActions): UseGameReturn {
   useEffect(() => {
     if (audio) sfxRef.current = audio;
   }, [audio]);
+
+  // マウント時に保存済みサウンド設定を音声システムに反映する
+  useEffect(() => {
+    const settings = new SettingsRepository(new LocalStorageAdapter()).load();
+    setSoundEnabled(settings.soundEnabled);
+  }, []);
 
   const [state, dispatch] = useReducer(gameReducer, undefined, createInitialGameState);
 

--- a/src/features/agile-quiz-sugoroku/presentation/styles/sr-only.ts
+++ b/src/features/agile-quiz-sugoroku/presentation/styles/sr-only.ts
@@ -1,0 +1,19 @@
+/**
+ * スクリーンリーダー専用（視覚的に隠す）スタイル。
+ * aria-live 等のテキストを視覚に出さず AT にのみ伝えるために使う。
+ */
+import type { CSSProperties } from 'react';
+
+/** 視覚的に隠しつつスクリーンリーダーには読ませる標準パターン */
+export const SR_ONLY_STYLE: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};


### PR DESCRIPTION
## 概要

Agile Quiz Sugoroku のブラッシュアップ（問題追加・機能・UI/UX を 3 フェーズに分割）の **Phase 1（基盤）** です。後続フェーズが乗る横断的な土台（サウンド設定・アクセシビリティ・デザイントークン統一）を整えます。設計書・全フェーズの実装計画も同梱しています。

- 設計: `docs/superpowers/specs/2026-06-13-agile-quiz-sugoroku-enhancement-design.md`
- 計画: `docs/superpowers/plans/2026-06-13-aqs-enhancement-phase{1,2,3}-*.md`

## 変更内容

### サウンド設定
- `SettingsRepository`（`aqs_settings`）でサウンド ON/OFF を永続化
- `sound.ts` にミュートゲート（`setSoundEnabled`/`isSoundEnabled`、全12再生関数で無効時スキップ）
- タイトル画面に ON/OFF トグル、`useGame` で起動時に復元（永続→復元→ライブ切替→実ミュートまで一気通貫）

### アクセシビリティ
- クイズ選択肢: `role="radiogroup"`/`role="radio"`/`aria-checked`/`aria-label` + 回答後の `aria-live` フィードバック
- タイマー: `role="timer"` + 閾値（10/5/0秒）通知で過剰読み上げを抑止
- 共通 `SR_ONLY_STYLE`（`presentation/styles/sr-only.ts`）、`Button` の `:focus-visible` 活用

### デザイントークン統一
- 4コンポーネントのインライン style を `DESIGN_TOKENS` へ寄せる（値を 1:1 照合し視覚不変を担保）
- ブール変数の命名規約修正（`soundOn` → `isSoundOn`）

## テスト方法

- [x] `npm run ci`（lint:ci → typecheck → test → build）全ステージ green
- [x] 各タスクで仕様適合レビュー + コード品質レビューの 2 段階レビューを通過
- [x] ミュートゲートの実効果テスト（無効時に Tone.js が呼ばれないこと）を追加
- [ ] E2E（Playwright）はローカル実行不可のため CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)