### PR TITLE
chore: CI を全 PR で実行するよう pull_request トリガーを緩和

### DIFF
--- a/.github/__tests__/ci-workflow.test.ts
+++ b/.github/__tests__/ci-workflow.test.ts
@@ -23,7 +23,8 @@ interface WorkflowJob {
 interface Workflow {
   name: string;
   on: {
-    pull_request: { branches: string[] };
+    // base を限定しない場合 YAML 上は null になる
+    pull_request: { branches?: string[] } | null;
     push: { branches: string[] };
   };
   concurrency: {
@@ -56,8 +57,10 @@ describe('CI ワークフロー', () => {
   });
 
   describe('トリガー設定', () => {
-    it('main ブランチへの pull_request でトリガーされること', () => {
-      expect(workflow.on.pull_request.branches).toContain('main');
+    it('全 PR で pull_request トリガーされること（base を限定しない＝スタック PR でも CI が走る）', () => {
+      // pull_request キーが存在し、branches による base 限定がないことを確認
+      expect(Object.prototype.hasOwnProperty.call(workflow.on, 'pull_request')).toBe(true);
+      expect(workflow.on.pull_request?.branches).toBeUndefined();
     });
 
     it('main ブランチへの push でトリガーされること', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
+  # スタック PR（base が main 以外の PR）でも必須チェックが走るよう、
+  # pull_request では base ブランチを限定しない。push は main のみ。
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
## 概要

スタック PR で CI が走らずマージがブロックされる問題の恒久対策です。

## 背景

main のルールセット `main-protection` は `Lint / TypeCheck / Test / Build` の合格を必須にしていますが、`ci.yml` の `pull_request` トリガーが `branches: [main]` に限定されていました。そのため **base が main 以外のスタック PR では CI が一度も走らず**、必須チェックが付かないため `BLOCKED`（マージ不可）になっていました（例: #112）。また base 自動付け替え（`edited` イベント）では CI が再トリガーされません。

## 変更内容

- `on.pull_request` から `branches: [main]` を削除し、**base に関わらず全 PR で CI を実行**
- `push` は従来どおり `main` のみ

## 影響

- 今後はスタック PR でも作成・更新時に CI が走り、必須チェックが付与される
- 既存の open PR（#112/#113）は本 PR とは別に、close→reopen 等で CI を再起動する必要あり（base が main になった後）

## テスト方法

- [x] 本 PR 自体で CI（Lint/TypeCheck/Test/Build）が実行される
- [ ] マージ後、base が main 以外の新規 PR で CI が走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)