### PR TITLE
refactor: KEYS & ARMS 入力処理の DRY 解消と GOD MODE バグ修正

### DIFF
--- a/docs/superpowers/plans/2026-06-14-keys-and-arms-input-dry.md
+++ b/docs/superpowers/plans/2026-06-14-keys-and-arms-input-dry.md
@@ -1,0 +1,621 @@
+# KEYS & ARMS 入力処理 DRY 解消 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 入力処理の DRY 負債（アクションキー二重定義・`gameTick` 重複）を解消し、その単一定義を使って `z` 開始で GOD MODE が発動しない既存バグを根治する。
+
+**Architecture:** (A) `ACTION_KEYS`/`isActionKey` を `core/input.ts` の単一定義にする。(B) `gameTick` を `core/game-tick.ts` に、トランジション前進を `core/transition.ts` に抽出し、`engine.ts` と `test-engine.ts` が共有する（render タイミングは温存＝振る舞い不変）。(C) cheat 蓄積ループで `isActionKey` を使い `z` を除外する（GOD MODE が z/space/Enter で一律発動）。
+
+**Tech Stack:** TypeScript, React 19, Jest 30 (SWC)。型: `npm run typecheck` / テスト: `npm test -- keys-and-arms` / 全体: `npm run ci`。
+
+**作業ディレクトリ:** `src/features/keys-and-arms/`（以下、パスはこのディレクトリ起点。ブランチ `refactor/keys-and-arms-input-dry` で作業、新規ブランチは作らない）
+
+**設計書:** `docs/superpowers/specs/2026-06-14-keys-and-arms-input-dry-refactoring-design.md`
+
+> **方針:** A・B は振る舞い不変（既存テストが安全網）。C のみ意図的な挙動変更（z 開始 GOD MODE）。
+> 各タスクで `npm run typecheck` + `npm test -- keys-and-arms` をグリーンにしてからコミットする。
+
+---
+
+## Task 1: (A) アクションキーの単一定義
+
+**Files:**
+- Modify: `core/input.ts`
+- Test: `__tests__/core/input.test.ts`
+
+- [ ] **Step 1: テストを追加（失敗する）**
+
+`__tests__/core/input.test.ts` の末尾（最後の `});` の前のトップレベル）に以下の describe を追加:
+
+```ts
+import { ACTION_KEYS, isActionKey, createInputHandler } from '../../core/input';
+
+describe('ACTION_KEYS / isActionKey', () => {
+  it('アクションキーは z と space', () => {
+    expect([...ACTION_KEYS]).toEqual(['z', ' ']);
+  });
+
+  it('isActionKey は z / space を true、それ以外を false にする', () => {
+    expect(isActionKey('z')).toBe(true);
+    expect(isActionKey('Z')).toBe(true); // 大文字も
+    expect(isActionKey(' ')).toBe(true);
+    expect(isActionKey('a')).toBe(false);
+    expect(isActionKey('enter')).toBe(false);
+  });
+
+  it('isAction は z または space の justPressed で true', () => {
+    const h = createInputHandler();
+    expect(h.isAction()).toBe(false);
+    h.handleKeyDown('z');
+    expect(h.isAction()).toBe(true);
+  });
+});
+```
+
+> 注: `__tests__/core/input.test.ts` の既存 import に `createInputHandler` が含まれていれば重複 import にならないよう調整する（既存行に統合）。
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `npx jest input.test -t "ACTION_KEYS"`
+Expected: FAIL（`ACTION_KEYS` / `isActionKey` が未エクスポート）
+
+- [ ] **Step 3: input.ts に単一定義を追加し、isAction/jAct を委譲**
+
+Modify `core/input.ts`。ファイル冒頭（`export interface InputHandler` の前）に追加:
+
+```ts
+/** アクションキー（拾う・攻撃・設置・開始などに使う）の唯一の定義 */
+export const ACTION_KEYS = ['z', ' '] as const;
+
+/** 指定キーがアクションキーかどうか */
+export function isActionKey(key: string): boolean {
+  return (ACTION_KEYS as readonly string[]).includes(key.toLowerCase());
+}
+```
+
+`isAction()`（現状 `return justPressed('z') || justPressed(' ');`）を変更:
+
+```ts
+  function isAction(): boolean {
+    return ACTION_KEYS.some((k) => justPressed(k));
+  }
+```
+
+`createInputHelpers` 内の `jAct`（現状 `return J('z') || J(' ');`）を変更:
+
+```ts
+  function jAct(): boolean { return ACTION_KEYS.some((k) => J(k)); }
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+Run: `npx jest input.test`
+Expected: PASS
+
+- [ ] **Step 5: 全体の型・テスト確認**
+
+Run: `npm run typecheck && npm test -- keys-and-arms`
+Expected: PASS（振る舞い不変。判定対象は従来どおり z/space）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/keys-and-arms/core/input.ts src/features/keys-and-arms/__tests__/core/input.test.ts
+git commit -m "refactor: KEYS & ARMS のアクションキー定義を単一化
+
+- ACTION_KEYS / isActionKey を core/input.ts の唯一の定義にする
+- isAction / jAct の重複した z/space 判定を ACTION_KEYS 参照に統一
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: (B-2) トランジション前進を core/transition.ts に抽出
+
+**Files:**
+- Create: `core/transition.ts`
+- Modify: `core/hud.ts`
+- Test: `__tests__/core/transition.test.ts`
+
+- [ ] **Step 1: 失敗するテストを追加**
+
+Create `__tests__/core/transition.test.ts`:
+
+```ts
+import { advanceTransition } from '../../core/transition';
+import { TRANSITION_TOTAL, TRANSITION_MID } from '../../constants';
+import { createTestEngine } from '../helpers/test-engine';
+
+describe('advanceTransition', () => {
+  it('残りカウントを1減らす', () => {
+    const G = createTestEngine().G;
+    G.transition = { t: TRANSITION_TOTAL, txt: '', fn: undefined, sub: '' };
+    advanceTransition(G);
+    expect(G.transition.t).toBe(TRANSITION_TOTAL - 1);
+  });
+
+  it('中点で登録コールバックを1回だけ実行する', () => {
+    const G = createTestEngine().G;
+    let calls = 0;
+    G.transition = { t: TRANSITION_MID + 1, txt: '', fn: () => { calls++; }, sub: '' };
+    advanceTransition(G); // t: MID+1 -> MID（中点でコールバック発火）
+    expect(G.transition.t).toBe(TRANSITION_MID);
+    expect(calls).toBe(1);
+    advanceTransition(G); // t: MID -> MID-1（発火しない）
+    expect(calls).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `npx jest transition.test`
+Expected: FAIL（`core/transition` が存在しない）
+
+- [ ] **Step 3: core/transition.ts を作成**
+
+Create `core/transition.ts`:
+
+```ts
+/**
+ * KEYS & ARMS — 画面トランジションの状態前進
+ *
+ * 残りカウントを進め、中点で登録コールバック（次ステージ init 等）を実行する。
+ * 注: 本番では描画関数 drawTrans（render 経由・約60Hz）から呼ばれる。
+ *     呼び出しタイミングは変更しないため、ここでは状態前進のみを担う。
+ */
+import type { GameState } from '../types';
+import { TRANSITION_MID } from '../constants';
+
+/** トランジションの状態を1ステップ進める */
+export function advanceTransition(G: GameState): void {
+  G.transition.t--;
+  if (G.transition.t === TRANSITION_MID && G.transition.fn) G.transition.fn();
+}
+```
+
+- [ ] **Step 4: hud.ts の drawTrans を共有ヘルパー利用に変更**
+
+Modify `core/hud.ts`。冒頭の import に追加:
+
+```ts
+import { advanceTransition } from './transition';
+```
+
+`drawTrans()` の以下2行:
+
+```ts
+    G.transition.t--;
+    if (G.transition.t === TRANSITION_MID && G.transition.fn) G.transition.fn();
+```
+
+を1行に置換:
+
+```ts
+    advanceTransition(G);
+```
+
+（`if (G.transition.t <= 0) return false;` ガードは残す。以降の `const p = ...` 描画ロジックは不変。）
+
+`TRANSITION_MID` が hud.ts 内で他に使われていなければ import から外す（typecheck/lint が未使用を検出）。
+
+- [ ] **Step 5: テスト緑を確認**
+
+Run: `npx jest transition.test && npm run typecheck && npm test -- keys-and-arms`
+Expected: PASS（drawTrans のタイミング・挙動は不変）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/keys-and-arms/core/transition.ts src/features/keys-and-arms/core/hud.ts src/features/keys-and-arms/__tests__/core/transition.test.ts
+git commit -m "refactor: KEYS & ARMS のトランジション前進を core/transition.ts に抽出
+
+- drawTrans 内の状態前進（t-- と中点コールバック）を advanceTransition に切り出し
+- 呼び出し位置（render 経由）は不変でタイミングを変えない
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: (B-1) gameTick を core/game-tick.ts に抽出
+
+**Files:**
+- Create: `core/game-tick.ts`
+- Modify: `engine.ts:69-131`
+
+- [ ] **Step 1: createGameTick を作成**
+
+Create `core/game-tick.ts`（中身は現行 `engine.ts` の `gameTick` と論理的に同一。この時点では cheat ループはそのまま＝振る舞い不変）:
+
+```ts
+/**
+ * KEYS & ARMS — ゲーム更新ティック（状態マシン）
+ *
+ * engine.ts と test-engine.ts の両方から共有利用する。
+ * 描画は含まない（render は engine 側に残る）。
+ */
+import type { GameState } from '../types';
+import type { HUDModule } from '../types/hud';
+import type { AudioModule } from '../types/audio';
+import type { StageNavigator } from '../types/stage-navigator';
+import type { Stage } from '../types/stage';
+import type { GameStorageRepository } from '../infrastructure/storage-repository';
+
+/** gameTick が必要とする依存の束 */
+export interface GameTickDeps {
+  G: GameState;
+  J: (key: string) => boolean;
+  clearJustPressed: () => void;
+  jAct: () => boolean;
+  hud: HUDModule;
+  audio: AudioModule;
+  nav: StageNavigator;
+  cave: Stage;
+  prairie: Stage;
+  boss: Stage;
+  helpScreen: { update(): void };
+  storage: GameStorageRepository;
+}
+
+/** ゲーム更新ティック（状態マシン）を生成する */
+export function createGameTick(deps: GameTickDeps): () => void {
+  const { G, J, clearJustPressed: clearJ, jAct, hud, audio, nav, cave, prairie, boss, helpScreen, storage } = deps;
+  const isGameplay = () =>
+    G.state !== 'title' && G.state !== 'over' && G.state !== 'trueEnd' && G.state !== 'ending1';
+
+  return function gameTick(): void {
+    G.tick++;
+    if (G.beatPulse > 0) G.beatPulse--;
+
+    // リセット確認
+    if (G.resetConfirm > 0) {
+      G.resetConfirm--;
+      if (jAct()) {
+        G.resetConfirm = 0; G.state = 'title'; G.blink = 0;
+        if (G.score > G.hi) { G.hi = G.score; storage.setHighScore(G.hi); }
+        clearJ(); return;
+      }
+      if (J('escape')) G.resetConfirm = 0;
+      clearJ(); return;
+    }
+
+    // ポーズトグル（ゲームプレイ中のみ）
+    if (J('p') && isGameplay() && G.state !== 'help') {
+      G.paused = !G.paused;
+      clearJ(); return;
+    }
+
+    // ポーズ中はティックスキップ
+    if (G.paused) {
+      if (J('escape')) { G.paused = false; G.resetConfirm = 90; }
+      clearJ(); return;
+    }
+
+    // ESC でリセット確認
+    if (J('escape') && isGameplay()) {
+      G.resetConfirm = 90; clearJ(); return;
+    }
+
+    // ヒットストップ
+    if (G.hitStop > 0) { G.hitStop--; clearJ(); return; }
+    if (G.hurtFlash > 0) G.hurtFlash--;
+    if (G.shakeT > 0) G.shakeT--;
+
+    if (G.transition.t > 0) {
+      if (isGameplay()) hud.doBeat();
+    } else {
+      let nb = false;
+      if (isGameplay()) nb = hud.doBeat();
+      switch (G.state) {
+        case 'cave': cave.update(nb); break;
+        case 'grass': prairie.update(nb); break;
+        case 'boss': boss.update(nb); break;
+        case 'title':
+          for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+            if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
+          }
+          if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }
+          if (jAct() || J('enter')) { audio.S.start(); nav.startGame(); }
+          break;
+        case 'help': helpScreen.update(); break;
+        case 'over': case 'trueEnd': case 'ending1': break;
+      }
+    }
+    clearJ();
+  };
+}
+```
+
+- [ ] **Step 2: engine.ts を createGameTick 利用に変更**
+
+Modify `engine.ts`。冒頭の import に追加:
+
+```ts
+import { createGameTick } from './core/game-tick';
+```
+
+`engine.ts:69` の `const isGameplay = () => ...;` 行を削除（createGameTick 内に移動済み）。
+
+> 確認: `isGameplay` が `render()` で使われていないこと（`grep -n "isGameplay" engine.ts` で gameTick 定義以外にヒットが無いこと）。
+> 万一 render で使っていたら、その行は残すこと。
+
+`engine.ts:71-131` の `/* GAME TICK — 状態マシン */ function gameTick() { ... }` ブロック全体を削除し、
+遅延バインド（`nav.boss = ...; nav.startGame = ...;` の直後）に以下を追加:
+
+```ts
+  const gameTick = createGameTick({
+    G, J, clearJustPressed: clearJ, jAct,
+    hud, audio, nav, cave, prairie, boss, helpScreen, storage,
+  });
+```
+
+`frame()` 内の `gameTick()` 呼び出しはそのまま（ローカル `const gameTick` を参照）。
+
+- [ ] **Step 3: 型・テスト確認**
+
+Run: `npm run typecheck`
+Expected: PASS（deps の型が揃う。不足キーがあればここで検出）
+
+Run: `npm test -- keys-and-arms`
+Expected: PASS（gameTick の中身は同一。振る舞い不変）
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/keys-and-arms/core/game-tick.ts src/features/keys-and-arms/engine.ts
+git commit -m "refactor: KEYS & ARMS の gameTick を core/game-tick.ts に抽出
+
+- engine.ts のクロージャ内 gameTick を createGameTick(deps) として切り出し
+- engine は deps を組んで呼ぶだけにし、render は engine 側に残す
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: (B-3) test-engine を共有 gameTick で駆動
+
+**Files:**
+- Modify: `__tests__/helpers/test-engine.ts`
+
+- [ ] **Step 1: test-engine が共有 gameTick と advanceTransition を使うよう変更**
+
+Modify `__tests__/helpers/test-engine.ts`。
+
+import に追加:
+
+```ts
+import { createGameTick } from '../../core/game-tick';
+import { advanceTransition } from '../../core/transition';
+```
+
+クラスにフィールドを追加（`private readonly` 群の付近）:
+
+```ts
+  private readonly runTick: () => void;
+```
+
+コンストラクタの末尾（遅延バインド `this.nav.startGame = this.titleScreen.startGame;` の後）に追加:
+
+```ts
+    this.runTick = createGameTick({
+      G: this.G,
+      J: this.input.justPressed,
+      clearJustPressed: this.input.clearJustPressed,
+      jAct: this.input.isAction,
+      hud: this.hud,
+      audio,
+      nav: this.nav,
+      cave: this.cave,
+      prairie: this.prairie,
+      boss: this.boss,
+      helpScreen: this.helpScreen,
+      storage: this.storage,
+    });
+```
+
+> 注: `audio` はコンストラクタ内のローカル `const audio = createNullAudioService();`。スコープ内なのでそのまま渡せる。
+
+既存の手書き `gameTick()` メソッド全体（`gameTick(): void { ... }`、`G.tick++` から末尾の `clearJ();` まで）を、以下に置換:
+
+```ts
+  /** 1 ティック実行（描画スキップ）。本番 engine と同じ更新ロジックを共有する。 */
+  gameTick(): void {
+    this.runTick();
+    // 本番では render（drawTrans）がトランジションを前進させるため、ここで同等処理を行う
+    if (this.G.transition.t > 0) advanceTransition(this.G);
+  }
+```
+
+- [ ] **Step 2: TRANSITION_MID 等の不要 import を整理**
+
+`test-engine.ts` が `TRANSITION_MID` を直接使わなくなった場合（手書き gameTick 削除により）、その import を削除する。
+typecheck / lint が未使用 import を検出する。
+
+- [ ] **Step 3: 型・テスト確認**
+
+Run: `npm run typecheck && npm test -- keys-and-arms`
+Expected: PASS（test-engine が本番 gameTick を駆動。既存テストの収束 `while (transition.t > 0) gameTick()` は維持される）
+
+> もし transition 関連の統合テストが落ちる場合、`gameTick()` の順序を確認:
+> `runTick()`（t>0 時は doBeat のみ）→ その後 `advanceTransition`（t-- と中点 fn）の順であること。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/keys-and-arms/__tests__/helpers/test-engine.ts
+git commit -m "refactor: KEYS & ARMS の test-engine を共有 gameTick で駆動
+
+- 手書きで再実装していた gameTick を廃止し createGameTick を利用
+- トランジション前進は advanceTransition を共有利用
+- 本番ループとの二重メンテとドリフトを解消
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: (C) z 衝突バグの根治
+
+**Files:**
+- Modify: `core/game-tick.ts`
+- Modify: `__tests__/integration/god-mode.test.ts`
+
+- [ ] **Step 1: god-mode テストの z 開始ケースを「発動する」に更新（失敗する）**
+
+Modify `__tests__/integration/god-mode.test.ts`。
+冒頭のファイル JSDoc から「既知の問題」の段落（`【既知の問題】開始キー 'z' は ...` のくだり）を、修正済みを反映した文に更新:
+
+```ts
+/**
+ * KEYS & ARMS — GOD MODE（隠しチート）の挙動テスト
+ *
+ * タイトル画面で "jin" と入力してからゲームを開始すると、HP が 20 で始まる。
+ * 開始キー（z / space / Enter）はいずれもチート文字として扱われないため、
+ * どのキーで開始しても GOD MODE が発動する。
+ * （screens/title.ts: cheatBuf.endsWith('jin') → hp = 20）
+ */
+```
+
+`【既知の問題】"jin" 入力 → z 開始では発動しない` の it ブロックを、以下に置換:
+
+```ts
+  it('"jin" 入力 → z 開始でも HP が 20 で始まる（発動する）', () => {
+    const engine = createTestEngine();
+    typeCheat(engine, 'jin');
+
+    startWith(engine, 'z');
+
+    expect(engine.G.hp).toBe(20);
+    expect(engine.G.maxHp).toBe(20);
+  });
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `npx jest god-mode`
+Expected: FAIL（`z` 開始ケースが HP 3 のまま → 期待 20 に対して失敗）
+
+- [ ] **Step 3: cheat ループでアクションキーを除外**
+
+Modify `core/game-tick.ts`。import に追加:
+
+```ts
+import { isActionKey } from './input';
+```
+
+title 節の cheat 蓄積ループを変更:
+
+```ts
+        case 'title':
+          for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+            if (isActionKey(k)) continue; // 開始キー(z)はチート文字として扱わない
+            if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
+          }
+          if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }
+          if (jAct() || J('enter')) { audio.S.start(); nav.startGame(); }
+          break;
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+Run: `npx jest god-mode`
+Expected: PASS（z / space / Enter いずれの開始でも GOD MODE 発動。未入力/誤入力は HP 3）
+
+- [ ] **Step 5: 全体テスト確認**
+
+Run: `npm run typecheck && npm test -- keys-and-arms`
+Expected: PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/keys-and-arms/core/game-tick.ts src/features/keys-and-arms/__tests__/integration/god-mode.test.ts
+git commit -m "fix: KEYS & ARMS の GOD MODE が z 開始で発動しないバグを修正
+
+- cheat 蓄積ループで isActionKey によりアクションキー(z)を除外
+- z/space/Enter のいずれの開始でも GOD MODE が一律発動するようになる
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: README の「既知の問題」を解消済みに更新
+
+**Files:**
+- Modify: `src/features/keys-and-arms/README.md`
+
+- [ ] **Step 1: 既知の問題セクションを修正済みに更新**
+
+Modify `README.md`。「### GOD MODE が `z` 開始だと発動しない」の節を、解消済みである旨に書き換える:
+
+```markdown
+### （解消済み）GOD MODE が `z` 開始だと発動しなかった問題
+
+以前は開始キー `z` が cheat 蓄積ループ（a〜z）に混入し、`z` 開始で `cheatBuf` が
+`jinz` になって GOD MODE が発動しないバグがあった。
+`core/game-tick.ts` の cheat 蓄積ループで `isActionKey` によりアクションキーを除外し、
+**`z`/`space`/`Enter` のいずれの開始でも発動するように修正済み**
+（`__tests__/integration/god-mode.test.ts` で検証）。
+```
+
+あわせて「デバッグ / 隠しコマンド（GOD MODE）」セクションの手順3を更新:
+
+```markdown
+3. **任意の開始キー（Z / スペース / Enter）** でゲームを開始すると、HP / 最大HP が `3` → `20` になる
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add src/features/keys-and-arms/README.md
+git commit -m "docs: KEYS & ARMS の GOD MODE 既知の問題を解消済みに更新
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: 最終検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: DRY 解消の自動チェック**
+
+Run:
+```bash
+cd src/features/keys-and-arms
+# gameTick の実装が1箇所だけであること（game-tick.ts のみ）
+grep -rln "function gameTick\|createGameTick" . --include='*.ts'
+# アクションキーの z/space リテラル直書きが input.ts の ACTION_KEYS だけであること
+grep -rn "'z'.*' '\|justPressed('z')\|J('z')" . --include='*.ts' | grep -v __tests__
+```
+Expected:
+- `createGameTick` の定義は `core/game-tick.ts` のみ、利用は engine.ts と test-engine.ts。`function gameTick` の手書き重複が無い。
+- `isAction`/`jAct` 内に z/space のリテラル直書きが残っていない（ACTION_KEYS 経由）。
+
+- [ ] **Step 2: フル CI**
+
+Run: `npm run ci`
+Expected: lint:ci + typecheck + test + build すべて PASS。
+
+- [ ] **Step 3: 手動動作確認（任意）**
+
+Run: `npm start` → `/keys-and-arms` を開き、
+タイトルで `jin` 入力 → **Z** で開始 → HP が 20 で始まることを目視確認。
+通常開始（チート無し）が HP 3 であること、ステージ遷移・ポーズ・リセットが従来どおり動くことも確認。
+
+---
+
+## 完了条件チェックリスト（設計書 §5 と対応）
+
+- [ ] `ACTION_KEYS` が `core/input.ts` の唯一の定義で `isAction`/`jAct` 両方が参照（Task 1）
+- [ ] `gameTick` の実装が `core/game-tick.ts` の1箇所、engine と test-engine が共有（Task 3, 4）
+- [ ] `advanceTransition` が `core/transition.ts` の唯一の定義で drawTrans と test-engine が共有（Task 2, 4）
+- [ ] `z`/`space`/`Enter` いずれの開始でも GOD MODE 発動（Task 5）
+- [ ] `god-mode.test.ts` が本番ロジック経由で z 開始 GOD MODE を検証（Task 4, 5）
+- [ ] `npm run ci` グリーン（Task 7）
+- [ ] A・B により既存の他テスト結果は不変（C による変化は z 開始 GOD MODE のみ）

--- a/docs/superpowers/specs/2026-06-14-keys-and-arms-input-dry-refactoring-design.md
+++ b/docs/superpowers/specs/2026-06-14-keys-and-arms-input-dry-refactoring-design.md
@@ -1,0 +1,179 @@
+# KEYS & ARMS 入力処理の DRY 解消 設計
+
+- 日付: 2026-06-14
+- 対象: `src/features/keys-and-arms/`
+- 種別: リファクタリング（A・B は振る舞い不変、C のみ意図的な挙動変更）
+- 前提 PR: #116（状態管理リファクタリング）— 本作業はその後続
+
+## 1. 背景と目的
+
+状態管理リファクタリング（PR #116）の調査過程で、GOD MODE（隠しコマンド `jin`）が
+`z` 開始では発動しない既存バグが判明した。その根本原因をたどると、入力処理まわりに
+DRY 違反が複数存在することが分かった。
+
+| # | DRY 違反 | 場所 |
+|---|---------|------|
+| A | アクションキー定義（`z`/`space`）の二重化 | `core/input.ts` の `isAction()` と `createInputHelpers().jAct()` |
+| B | `gameTick` 丸ごとの重複（テストが本番ループを再実装） | `engine.ts` の `gameTick` vs `__tests__/helpers/test-engine.ts` の `gameTick` |
+| C | 「アクションキー」の単一の真実が無いため、cheat 蓄積ループが開始キーを除外できない（バグの構造的原因） | 同上 |
+
+本作業の目的:
+
+1. **A**: アクションキー集合の定義を単一の真実に統一する（振る舞い不変）。
+2. **B**: `gameTick` の重複を解消し、テストが本番ループを駆動するようにする（振る舞い不変）。
+   これにより今回のようなロジックの静かなドリフトが構造的に起こり得なくなる。
+3. **C**: A の単一定義を使って `z` 衝突バグを根治し、GOD MODE を `z`/`space`/`Enter` で
+   一律に発動させる（**意図的な挙動変更**）。
+
+### 非目標（YAGNI）
+
+- 「描画関数（`drawTrans`）が状態を変更している」という設計上の歪みの根治。
+  トランジション前進を update（gameTick, 30Hz）側へ移すと、現在 render（≈60Hz）で
+  前進している分が約2倍に伸び、**トランジション時間が変わってしまう**ため扱わない。
+  本作業では「前進処理を共有ヘルパー化して重複だけ消す」に留め、呼び出し位置（render）は変えない。
+- 入力以外の領域のリファクタリング。
+
+## 2. 現状調査の要点
+
+- アクションキー判定は2箇所に独立定義: `input.ts:39` `isAction()`（`justPressed('z')||justPressed(' ')`）、
+  `input.ts` `createInputHelpers().jAct()`（`J('z')||J(' ')`）。後者は game-over / ending /
+  true-end / boss-logic / cave-logic の5ファイルで利用。
+- `gameTick` は `engine.ts`（本番）と `test-engine.ts`（テスト）に**別々に実装**されている。
+- トランジションの状態前進（`G.transition.t--` と中点での `fn()` 実行）は
+  `core/hud.ts` の `drawTrans()` 内にあり、`render()` から呼ばれる。
+- タイミング: `TICK_RATE = 30`（gameTick は 30Hz）、`render()` は rAF（≈60Hz）。
+  `TRANSITION_TOTAL = 56`、`TRANSITION_MID = 28`。
+- GOD MODE 判定: `screens/title.ts`（`cheatBuf.endsWith('jin')` → `hp = cheat ? 20 : 3`）。
+  cheat 蓄積は `engine.ts` の title 節（a〜z のキー入力を `G.cheatBuf` へ）。
+- z 衝突: 開始キー `z` が a〜z 蓄積ループに含まれるため、`z` 開始時に
+  `cheatBuf` が `jin` → `jinz` になり `endsWith('jin')` が false。
+
+## 3. 設計
+
+### 3.1 (A) アクションキーの単一の真実【振る舞い不変】
+
+`core/input.ts` にアクションキー集合の唯一の定義と判定述語を置く。
+
+```ts
+/** アクションキー（拾う・攻撃・設置・開始などに使う） */
+export const ACTION_KEYS = ['z', ' '] as const;
+
+/** 指定キーがアクションキーかどうか */
+export function isActionKey(key: string): boolean {
+  return (ACTION_KEYS as readonly string[]).includes(key.toLowerCase());
+}
+```
+
+- `InputHandler.isAction()` → `return ACTION_KEYS.some((k) => justPressed(k));`
+- `createInputHelpers().jAct()` → `return ACTION_KEYS.some((k) => J(k));`
+
+両者が `ACTION_KEYS` を参照する。判定対象は従来どおり `z`/`space` で、動作は完全同一。
+
+### 3.2 (B) gameTick 重複の解消【振る舞い不変】
+
+**(B-1) gameTick の抽出**
+
+`engine.ts` の `gameTick` を `core/game-tick.ts` の `createGameTick(deps)` に切り出す。
+`deps` は現状クロージャが参照している依存をまとめたもの:
+
+```ts
+export interface GameTickDeps {
+  G: GameState;
+  J: (key: string) => boolean;
+  clearJustPressed: () => void;
+  jAct: () => boolean;
+  hud: HUDModule;
+  audio: AudioModule;
+  nav: StageNavigator;
+  cave: Stage;
+  prairie: Stage;
+  boss: Stage;
+  titleScreen: { startGame(): void };
+  helpScreen: { update(): void };
+}
+
+/** ゲーム更新ティック（状態マシン）を生成する */
+export function createGameTick(deps: GameTickDeps): () => void { /* ... */ }
+```
+
+- `engine.ts` は deps を組み立て `const gameTick = createGameTick(deps)` を呼ぶだけにする。
+  `render()` は engine 側に残す（描画は実 Canvas 依存のため）。
+- 抽出後の gameTick の中身は現行 `engine.ts:68-127` と論理的に同一（title 節の cheat 蓄積を含む）。
+
+**(B-2) トランジション前進の共有化**
+
+`drawTrans()` 内の状態前進部分を `core/transition.ts` に切り出す。
+
+```ts
+import type { GameState } from '../types';
+import { TRANSITION_MID } from '../constants';
+
+/**
+ * トランジションの状態を1ステップ進める。
+ * 残りカウントを減らし、中点で登録コールバック（次ステージ init 等）を実行する。
+ * 注: 本番では render（≈60Hz）から呼ばれるため、呼び出し位置は変更しない。
+ */
+export function advanceTransition(G: GameState): void {
+  G.transition.t--;
+  if (G.transition.t === TRANSITION_MID && G.transition.fn) G.transition.fn();
+}
+```
+
+- `core/hud.ts` の `drawTrans()` は冒頭ガード（`if (G.transition.t <= 0) return false;`）の後に
+  `advanceTransition(G)` を呼び、以降は従来どおり `G.transition.t` を読んで描画する。
+  **呼び出しタイミング（render 経由・≈60Hz）は不変。**
+
+**(B-3) test-engine の本番駆動化**
+
+`__tests__/helpers/test-engine.ts` の手書き `gameTick` を廃止し、`createGameTick(deps)` を利用する。
+トランジション消化は `advanceTransition(G)` を呼ぶ。
+
+- test-engine の `gameTick()` メソッド: `this.runTick()`（= 共有 gameTick）を呼び、
+  トランジション活性時は `advanceTransition(this.G)` を呼ぶ（本番が render で前進するのを模す）。
+  既存テストの `while (G.transition.t > 0) gameTick()` 収束を維持する。
+- これにより gameTick の二重メンテナンスが消滅し、テストが本番ロジックを直接検証する。
+
+### 3.3 (C) z 衝突バグの根治【意図的な挙動変更】
+
+抽出後の gameTick の title 節の cheat 蓄積ループで、A の `isActionKey` を使って
+アクションキーを除外する。
+
+```ts
+case 'title':
+  for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+    if (isActionKey(k)) continue; // 開始キー(z)はチート文字として扱わない
+    if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
+  }
+  if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }
+  if (jAct() || J('enter')) { audio.S.start(); nav.startGame(); }
+  break;
+```
+
+→ `z` 開始時も `cheatBuf` は `jin` のまま保たれ、GOD MODE が `z`/`space`/`Enter` で一律に発動する。
+
+トレードオフ: 将来のチートコードに `z` を含められない（現行 `jin` は無関係）。
+これは「`z` はアクションキーであり、チート入力文字ではない」という設計判断として受容する。
+
+## 4. テスト戦略
+
+- **A・B は振る舞い不変** → 既存205テストが全グリーンであることが第一の安全網。
+- **B により GOD MODE テストは本番 `gameTick` を直接検証**するようになる（再実装ドリフトの解消）。
+- `__tests__/integration/god-mode.test.ts` を更新:
+  - 「`z` 開始でも HP 20」に期待値を変更（C のバグ修正を固定）。
+  - space/Enter 開始で HP 20、未入力/誤入力で HP 3 は据え置き。
+- A 用に軽い単体テストを追加: `isActionKey('z')`/`isActionKey(' ')` が true、その他が false。
+  `isAction()` と `jAct()` が同一キー集合で一致することを検証。
+- `core/transition.ts` の `advanceTransition` に単体テストを追加:
+  中点で `fn` が1回だけ呼ばれ、`t` が1減ること。
+
+## 5. 完了条件
+
+- [ ] `ACTION_KEYS` が `core/input.ts` の唯一の定義で、`isAction`/`jAct` が両方参照している
+- [ ] `gameTick` の実装が1箇所（`core/game-tick.ts`）に集約され、`engine.ts` と
+      `test-engine.ts` の両方がそれを使用している（重複実装が無い）
+- [ ] `advanceTransition` が `core/transition.ts` の唯一の定義で、`drawTrans` と
+      test-engine が共有利用している
+- [ ] `z`/`space`/`Enter` のいずれの開始でも GOD MODE が発動する
+- [ ] `god-mode.test.ts` が本番ロジック経由で z 開始 GOD MODE を検証している
+- [ ] `npm run ci`（lint:ci + typecheck + test + build）グリーン
+- [ ] A・B により既存の他テストの結果は不変（C による変化は z 開始 GOD MODE のみ）

--- a/src/features/keys-and-arms/README.md
+++ b/src/features/keys-and-arms/README.md
@@ -68,26 +68,23 @@ src/pages/KeysAndArmsPage.tsx  # ページコンポーネント
 
 1. **タイトル画面で**キーボードから `j` → `i` → `n`（"jin"）と入力する
 2. 画面に **`— GOD MODE —`** と表示されればチート有効
-3. **スペース** または **Enter** でゲームを開始すると、HP / 最大HP が `3` → `20` になる
+3. **任意の開始キー（Z / スペース / Enter）** でゲームを開始すると、HP / 最大HP が `3` → `20` になる
 
 - 判定ロジック: `screens/title.ts`（`cheatBuf.endsWith('jin')` → `hp = cheat ? 20 : 3`）
-- 入力蓄積: `engine.ts` の title 節（a〜z のキー入力を `G.cheatBuf` に蓄積）
+- 入力蓄積: `core/game-tick.ts` の title 節（a〜z のキー入力を `G.cheatBuf` に蓄積。アクションキーは除外）
 - 仮想パッドでは a〜z を入力できないため、**物理キーボード必須**
 
 ## 既知の問題
 
-### GOD MODE が `z` 開始だと発動しない
+### （解消済み）GOD MODE が `z` 開始だと発動しなかった問題
 
-`engine.ts` の title 節では、開始キー `z` が「チート文字蓄積ループ（a〜z）」にも含まれます。
-そのため `z` で開始すると、同じティック内で `G.cheatBuf` が `jin` → **`jinz`** になり、
-直後の `startGame()` の `cheatBuf.endsWith('jin')` が `false` になって GOD MODE が発動しません。
+以前は開始キー `z` が cheat 蓄積ループ（a〜z）に混入し、`z` 開始で `G.cheatBuf` が
+`jin` → **`jinz`** になって GOD MODE が発動しないバグがあった。
+`core/game-tick.ts` の cheat 蓄積ループで `isActionKey`（`core/input.ts` の単一定義）により
+アクションキーを除外し、**`z`/`スペース`/`Enter` のいずれの開始でも発動するように修正済み**。
 
-- **回避策**: 開始は **スペース** か **Enter** で行う（どちらも a〜z 外なので `cheatBuf` が保たれる）
-- **発生源**: 2026-06 の状態管理リファクタリング以前から存在する既存バグ（当該リファクタは無関係）
-- **根治案**: title 節のチート蓄積ループで開始キー `z` を除外する、
-  または開始判定をチート蓄積より前に移動する
-- **挙動の固定**: `__tests__/integration/god-mode.test.ts` がスペース/Enter 発動・`z` 非発動を
-  実行可能な形で検証している（根治した際はこのテストの期待値を更新すること）
+- **検証**: `__tests__/integration/god-mode.test.ts` が z/スペース/Enter での発動を実行可能な形で固定
+- **発生源**: 2026-06 の状態管理リファクタリング以前から存在した既存バグ（当該リファクタとは無関係）
 
 ## 起動URL
 

--- a/src/features/keys-and-arms/__tests__/core/input.test.ts
+++ b/src/features/keys-and-arms/__tests__/core/input.test.ts
@@ -1,4 +1,4 @@
-import { ACTION_KEYS, isActionKey, createInputHandler } from '../../core/input';
+import { ACTION_KEYS, isActionKey, isActionHeld, createInputHandler } from '../../core/input';
 
 describe('InputHandler', () => {
   describe('handleKeyDown', () => {
@@ -138,5 +138,12 @@ describe('ACTION_KEYS / isActionKey', () => {
     expect(h.isAction()).toBe(false);
     h.handleKeyDown('z');
     expect(h.isAction()).toBe(true);
+  });
+
+  it('isActionHeld は z / space の押下中フラグで true', () => {
+    expect(isActionHeld({})).toBe(false);
+    expect(isActionHeld({ z: true })).toBe(true);
+    expect(isActionHeld({ ' ': true })).toBe(true);
+    expect(isActionHeld({ a: true })).toBe(false);
   });
 });

--- a/src/features/keys-and-arms/__tests__/core/input.test.ts
+++ b/src/features/keys-and-arms/__tests__/core/input.test.ts
@@ -1,4 +1,4 @@
-import { createInputHandler } from '../../core/input';
+import { ACTION_KEYS, isActionKey, createInputHandler } from '../../core/input';
 
 describe('InputHandler', () => {
   describe('handleKeyDown', () => {
@@ -117,5 +117,26 @@ describe('InputHandler', () => {
       // Act & Assert
       expect(input.isAction()).toBeFalsy();
     });
+  });
+});
+
+describe('ACTION_KEYS / isActionKey', () => {
+  it('アクションキーは z と space', () => {
+    expect([...ACTION_KEYS]).toEqual(['z', ' ']);
+  });
+
+  it('isActionKey は z / space を true、それ以外を false にする', () => {
+    expect(isActionKey('z')).toBe(true);
+    expect(isActionKey('Z')).toBe(true);
+    expect(isActionKey(' ')).toBe(true);
+    expect(isActionKey('a')).toBe(false);
+    expect(isActionKey('enter')).toBe(false);
+  });
+
+  it('isAction は z または space の justPressed で true', () => {
+    const h = createInputHandler();
+    expect(h.isAction()).toBe(false);
+    h.handleKeyDown('z');
+    expect(h.isAction()).toBe(true);
   });
 });

--- a/src/features/keys-and-arms/__tests__/core/transition.test.ts
+++ b/src/features/keys-and-arms/__tests__/core/transition.test.ts
@@ -1,0 +1,23 @@
+import { advanceTransition } from '../../core/transition';
+import { TRANSITION_TOTAL, TRANSITION_MID } from '../../constants';
+import { createTestEngine } from '../helpers/test-engine';
+
+describe('advanceTransition', () => {
+  it('残りカウントを1減らす', () => {
+    const G = createTestEngine().G;
+    G.transition = { t: TRANSITION_TOTAL, txt: '', fn: undefined, sub: '' };
+    advanceTransition(G);
+    expect(G.transition.t).toBe(TRANSITION_TOTAL - 1);
+  });
+
+  it('中点で登録コールバックを1回だけ実行する', () => {
+    const G = createTestEngine().G;
+    let calls = 0;
+    G.transition = { t: TRANSITION_MID + 1, txt: '', fn: () => { calls++; }, sub: '' };
+    advanceTransition(G); // t: MID+1 -> MID（中点でコールバック発火）
+    expect(G.transition.t).toBe(TRANSITION_MID);
+    expect(calls).toBe(1);
+    advanceTransition(G); // t: MID -> MID-1（発火しない）
+    expect(calls).toBe(1);
+  });
+});

--- a/src/features/keys-and-arms/__tests__/helpers/test-engine.ts
+++ b/src/features/keys-and-arms/__tests__/helpers/test-engine.ts
@@ -6,8 +6,9 @@
  *
  * engine.ts と同じ組み立てを行うが、描画は実Canvas不要。
  */
-import { TRANSITION_MID } from '../../constants';
 import type { GameState, GameScreen } from '../../types/game-state';
+import { createGameTick } from '../../core/game-tick';
+import { advanceTransition } from '../../core/transition';
 import type { EngineContext } from '../../types/engine-context';
 import type { StageNavigator } from '../../types/stage-navigator';
 import { createRendering } from '../../core/rendering';
@@ -50,6 +51,7 @@ export class TestEngine {
   private readonly hud: EngineContext['hud'];
   private readonly helpScreen: { update(): void };
   private readonly titleScreen: { startGame(): void };
+  private readonly runTick: () => void;
 
   constructor(options: TestEngineOptions = {}) {
     const ctx = createMockCanvasContext();
@@ -95,79 +97,28 @@ export class TestEngine {
     this.nav.prairie = this.prairie.init.bind(this.prairie);
     this.nav.boss = this.boss.init.bind(this.boss);
     this.nav.startGame = this.titleScreen.startGame;
+
+    this.runTick = createGameTick({
+      G: this.G,
+      J: this.input.justPressed,
+      clearJustPressed: this.input.clearJustPressed,
+      jAct: this.input.isAction,
+      hud: this.hud,
+      audio,
+      nav: this.nav,
+      cave: this.cave,
+      prairie: this.prairie,
+      boss: this.boss,
+      helpScreen: this.helpScreen,
+      storage: this.storage,
+    });
   }
 
-  /** 1 ティック実行（描画スキップ） */
+  /** 1 ティック実行（描画スキップ）。本番 engine と同じ更新ロジックを共有する。 */
   gameTick(): void {
-    const G = this.G;
-    const { justPressed: J, clearJustPressed: clearJ, isAction: jAct } = this.input;
-
-    G.tick++;
-    if (G.beatPulse > 0) G.beatPulse--;
-
-    const isGameplay = () =>
-      G.state !== 'title' && G.state !== 'over' &&
-      G.state !== 'trueEnd' && G.state !== 'ending1';
-
-    // リセット確認
-    if (G.resetConfirm > 0) {
-      G.resetConfirm--;
-      if (jAct()) {
-        G.resetConfirm = 0; G.state = 'title'; G.blink = 0;
-        if (G.score > G.hi) { G.hi = G.score; this.storage.setHighScore(G.hi); }
-        clearJ(); return;
-      }
-      if (J('escape')) G.resetConfirm = 0;
-      clearJ(); return;
-    }
-
-    // ポーズトグル
-    if (J('p') && isGameplay() && G.state !== 'help') {
-      G.paused = !G.paused;
-      clearJ(); return;
-    }
-
-    // ポーズ中スキップ
-    if (G.paused) {
-      if (J('escape')) { G.paused = false; G.resetConfirm = 90; }
-      clearJ(); return;
-    }
-
-    // ESC リセット確認
-    if (J('escape') && isGameplay()) {
-      G.resetConfirm = 90; clearJ(); return;
-    }
-
-    // ヒットストップ
-    if (G.hitStop > 0) { G.hitStop--; clearJ(); return; }
-    if (G.hurtFlash > 0) G.hurtFlash--;
-    if (G.shakeT > 0) G.shakeT--;
-
-    if (G.transition.t > 0) {
-      if (isGameplay()) this.hud.doBeat();
-      // 描画をスキップするため、トランジション処理をここで実行
-      G.transition.t--;
-      if (G.transition.t === TRANSITION_MID && G.transition.fn) G.transition.fn();
-    } else {
-      let nb = false;
-      if (isGameplay()) nb = this.hud.doBeat();
-      switch (G.state) {
-        case 'cave': this.cave.update(nb); break;
-        case 'grass': this.prairie.update(nb); break;
-        case 'boss': this.boss.update(nb); break;
-        case 'title':
-          // 本番 engine.ts と同一: チートバッファ蓄積（a〜z）
-          for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
-            if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
-          }
-          if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }
-          if (jAct() || J('enter')) { this.titleScreen.startGame(); }
-          break;
-        case 'help': this.helpScreen.update(); break;
-        case 'over': case 'trueEnd': case 'ending1': break;
-      }
-    }
-    clearJ();
+    this.runTick();
+    // 本番では render(drawTrans) がトランジションを前進させるため、ここで同等処理を行う
+    if (this.G.transition.t > 0) advanceTransition(this.G);
   }
 
   /** 指定ティック数だけゲームを進行 */

--- a/src/features/keys-and-arms/__tests__/integration/god-mode.test.ts
+++ b/src/features/keys-and-arms/__tests__/integration/god-mode.test.ts
@@ -1,16 +1,10 @@
 /**
- * KEYS & ARMS — GOD MODE（隠しチート）の挙動ドキュメント兼回帰テスト
+ * KEYS & ARMS — GOD MODE（隠しチート）の挙動テスト
  *
- * タイトル画面で "jin" と入力してからゲームを開始すると、
- * HP が通常の 3 ではなく 20 で始まる隠しコマンド。
+ * タイトル画面で "jin" と入力してからゲームを開始すると、HP が 20 で始まる。
+ * 開始キー（z / space / Enter）はいずれもチート文字として扱われないため、
+ * どのキーで開始しても GOD MODE が発動する。
  * （screens/title.ts: cheatBuf.endsWith('jin') → hp = 20）
- *
- * 【既知の問題】開始キー 'z' は engine.ts の title 節にある
- * チート蓄積ループ（a〜z）に含まれるため、'z' で開始すると同じティックで
- * cheatBuf が 'jin' → 'jinz' になり GOD MODE が発動しない。
- * スペース / Enter で開始すれば発動する。詳細は README.md「既知の問題」を参照。
- *
- * このテストは現状の挙動を実行可能な形で固定し、将来の回帰／修正を検知する。
  */
 import { createTestEngine } from '../helpers/test-engine';
 
@@ -54,16 +48,14 @@ describe('GOD MODE（隠しチート "jin"）', () => {
     expect(engine.G.maxHp).toBe(20);
   });
 
-  it('【既知の問題】"jin" 入力 → z 開始では発動しない（cheatBuf が "jinz" になるため）', () => {
-    // 開始キー 'z' が a〜z 蓄積ループに混入する既存バグの固定。
-    // 修正された場合はこのテストが落ちるので、その時点で期待値を 20 に更新する。
+  it('"jin" 入力 → z 開始でも HP が 20 で始まる（発動する）', () => {
     const engine = createTestEngine();
     typeCheat(engine, 'jin');
 
     startWith(engine, 'z');
 
-    expect(engine.G.hp).toBe(3);
-    expect(engine.G.maxHp).toBe(3);
+    expect(engine.G.hp).toBe(20);
+    expect(engine.G.maxHp).toBe(20);
   });
 
   it('チート未入力で開始すると HP は通常の 3 で始まる', () => {

--- a/src/features/keys-and-arms/core/game-tick.ts
+++ b/src/features/keys-and-arms/core/game-tick.ts
@@ -10,6 +10,7 @@ import type { AudioModule } from '../types/audio';
 import type { StageNavigator } from '../types/stage-navigator';
 import type { Stage } from '../types/stage';
 import type { GameStorageRepository } from '../infrastructure/storage-repository';
+import { isActionKey } from './input';
 
 /** gameTick が必要とする依存の束 */
 export interface GameTickDeps {
@@ -82,6 +83,7 @@ export function createGameTick(deps: GameTickDeps): () => void {
         case 'boss': boss.update(nb); break;
         case 'title':
           for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+            if (isActionKey(k)) continue; // 開始キー(z)はチート文字として扱わない
             if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
           }
           if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }

--- a/src/features/keys-and-arms/core/game-tick.ts
+++ b/src/features/keys-and-arms/core/game-tick.ts
@@ -1,0 +1,96 @@
+/**
+ * KEYS & ARMS — ゲーム更新ティック（状態マシン）
+ *
+ * engine.ts と test-engine.ts の両方から共有利用する。
+ * 描画は含まない（render は engine 側に残る）。
+ */
+import type { GameState } from '../types';
+import type { HUDModule } from '../types/hud';
+import type { AudioModule } from '../types/audio';
+import type { StageNavigator } from '../types/stage-navigator';
+import type { Stage } from '../types/stage';
+import type { GameStorageRepository } from '../infrastructure/storage-repository';
+
+/** gameTick が必要とする依存の束 */
+export interface GameTickDeps {
+  G: GameState;
+  J: (key: string) => boolean;
+  clearJustPressed: () => void;
+  jAct: () => boolean;
+  hud: HUDModule;
+  audio: AudioModule;
+  nav: StageNavigator;
+  cave: Stage;
+  prairie: Stage;
+  boss: Stage;
+  helpScreen: { update(): void };
+  storage: GameStorageRepository;
+}
+
+/** ゲーム更新ティック（状態マシン）を生成する */
+export function createGameTick(deps: GameTickDeps): () => void {
+  const { G, J, clearJustPressed: clearJ, jAct, hud, audio, nav, cave, prairie, boss, helpScreen, storage } = deps;
+  const isGameplay = () =>
+    G.state !== 'title' && G.state !== 'over' && G.state !== 'trueEnd' && G.state !== 'ending1';
+
+  return function gameTick(): void {
+    G.tick++;
+    if (G.beatPulse > 0) G.beatPulse--;
+
+    // リセット確認
+    if (G.resetConfirm > 0) {
+      G.resetConfirm--;
+      if (jAct()) {
+        G.resetConfirm = 0; G.state = 'title'; G.blink = 0;
+        if (G.score > G.hi) { G.hi = G.score; storage.setHighScore(G.hi); }
+        clearJ(); return;
+      }
+      if (J('escape')) G.resetConfirm = 0;
+      clearJ(); return;
+    }
+
+    // ポーズトグル（ゲームプレイ中のみ）
+    if (J('p') && isGameplay() && G.state !== 'help') {
+      G.paused = !G.paused;
+      clearJ(); return;
+    }
+
+    // ポーズ中はティックスキップ
+    if (G.paused) {
+      if (J('escape')) { G.paused = false; G.resetConfirm = 90; }
+      clearJ(); return;
+    }
+
+    // ESC でリセット確認
+    if (J('escape') && isGameplay()) {
+      G.resetConfirm = 90; clearJ(); return;
+    }
+
+    // ヒットストップ
+    if (G.hitStop > 0) { G.hitStop--; clearJ(); return; }
+    if (G.hurtFlash > 0) G.hurtFlash--;
+    if (G.shakeT > 0) G.shakeT--;
+
+    if (G.transition.t > 0) {
+      if (isGameplay()) hud.doBeat();
+    } else {
+      let nb = false;
+      if (isGameplay()) nb = hud.doBeat();
+      switch (G.state) {
+        case 'cave': cave.update(nb); break;
+        case 'grass': prairie.update(nb); break;
+        case 'boss': boss.update(nb); break;
+        case 'title':
+          for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+            if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
+          }
+          if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }
+          if (jAct() || J('enter')) { audio.S.start(); nav.startGame(); }
+          break;
+        case 'help': helpScreen.update(); break;
+        case 'over': case 'trueEnd': case 'ending1': break;
+      }
+    }
+    clearJ();
+  };
+}

--- a/src/features/keys-and-arms/core/hud.ts
+++ b/src/features/keys-and-arms/core/hud.ts
@@ -8,6 +8,7 @@ import type { GameState } from '../types/game-state';
 import type { AudioModule } from '../types/audio';
 import type { HUDModule } from '../types/hud';
 import type { GameStorageRepository } from '../infrastructure/storage-repository';
+import { advanceTransition } from './transition';
 
 /**
  * HUD・トランジションモジュールを生成する
@@ -100,8 +101,7 @@ export function createHUD(draw: DrawingAPI, G: GameState, audio: AudioModule, st
   /** トランジション描画 */
   function drawTrans(): boolean {
     if (G.transition.t <= 0) return false;
-    G.transition.t--;
-    if (G.transition.t === TRANSITION_MID && G.transition.fn) G.transition.fn();
+    advanceTransition(G);
     const p = G.transition.t > TRANSITION_MID ? (TRANSITION_TOTAL - G.transition.t) / TRANSITION_MID : G.transition.t / TRANSITION_MID;
     const wh = Math.floor(H * p);
     $.fillStyle = `rgba(176,188,152,.95)`;

--- a/src/features/keys-and-arms/core/input.ts
+++ b/src/features/keys-and-arms/core/input.ts
@@ -13,6 +13,11 @@ export function isActionKey(key: string): boolean {
   return (ACTION_KEYS as readonly string[]).includes(key.toLowerCase());
 }
 
+/** アクションキーが押下中（held）かどうか */
+export function isActionHeld(kd: Record<string, boolean>): boolean {
+  return ACTION_KEYS.some((k) => kd[k]);
+}
+
 export interface InputHandler {
   /** 押下中フラグ */
   readonly kd: Record<string, boolean>;

--- a/src/features/keys-and-arms/core/input.ts
+++ b/src/features/keys-and-arms/core/input.ts
@@ -5,6 +5,14 @@
  * kd: 押下中フラグ、jp: フレーム中に押されたフラグ（1フレーム有効）
  */
 
+/** アクションキー（拾う・攻撃・設置・開始などに使う）の唯一の定義 */
+export const ACTION_KEYS = ['z', ' '] as const;
+
+/** 指定キーがアクションキーかどうか */
+export function isActionKey(key: string): boolean {
+  return (ACTION_KEYS as readonly string[]).includes(key.toLowerCase());
+}
+
 export interface InputHandler {
   /** 押下中フラグ */
   readonly kd: Record<string, boolean>;
@@ -36,7 +44,7 @@ export function createInputHandler(): InputHandler {
   }
 
   function isAction(): boolean {
-    return justPressed('z') || justPressed(' ');
+    return ACTION_KEYS.some((k) => justPressed(k));
   }
 
   function handleKeyDown(key: string): void {
@@ -60,6 +68,6 @@ export function createInputHelpers(jp: Record<string, boolean>) {
   /** キーが今フレーム押されたか */
   function J(k: string): boolean { return !!jp[k.toLowerCase()]; }
   /** アクションキー（z / スペース）が押されたか */
-  function jAct(): boolean { return J('z') || J(' '); }
+  function jAct(): boolean { return ACTION_KEYS.some((k) => J(k)); }
   return { J, jAct };
 }

--- a/src/features/keys-and-arms/core/transition.ts
+++ b/src/features/keys-and-arms/core/transition.ts
@@ -1,0 +1,15 @@
+/**
+ * KEYS & ARMS — 画面トランジションの状態前進
+ *
+ * 残りカウントを進め、中点で登録コールバック（次ステージ init 等）を実行する。
+ * 注: 本番では描画関数 drawTrans（render 経由・約60Hz）から呼ばれる。
+ *     呼び出しタイミングは変更しないため、ここでは状態前進のみを担う。
+ */
+import type { GameState } from '../types';
+import { TRANSITION_MID } from '../constants';
+
+/** トランジションの状態を1ステップ進める */
+export function advanceTransition(G: GameState): void {
+  G.transition.t--;
+  if (G.transition.t === TRANSITION_MID && G.transition.fn) G.transition.fn();
+}

--- a/src/features/keys-and-arms/engine.ts
+++ b/src/features/keys-and-arms/engine.ts
@@ -7,6 +7,7 @@ import { createAudio } from './core/audio';
 import { createParticles } from './core/particles';
 import { createHUD } from './core/hud';
 import { createInputHandler } from './core/input';
+import { createGameTick } from './core/game-tick';
 import { createInitialGameState } from './core/game-state';
 import { createLocalStorageRepository } from './infrastructure/storage-repository';
 import { createRenderEffects } from './core/render-effects';
@@ -66,69 +67,12 @@ export function createEngine(canvas: HTMLCanvasElement): Engine {
   /* 遅延バインド（nav に実体を差し込む） */
   nav.cave = cave.init; nav.prairie = prairie.init;
   nav.boss = boss.init; nav.startGame = titleScreen.startGame;
-  const isGameplay = () => G.state !== 'title' && G.state !== 'over' && G.state !== 'trueEnd' && G.state !== 'ending1';
 
-  /* GAME TICK — 状態マシン */
-  function gameTick() {
-    G.tick++;
-    if (G.beatPulse > 0) G.beatPulse--;
-
-    // リセット確認
-    if (G.resetConfirm > 0) {
-      G.resetConfirm--;
-      if (jAct()) {
-        G.resetConfirm = 0; G.state = 'title'; G.blink = 0;
-        if (G.score > G.hi) { G.hi = G.score; storage.setHighScore(G.hi); }
-        clearJ(); return;
-      }
-      if (J('escape')) G.resetConfirm = 0;
-      clearJ(); return;
-    }
-
-    // ポーズトグル（ゲームプレイ中のみ）
-    if (J('p') && isGameplay() && G.state !== 'help') {
-      G.paused = !G.paused;
-      clearJ(); return;
-    }
-
-    // ポーズ中はティックスキップ
-    if (G.paused) {
-      if (J('escape')) { G.paused = false; G.resetConfirm = 90; }
-      clearJ(); return;
-    }
-
-    // ESC でリセット確認
-    if (J('escape') && isGameplay()) {
-      G.resetConfirm = 90; clearJ(); return;
-    }
-
-    // ヒットストップ
-    if (G.hitStop > 0) { G.hitStop--; clearJ(); return; }
-    if (G.hurtFlash > 0) G.hurtFlash--;
-    if (G.shakeT > 0) G.shakeT--;
-
-    if (G.transition.t > 0) {
-      if (isGameplay()) hud.doBeat();
-    } else {
-      let nb = false;
-      if (isGameplay()) nb = hud.doBeat();
-      switch (G.state) {
-        case 'cave': cave.update(nb); break;
-        case 'grass': prairie.update(nb); break;
-        case 'boss': boss.update(nb); break;
-        case 'title':
-          for (const k of 'abcdefghijklmnopqrstuvwxyz'.split('')) {
-            if (J(k)) { G.cheatBuf += k; if (G.cheatBuf.length > 10) G.cheatBuf = G.cheatBuf.slice(-10); }
-          }
-          if (J('arrowup')) { G.state = 'help'; G.helpPage = 0; clearJ(); break; }
-          if (jAct() || J('enter')) { audio.S.start(); nav.startGame(); }
-          break;
-        case 'help': helpScreen.update(); break;
-        case 'over': case 'trueEnd': case 'ending1': break;
-      }
-    }
-    clearJ();
-  }
+  /* GAME TICK — 状態マシン（core/game-tick.ts に抽出済み） */
+  const gameTick = createGameTick({
+    G, J, clearJustPressed: clearJ, jAct,
+    hud, audio, nav, cave, prairie, boss, helpScreen, storage,
+  });
 
   /* RENDER — 描画 */
   function render() {

--- a/src/features/keys-and-arms/screens/help.ts
+++ b/src/features/keys-and-arms/screens/help.ts
@@ -16,7 +16,7 @@ export function createHelpScreen(ctx: EngineContext) {
   const { $, onFill, txtC, txt, px } = draw;
 
   // 入力ヘルパー
-  const { J } = createInputHelpers(G.jp);
+  const { J, jAct } = createInputHelpers(G.jp);
 
   // 3ページ構成
   const PAGES = [
@@ -171,8 +171,8 @@ export function createHelpScreen(ctx: EngineContext) {
     if (J('arrowright') && G.helpPage < 2) { G.helpPage++; }
     if (J('arrowleft') && G.helpPage > 0) { G.helpPage--; }
 
-    // Z / ESC でタイトルに戻る
-    if (J('z') || J(' ') || J('escape')) {
+    // アクションキー / ESC でタイトルに戻る
+    if (jAct() || J('escape')) {
       G.state = 'title'; G.blink = 0;
     }
   }

--- a/src/features/keys-and-arms/stages/cave/cave-logic.ts
+++ b/src/features/keys-and-arms/stages/cave/cave-logic.ts
@@ -13,7 +13,7 @@ import {
 } from '../../constants';
 
 import { rng, rngInt, rngSpread } from '../../core/math';
-import { createInputHelpers } from '../../core/input';
+import { createInputHelpers, isActionHeld } from '../../core/input';
 
 import { Difficulty } from '../../difficulty';
 
@@ -83,7 +83,7 @@ export function createCaveLogic(ctx: EngineContext) {
       else if (moved) { C.prevPos = oldPos; C.trailAlpha = .3; S.step(); C.walkAnim = 3; C.idleT = 0; addStepDust(POS[C.pos].x, POS[C.pos].y + 20);
         if (ROOM_NAMES[C.pos] !== ROOM_NAMES[oldPos]) { C.roomNameT = 40; C.roomName = ROOM_NAMES[C.pos]; } } }
     // === CAGE HOLD メカニクス（TRAPの鍵、pos 9）===
-    const actHeld = G.kd['z'] || G.kd[' '];
+    const actHeld = isActionHeld(G.kd);
     C.cageHolding = false;
     if (C.pos === 9 && !C.keys[0] && !C.carrying && !C.trapOn && actHeld && C.hurtCD <= 0 && C.actAnim <= 0) {
       C.cageHolding = true; C.idleT = 0; C.cageProgress += 2.5;


### PR DESCRIPTION
## 概要

KEYS & ARMS の入力処理まわりの DRY 負債を解消し、その単一定義を使って GOD MODE が `z` 開始で発動しない既存バグを根治します。**A・B は振る舞い不変、C のみ意図的な挙動変更**です。

> このPRは **#116（状態管理リファクタリング）の上にスタック**しています。base を #116 のブランチに設定しているため、差分は入力DRY分のみです。#116 ブランチへマージ後、#116 が main へマージされる想定です。

設計書: `docs/superpowers/specs/2026-06-14-keys-and-arms-input-dry-refactoring-design.md`
実装計画: `docs/superpowers/plans/2026-06-14-keys-and-arms-input-dry.md`

## 変更内容

- **(A) アクションキーの単一定義**: `ACTION_KEYS` / `isActionKey` / `isActionHeld` を `core/input.ts` の唯一の定義にし、`isAction`・`jAct`・ヘルプ画面・cave-logic の押下中判定がすべて参照（z/space の直書きを根絶）
- **(B) gameTick 重複の解消**: `gameTick` を `core/game-tick.ts`（`createGameTick`）に、トランジション前進を `core/transition.ts`（`advanceTransition`）に抽出。`engine.ts` と `test-engine.ts` が共有し、テストが本番ループを直接駆動するように（再実装ドリフトの構造的解消）。トランジション前進は render 経由のまま温存しタイミング不変
- **(C) GOD MODE バグ修正**: cheat 蓄積ループで `isActionKey` によりアクションキー（z）を除外。`z`/`スペース`/`Enter` のいずれの開始でも GOD MODE が一律発動

## テスト方法

- [x] `npm run typecheck` パス
- [x] `npm run lint:ci`（警告ゼロ強制）パス
- [x] `npm test`（keys-and-arms: 24スイート / 211テスト、リポジトリ全体 7985テスト）パス
- [x] `npm run build` 成功
- [x] GOD MODE 回帰テスト（z/スペース/Enter 発動・未入力/誤入力で非発動）を本番ループ経由で検証
- [ ] 手動確認: タイトルで `jin` → **Z** 開始で HP 20 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)