### PR TITLE
refactor: IPNE 敵AIロジックを責務単位に分割 (Phase A)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-ipne-enemyai-split.md
+++ b/docs/superpowers/plans/2026-06-14-ipne-enemyai-split.md
@@ -1,0 +1,1251 @@
+# IPNE 敵AIロジック責務分割 実装計画（Phase A）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `enemyAiFunctions.ts`（600行）を責務単位の6ファイル＋`behaviors/`4ファイルへ分割し、方向計算のコピペ5箇所を `calculateStep()` に集約する（振る舞い不変）。
+
+**Architecture:** `enemyAiFunctions.ts` を re-export barrel として残し、実装を新ファイル群へ移動する。内側（`aiGeometry`/`aiRandom`）から外側（`enemyOrchestrator`）の順に作る。既存テスト群（`enemyAiFunctions.test.ts` / `enemyAI.test.ts` / `enemyAttackAnim.test.ts`）が全工程で緑のままであることが振る舞い不変の証明となる。
+
+**Tech Stack:** TypeScript, Jest (SWC), 純粋関数によるドメインロジック。
+
+**設計の出典:** `docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md`
+
+---
+
+## 公開 API（barrel で完全維持すべき24エクスポート）
+
+分割後も `enemyAiFunctions.ts` から以下が**同名・同シグネチャ**で export され続けること。これが Definition of Done の中核。
+
+```
+setRandomProvider, resetRandomProvider,
+canEnemyAttack, setEnemyAttackCooldown,
+detectPlayer, shouldChase, shouldStopChase,
+moveEnemyTowards, generatePatrolPath, getNextPatrolPoint,
+updatePatrolEnemy, updateChargeEnemy, updateRangedEnemy, updateFleeEnemy,
+getDirectPathToPlayer, calculateFleeDirection,
+updateEnemyAI, updateEnemies, updateEnemiesWithContact,
+ENEMY_ATTACK_ANIM_DURATION, markEnemyAttacking, resolveEnemyAttackState,
+AI_CONFIG,
+type EnemyUpdateResult
+```
+
+**barrel で再公開しない（内部共有のみ）**: `getManhattanDistance`, `calculateStep`,
+`defaultRandom`, `stepTowards`, `stepAway`, `stepRandom`, `attemptLunge`,
+`moveEnemyAway`, `moveEnemyRandom`, `resolveKnockbackState`, `toPositionKey`,
+`RANGED_PREFERRED_DISTANCE`。これらは元々 private なので公開してはならない。
+
+## ディレクトリ構成（最終形）
+
+すべて `src/features/ipne/domain/policies/enemyAi/` 配下。
+
+```
+enemyAi/
+  enemyAiFunctions.ts        # barrel（Task 8 で純粋 re-export 化）
+  aiRandom.ts                # Task 2
+  aiGeometry.ts              # Task 1
+  enemyMovement.ts           # Task 3
+  attackState.ts             # Task 4
+  enemyOrchestrator.ts       # Task 7
+  behaviors/
+    patrolBehavior.ts        # Task 5
+    chargeBehavior.ts        # Task 5
+    rangedBehavior.ts        # Task 6
+    fleeBehavior.ts          # Task 6
+  # 既存・無修正: EnemyAiPolicyRegistry.ts, policies.ts, types.ts
+```
+
+**import パス規約:**
+- `enemyAi/` 直下のファイル → `../../types`, `../../services/collisionService`, `../../config/gameBalance`, `../../ports`
+- `enemyAi/behaviors/` 配下のファイル → `../../../types` 等（1階層深い）。兄弟 enemyAi モジュールは `../aiGeometry` 等
+
+---
+
+## Task 0: ベースライン確認
+
+**Files:** なし（確認のみ）
+
+- [ ] **Step 1: 現ブランチと作業ディレクトリを確認**
+
+Run: `git branch --show-current && pwd`
+Expected: `refactor/ipne-enemyai-split` / `/workspaces/claym/local/cline-playground-for-frontend`
+
+- [ ] **Step 2: 対象テストがすべて緑であることを確認（安全網の起点）**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -20`
+Expected: PASS（`enemyAiFunctions.test.ts` / `EnemyAiPolicyRegistry.test.ts` / `enemyAI.test.ts` / `enemyAttackAnim.test.ts` 全件 green）
+
+- [ ] **Step 3: 型チェックのベースライン**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし（exit 0）
+
+---
+
+## Task 1: `aiGeometry.ts` を作成（calculateStep を TDD で新設＋幾何/検知を移動）
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/aiGeometry.ts`
+- Create: `src/features/ipne/domain/policies/enemyAi/aiGeometry.test.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`（該当関数を削除し re-export 追加）
+
+移動する要素: `getManhattanDistance`(private), `AI_CONFIG`, `detectPlayer`, `shouldChase`,
+`shouldStopChase`, `calculateFleeDirection`, `getDirectPathToPlayer`。
+新設: `calculateStep`。`calculateFleeDirection` と `getDirectPathToPlayer` は `calculateStep` を使う形に書き換える。
+
+- [ ] **Step 1: `calculateStep` の失敗テストを書く**
+
+Create `aiGeometry.test.ts`:
+
+```typescript
+import { calculateStep, calculateFleeDirection, getDirectPathToPlayer } from './aiGeometry';
+import { createPatrolEnemy } from '../../entities/enemy';
+
+const mockIdGen = {
+  generateEnemyId: () => 'e1',
+  generateTrapId: () => 't1',
+  generateItemId: () => 'i1',
+  generateFeedbackId: () => 'f1',
+};
+
+describe('aiGeometry', () => {
+  describe('calculateStep', () => {
+    it('各軸の単位ステップ（-1/0/+1）を返す', () => {
+      expect(calculateStep({ x: 2, y: 2 }, { x: 5, y: 1 })).toEqual({ stepX: 1, stepY: -1 });
+    });
+    it('同一座標では 0 を返す', () => {
+      expect(calculateStep({ x: 3, y: 3 }, { x: 3, y: 3 })).toEqual({ stepX: 0, stepY: 0 });
+    });
+    it('負方向では -1 を返す', () => {
+      expect(calculateStep({ x: 5, y: 5 }, { x: 1, y: 1 })).toEqual({ stepX: -1, stepY: -1 });
+    });
+  });
+
+  describe('calculateFleeDirection', () => {
+    it('プレイヤーと反対方向の隣接マスを返す', () => {
+      const enemy = createPatrolEnemy(3, 3, mockIdGen);
+      // プレイヤーが左(x=2)にいるので敵は右(x=4)へ逃げる
+      expect(calculateFleeDirection(enemy, { x: 2, y: 3 })).toEqual({ x: 4, y: 3 });
+    });
+  });
+
+  describe('getDirectPathToPlayer', () => {
+    it('敵からプレイヤーへの直線パスを返す', () => {
+      const enemy = createPatrolEnemy(1, 1, mockIdGen);
+      const path = getDirectPathToPlayer(enemy, { x: 3, y: 1 });
+      expect(path).toEqual([{ x: 2, y: 1 }, { x: 3, y: 1 }]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `npm test -- aiGeometry 2>&1 | tail -15`
+Expected: FAIL（`Cannot find module './aiGeometry'`）
+
+- [ ] **Step 3: `aiGeometry.ts` を実装**
+
+Create `aiGeometry.ts`:
+
+```typescript
+/**
+ * 敵AIの幾何計算・検知判定
+ *
+ * 座標計算（方向ステップ・距離）とプレイヤー検知・追跡継続判定を提供する。
+ * 純粋関数のみ（マップ衝突や乱数には依存しない）。
+ */
+import { Enemy, Position } from '../../types';
+import { GAME_BALANCE } from '../../config/gameBalance';
+
+/** AI の検知・追跡・攻撃に関する時間定数 */
+export const AI_CONFIG = {
+  updateInterval: GAME_BALANCE.enemyAi.updateIntervalMs,
+  chaseTimeout: GAME_BALANCE.enemyAi.chaseTimeoutMs,
+  attackCooldown: GAME_BALANCE.enemyAi.attackCooldownMs,
+} as const;
+
+/** マンハッタン距離（barrel では非公開。モジュール間共有用） */
+export const getManhattanDistance = (a: Position, b: Position): number =>
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+
+/**
+ * 2点間の各軸の単位ステップ（-1 / 0 / +1）を返す。
+ * 座標は整数のため Math.sign は従来の `d>0?1:-1`（0→0）と挙動が一致する。
+ */
+export const calculateStep = (
+  from: Position,
+  to: Position
+): { stepX: number; stepY: number } => ({
+  stepX: Math.sign(to.x - from.x),
+  stepY: Math.sign(to.y - from.y),
+});
+
+/** プレイヤーが検知範囲内か */
+export const detectPlayer = (enemy: Enemy, player: Position): boolean =>
+  getManhattanDistance(enemy, player) <= enemy.detectionRange;
+
+/** 追跡を開始すべきか */
+export const shouldChase = (enemy: Enemy, player: Position): boolean => {
+  if (!detectPlayer(enemy, player)) return false;
+  if (enemy.chaseRange === undefined) return true;
+  return getManhattanDistance(enemy, player) <= enemy.chaseRange;
+};
+
+/** 追跡を中断すべきか */
+export const shouldStopChase = (enemy: Enemy, player: Position, currentTime: number): boolean => {
+  if (enemy.chaseRange !== undefined && getManhattanDistance(enemy, player) > enemy.chaseRange) {
+    return true;
+  }
+  if (enemy.lastSeenAt !== undefined && currentTime - enemy.lastSeenAt > AI_CONFIG.chaseTimeout) {
+    return true;
+  }
+  return false;
+};
+
+/** プレイヤーと反対方向の隣接マス（逃走方向） */
+export const calculateFleeDirection = (enemy: Enemy, player: Position): Position => {
+  const { stepX, stepY } = calculateStep(player, enemy);
+  return { x: enemy.x + stepX, y: enemy.y + stepY };
+};
+
+/** 敵からプレイヤーへの直線パス（L字: 先に横、次に縦） */
+export const getDirectPathToPlayer = (enemy: Enemy, player: Position): Position[] => {
+  const { stepX, stepY } = calculateStep(enemy, player);
+  const path: Position[] = [];
+  let currentX = enemy.x;
+  let currentY = enemy.y;
+  while (currentX !== player.x) {
+    currentX += stepX;
+    path.push({ x: currentX, y: currentY });
+  }
+  while (currentY !== player.y) {
+    currentY += stepY;
+    path.push({ x: currentX, y: currentY });
+  }
+  return path;
+};
+```
+
+- [ ] **Step 4: `aiGeometry.test.ts` が通ることを確認**
+
+Run: `npm test -- aiGeometry 2>&1 | tail -15`
+Expected: PASS
+
+- [ ] **Step 5: `enemyAiFunctions.ts` から移動済み関数を削除し re-export に置換**
+
+`enemyAiFunctions.ts` で以下を実施:
+1. 削除する定義: `getManhattanDistance`(51-53行), `AI_CONFIG`(45-49行), `detectPlayer`(69-72行), `shouldChase`(74-78行), `shouldStopChase`(80-88行), `getDirectPathToPlayer`(323-344行), `calculateFleeDirection`(346-353行), 末尾の `export { AI_CONFIG };`(600行)。
+2. ファイル冒頭の import 群の直後に以下を追加:
+
+```typescript
+import {
+  AI_CONFIG,
+  getManhattanDistance,
+  detectPlayer,
+  shouldChase,
+  shouldStopChase,
+  calculateFleeDirection,
+  getDirectPathToPlayer,
+} from './aiGeometry';
+
+// 公開 API（barrel）として再公開
+export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
+```
+
+> 注: `getManhattanDistance` は import するが **re-export しない**（元々 private）。
+> このファイル内に残る関数（`canEnemyAttack` 等）がまだ `getManhattanDistance` / `AI_CONFIG` を
+> 参照しているため、import は必要。
+
+- [ ] **Step 6: 既存テストが緑のままであることを確認（振る舞い不変の証明）**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS（全件）
+
+- [ ] **Step 7: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/aiGeometry.ts \
+        src/features/ipne/domain/policies/enemyAi/aiGeometry.test.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵AIの幾何・検知判定を aiGeometry へ分離
+
+- calculateStep を新設し方向計算の重複を解消する起点を用意
+- detectPlayer/shouldChase/shouldStopChase/calculateFleeDirection/getDirectPathToPlayer を移動
+- enemyAiFunctions.ts は barrel として後方互換を維持"
+```
+
+---
+
+## Task 2: `aiRandom.ts` を作成（乱数プロバイダ DI を移動）
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/aiRandom.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+移動する要素: `defaultRandom`(private), `_random`(private state), `setRandomProvider`(public),
+`resetRandomProvider`(public)。`_random` は他モジュールから参照するため getter を設ける。
+
+- [ ] **Step 1: `aiRandom.ts` を実装**
+
+Create `aiRandom.ts`:
+
+```typescript
+/**
+ * 敵AIの乱数プロバイダ管理
+ *
+ * テスト時に setRandomProvider で決定的な乱数へ差し替えられる。
+ * NOTE: モジュールレベルの可変状態は既知の負債（spec §6）。Phase A では現状維持。
+ */
+import { RandomProvider } from '../../ports';
+
+/** デフォルトの乱数プロバイダー（Math.random ベース） */
+export const defaultRandom: RandomProvider = {
+  random: () => Math.random(),
+  randomInt: (min, max) => min + Math.floor(Math.random() * (max - min)),
+  pick: (array) => array[Math.floor(Math.random() * array.length)],
+  shuffle: (array) => {
+    const result = [...array];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  },
+};
+
+let _random: RandomProvider = defaultRandom;
+
+/** 現在の乱数プロバイダーを取得する（モジュール間共有用） */
+export const getRandom = (): RandomProvider => _random;
+
+/** 乱数プロバイダーを設定する（テスト用） */
+export function setRandomProvider(random: RandomProvider): void {
+  _random = random;
+}
+
+/** 乱数プロバイダーをデフォルトにリセットする */
+export function resetRandomProvider(): void {
+  _random = defaultRandom;
+}
+```
+
+- [ ] **Step 2: `enemyAiFunctions.ts` から乱数定義を削除し re-export に置換**
+
+`enemyAiFunctions.ts` で以下を実施:
+1. 削除: `defaultRandom`(13-26行), `let _random...`(28-29行), `setRandomProvider`(31-36行), `resetRandomProvider`(38-43行)。
+2. import 群に追加し再公開:
+
+```typescript
+import { getRandom, setRandomProvider, resetRandomProvider } from './aiRandom';
+
+export { setRandomProvider, resetRandomProvider };
+```
+
+3. このファイル内に残る `_random.random()` / `_random.shuffle()` などの参照を **`getRandom()`** 経由に置換する（`attemptLunge`, `stepRandom`, `generatePatrolPath` 内。例: `_random.random()` → `getRandom().random()`）。
+
+> 注: `defaultRandom` は re-export しない（元々 private）。
+
+- [ ] **Step 3: 既存テストが緑であることを確認**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS（特に乱数差し替えに依存するテストが通ること）
+
+- [ ] **Step 4: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/aiRandom.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵AIの乱数プロバイダを aiRandom へ分離
+
+- defaultRandom/setRandomProvider/resetRandomProvider を移動
+- モジュール間共有は getRandom() 経由に統一
+- グローバル可変状態の DI 化は別フェーズの課題として spec に記録済み"
+```
+
+---
+
+## Task 3: `enemyMovement.ts` を作成（移動エンジンを移動・calculateStep 適用）
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/enemyMovement.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+移動する要素: `stepTowards`, `stepAway`, `stepRandom`, `attemptLunge`（全 private）,
+`moveEnemyTowards`(public), `moveEnemyAway`, `moveEnemyRandom`（private）,
+`generatePatrolPath`(public), `getNextPatrolPoint`(public)。
+`stepTowards` / `stepAway` / `attemptLunge` の方向計算を `calculateStep` に置換する。
+
+- [ ] **Step 1: `enemyMovement.ts` を実装**
+
+Create `enemyMovement.ts`:
+
+```typescript
+/**
+ * 敵の移動エンジン
+ *
+ * マップ衝突（collisionService）を考慮した1ステップ移動と巡回パス生成を提供する。
+ * 方向計算は aiGeometry.calculateStep に集約。
+ */
+import { Enemy, GameMap, Position } from '../../types';
+import { canMove } from '../../services/collisionService';
+import { calculateStep, getManhattanDistance } from './aiGeometry';
+import { getRandom } from './aiRandom';
+
+/** ターゲットへ1歩近づく（横優先/縦優先を距離差で決定、塞がれたら停止） */
+const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => {
+  const { stepX, stepY } = calculateStep(enemy, target);
+  const dx = target.x - enemy.x;
+  const dy = target.y - enemy.y;
+  const tryHorizontal = Math.abs(dx) >= Math.abs(dy);
+
+  const candidates: Position[] = tryHorizontal
+    ? [
+        { x: enemy.x + stepX, y: enemy.y },
+        { x: enemy.x, y: enemy.y + stepY },
+      ]
+    : [
+        { x: enemy.x, y: enemy.y + stepY },
+        { x: enemy.x + stepX, y: enemy.y },
+      ];
+
+  for (const pos of candidates) {
+    if (canMove(map, pos.x, pos.y)) return pos;
+  }
+  return { x: enemy.x, y: enemy.y };
+};
+
+/** プレイヤーから1歩離れる（4方向を順に試行） */
+const stepAway = (enemy: Enemy, player: Position, map: GameMap): Position => {
+  const { stepX, stepY } = calculateStep(player, enemy);
+  const candidates: Position[] = [
+    { x: enemy.x + stepX, y: enemy.y },
+    { x: enemy.x, y: enemy.y + stepY },
+    { x: enemy.x - stepX, y: enemy.y },
+    { x: enemy.x, y: enemy.y - stepY },
+  ];
+  for (const pos of candidates) {
+    if (canMove(map, pos.x, pos.y)) return pos;
+  }
+  return { x: enemy.x, y: enemy.y };
+};
+
+/** 突進（最大距離内かつ確率成立時、2マス先まで一気に移動） */
+const attemptLunge = (
+  enemy: Enemy,
+  target: Position,
+  map: GameMap,
+  maxDistance: number,
+  chance: number
+): Enemy | null => {
+  const distance = getManhattanDistance(enemy, target);
+  if (distance > maxDistance) return null;
+  if (getRandom().random() > chance) return null;
+
+  const { stepX, stepY } = calculateStep(enemy, target);
+  const dx = target.x - enemy.x;
+  const dy = target.y - enemy.y;
+  const preferHorizontal = Math.abs(dx) >= Math.abs(dy);
+
+  const firstStep = preferHorizontal
+    ? { x: enemy.x + stepX, y: enemy.y }
+    : { x: enemy.x, y: enemy.y + stepY };
+  const secondStep = preferHorizontal
+    ? { x: enemy.x + stepX * 2, y: enemy.y }
+    : { x: enemy.x, y: enemy.y + stepY * 2 };
+
+  if (!canMove(map, firstStep.x, firstStep.y)) return null;
+  if (!canMove(map, secondStep.x, secondStep.y)) return null;
+  return { ...enemy, x: secondStep.x, y: secondStep.y };
+};
+
+/** ランダムな方向に1歩移動 */
+const stepRandom = (enemy: Enemy, map: GameMap): Position => {
+  const directions = [
+    { x: enemy.x + 1, y: enemy.y },
+    { x: enemy.x - 1, y: enemy.y },
+    { x: enemy.x, y: enemy.y + 1 },
+    { x: enemy.x, y: enemy.y - 1 },
+  ];
+  const shuffled = getRandom().shuffle(directions);
+  for (const pos of shuffled) {
+    if (canMove(map, pos.x, pos.y)) return pos;
+  }
+  return { x: enemy.x, y: enemy.y };
+};
+
+export const moveEnemyTowards = (enemy: Enemy, target: Position, map: GameMap): Enemy => {
+  const next = stepTowards(enemy, target, map);
+  return { ...enemy, x: next.x, y: next.y };
+};
+
+export const moveEnemyAway = (enemy: Enemy, player: Position, map: GameMap): Enemy => {
+  const next = stepAway(enemy, player, map);
+  return { ...enemy, x: next.x, y: next.y };
+};
+
+export const moveEnemyRandom = (enemy: Enemy, map: GameMap): Enemy => {
+  const next = stepRandom(enemy, map);
+  return { ...enemy, x: next.x, y: next.y };
+};
+
+export { attemptLunge };
+
+/** 巡回パスを生成する（往路＋復路、長さ4-8マス） */
+export const generatePatrolPath = (origin: Position): Position[] => {
+  const length = getRandom().randomInt(4, 9); // 4-8
+  const horizontal = getRandom().random() > 0.5;
+  const path: Position[] = [];
+  for (let i = 0; i < length; i++) {
+    path.push({
+      x: origin.x + (horizontal ? i : 0),
+      y: origin.y + (horizontal ? 0 : i),
+    });
+  }
+  const back = [...path].reverse().slice(1);
+  return [...path, ...back];
+};
+
+/** 次の巡回ポイントを取得する */
+export const getNextPatrolPoint = (enemy: Enemy): Position | undefined => {
+  if (!enemy.patrolPath || enemy.patrolPath.length === 0) return undefined;
+  const index = enemy.patrolIndex ?? 0;
+  return enemy.patrolPath[index];
+};
+```
+
+- [ ] **Step 2: `enemyAiFunctions.ts` から移動定義を削除し re-export に置換**
+
+`enemyAiFunctions.ts` で以下を実施:
+1. 削除: `stepTowards`(90-115行), `stepAway`(117-137行), `attemptLunge`(139-167行), `stepRandom`(169-188行), `moveEnemyTowards`(190-193行), `moveEnemyAway`(195-198行), `moveEnemyRandom`(200-203行), `generatePatrolPath`(205-219行), `getNextPatrolPoint`(221-225行)。
+   ※行番号は Task 1/2 の削除でずれているため、関数名で特定すること。
+2. import 群に追加し再公開:
+
+```typescript
+import {
+  moveEnemyTowards,
+  moveEnemyAway,
+  moveEnemyRandom,
+  attemptLunge,
+  generatePatrolPath,
+  getNextPatrolPoint,
+} from './enemyMovement';
+
+export { moveEnemyTowards, generatePatrolPath, getNextPatrolPoint };
+```
+
+> 注: `moveEnemyAway` / `moveEnemyRandom` / `attemptLunge` は import するが re-export しない（元々 private）。
+> これらは残存する `updatePatrolEnemy` 等がまだ参照するため import が必要。
+> Task 2 で導入した `getRandom` の import は、このファイルから乱数を直接使う箇所が無くなれば削除する（lint で検出）。
+
+- [ ] **Step 3: 既存テストが緑であることを確認**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS（特に `enemyAI.test.ts` の「巡回移動がパスに沿って進むこと」「標本型移動がプレイヤーから離れること」）
+
+- [ ] **Step 4: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/enemyMovement.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵の移動エンジンを enemyMovement へ分離
+
+- step/move 系・突進・巡回パス生成を移動
+- 方向計算を calculateStep に集約しコピペを解消
+- moveEnemyTowards/generatePatrolPath/getNextPatrolPoint は barrel 維持"
+```
+
+---
+
+## Task 4: `attackState.ts` を作成（攻撃・ノックバック状態を移動）
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/attackState.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+移動する要素: `canEnemyAttack`(public), `setEnemyAttackCooldown`(public),
+`ENEMY_ATTACK_ANIM_DURATION`(public), `markEnemyAttacking`(public),
+`resolveEnemyAttackState`(public), `resolveKnockbackState`(private)。
+
+- [ ] **Step 1: `attackState.ts` を実装**
+
+Create `attackState.ts`:
+
+```typescript
+/**
+ * 敵の攻撃可否・攻撃/ノックバックアニメーション状態の解決
+ */
+import { Enemy, EnemyState, EnemyType, Position } from '../../types';
+import { GAME_BALANCE } from '../../config/gameBalance';
+import { AI_CONFIG, getManhattanDistance } from './aiGeometry';
+
+/** 敵攻撃アニメーションの持続時間（ms） */
+export const ENEMY_ATTACK_ANIM_DURATION = GAME_BALANCE.enemyAi.attackAnimDurationMs;
+
+/** 敵が攻撃可能かどうか */
+export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
+  if (enemy.attackRange <= 0) return false;
+  if (currentTime < enemy.attackCooldownUntil) return false;
+  return getManhattanDistance(enemy, player) <= enemy.attackRange;
+};
+
+/** 敵の攻撃クールダウンを設定 */
+export const setEnemyAttackCooldown = (enemy: Enemy, currentTime: number): Enemy => {
+  const cooldown =
+    enemy.type === EnemyType.BOSS
+      ? GAME_BALANCE.enemyAi.bossAttackCooldownMs
+      : AI_CONFIG.attackCooldown;
+  return { ...enemy, attackCooldownUntil: currentTime + cooldown };
+};
+
+/**
+ * 敵を攻撃状態にマークする
+ * knockback 状態の敵には適用しない
+ */
+export const markEnemyAttacking = (enemy: Enemy, now: number): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+  return {
+    ...enemy,
+    state: EnemyState.ATTACK,
+    attackAnimUntil: now + ENEMY_ATTACK_ANIM_DURATION,
+  };
+};
+
+/**
+ * 敵の攻撃アニメーション状態を解決する
+ * 持続時間経過後に IDLE 状態に戻す
+ */
+export const resolveEnemyAttackState = (enemy: Enemy, now: number): Enemy => {
+  if (enemy.state !== EnemyState.ATTACK) return enemy;
+  if (enemy.attackAnimUntil === undefined) return { ...enemy, state: EnemyState.IDLE };
+  if (now < enemy.attackAnimUntil) return enemy;
+  return { ...enemy, state: EnemyState.IDLE, attackAnimUntil: undefined };
+};
+
+/** ノックバック状態を解決する（持続時間経過後に IDLE へ） */
+export const resolveKnockbackState = (enemy: Enemy, currentTime: number): Enemy => {
+  if (enemy.state !== EnemyState.KNOCKBACK) return enemy;
+  if (enemy.knockbackUntil === undefined) return { ...enemy, state: EnemyState.IDLE };
+  if (currentTime < enemy.knockbackUntil) return enemy;
+  return { ...enemy, state: EnemyState.IDLE, knockbackDirection: undefined, knockbackUntil: undefined };
+};
+```
+
+- [ ] **Step 2: `enemyAiFunctions.ts` から移動定義を削除し re-export に置換**
+
+`enemyAiFunctions.ts` で以下を実施（関数名で特定）:
+1. 削除: `canEnemyAttack`, `setEnemyAttackCooldown`, `ENEMY_ATTACK_ANIM_DURATION`, `markEnemyAttacking`, `resolveEnemyAttackState`, `resolveKnockbackState`。
+2. import 群に追加し再公開:
+
+```typescript
+import {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  ENEMY_ATTACK_ANIM_DURATION,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
+  resolveKnockbackState,
+} from './attackState';
+
+export {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  ENEMY_ATTACK_ANIM_DURATION,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
+};
+```
+
+> 注: `resolveKnockbackState` は import するが re-export しない（元々 private、`updateEnemyAI` が使用）。
+
+- [ ] **Step 3: 既存テストが緑であることを確認**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS（特に `enemyAttackAnim.test.ts` と `markEnemyAttacking`/`resolveEnemyAttackState`/`AI_CONFIG` テスト）
+
+- [ ] **Step 4: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/attackState.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵の攻撃・ノックバック状態解決を attackState へ分離"
+```
+
+---
+
+## Task 5: `behaviors/patrolBehavior.ts` と `behaviors/chargeBehavior.ts` を作成
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/behaviors/patrolBehavior.ts`
+- Create: `src/features/ipne/domain/policies/enemyAi/behaviors/chargeBehavior.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+移動する要素: `updatePatrolEnemy`(public), `updateChargeEnemy`(public)。本体は現状を**逐語移動**し、
+依存関数を新モジュールから import するだけ（ロジック不変）。
+
+- [ ] **Step 1: `patrolBehavior.ts` を実装**
+
+Create `behaviors/patrolBehavior.ts`（`updatePatrolEnemy` の本体は `enemyAiFunctions.ts` 227-284行を逐語移動）:
+
+```typescript
+/** PATROL 型敵のAI更新 */
+import { Enemy, EnemyState, GameMap, Position } from '../../../types';
+import { detectPlayer, shouldStopChase } from '../aiGeometry';
+import { moveEnemyTowards, moveEnemyRandom, attemptLunge, getNextPatrolPoint } from '../enemyMovement';
+
+export const updatePatrolEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  const playerDetected = detectPlayer(enemy, player);
+
+  if (playerDetected) {
+    const updated = {
+      ...enemy,
+      state: EnemyState.CHASE,
+      lastKnownPlayerPos: player,
+      lastSeenAt: currentTime,
+    };
+    const lunge = attemptLunge(updated, player, map, 2, 0.1);
+    return lunge ?? moveEnemyTowards(updated, player, map);
+  }
+
+  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.RETURN };
+  }
+
+  if (enemy.state === EnemyState.CHASE) {
+    const lunge = attemptLunge(enemy, player, map, 2, 0.1);
+    const updated = lunge ?? moveEnemyTowards(enemy, player, map);
+    return { ...updated, lastKnownPlayerPos: player, lastSeenAt: currentTime };
+  }
+
+  if (enemy.state === EnemyState.RETURN) {
+    if (enemy.x === enemy.homePosition.x && enemy.y === enemy.homePosition.y) {
+      return { ...enemy, state: EnemyState.PATROL };
+    }
+    return moveEnemyTowards(enemy, enemy.homePosition, map);
+  }
+
+  if (enemy.patrolPath && enemy.patrolPath.length > 0) {
+    const target = getNextPatrolPoint(enemy);
+    if (target) {
+      const moved = moveEnemyTowards(enemy, target, map);
+      if (moved.x === target.x && moved.y === target.y) {
+        const nextIndex = (enemy.patrolIndex ?? 0) + 1;
+        return { ...moved, patrolIndex: nextIndex % enemy.patrolPath.length };
+      }
+      return moved;
+    }
+  }
+
+  return moveEnemyRandom(enemy, map);
+};
+```
+
+- [ ] **Step 2: `chargeBehavior.ts` を実装**
+
+Create `behaviors/chargeBehavior.ts`（`updateChargeEnemy` 本体を 286-321行から逐語移動）:
+
+```typescript
+/** CHARGE/BOSS 型敵のAI更新 */
+import { Enemy, EnemyState, EnemyType, GameMap, Position } from '../../../types';
+import { shouldChase, shouldStopChase, getManhattanDistance } from '../aiGeometry';
+import { moveEnemyTowards, attemptLunge } from '../enemyMovement';
+
+export const updateChargeEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  if (shouldChase(enemy, player)) {
+    const moved = moveEnemyTowards(enemy, player, map);
+    return {
+      ...moved,
+      state: EnemyState.CHASE,
+      lastKnownPlayerPos: player,
+      lastSeenAt: currentTime,
+    };
+  }
+
+  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.IDLE };
+  }
+
+  if (enemy.state === EnemyState.CHASE) {
+    if (enemy.type === EnemyType.BOSS) {
+      const distance = getManhattanDistance(enemy, player);
+      const lungeChance = distance <= 2 ? 0.55 : distance <= 4 ? 0.4 : 0.25;
+      const lungeRange = distance <= 2 ? 3 : 4;
+      const lunge = attemptLunge(enemy, player, map, lungeRange, lungeChance);
+      return lunge ?? moveEnemyTowards(enemy, player, map);
+    }
+    const lunge = attemptLunge(enemy, player, map, 2, 0.2);
+    return lunge ?? moveEnemyTowards(enemy, player, map);
+  }
+
+  return { ...enemy, state: EnemyState.IDLE };
+};
+```
+
+- [ ] **Step 3: `enemyAiFunctions.ts` を更新**
+
+`enemyAiFunctions.ts` で `updatePatrolEnemy` / `updateChargeEnemy` の定義を削除し、再公開:
+
+```typescript
+import { updatePatrolEnemy } from './behaviors/patrolBehavior';
+import { updateChargeEnemy } from './behaviors/chargeBehavior';
+
+export { updatePatrolEnemy, updateChargeEnemy };
+```
+
+> 注: これらは Task 7 の registry 構築でも使うため、enemyAiFunctions に残る registry コードが
+> import 済みの名前を参照できる状態を保つ。
+
+- [ ] **Step 4: 既存テストが緑であることを確認**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS
+
+- [ ] **Step 5: 型チェック＆コミット**
+
+Run: `npm run typecheck 2>&1 | tail -5`（エラーなし）
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/behaviors/patrolBehavior.ts \
+        src/features/ipne/domain/policies/enemyAi/behaviors/chargeBehavior.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵AIの PATROL/CHARGE 更新を behaviors へ分離"
+```
+
+---
+
+## Task 6: `behaviors/rangedBehavior.ts` と `behaviors/fleeBehavior.ts` を作成
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/behaviors/rangedBehavior.ts`
+- Create: `src/features/ipne/domain/policies/enemyAi/behaviors/fleeBehavior.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+移動する要素: `updateRangedEnemy`(public), `updateFleeEnemy`(public),
+`RANGED_PREFERRED_DISTANCE`(private、ranged 内へ)。
+
+- [ ] **Step 1: `rangedBehavior.ts` を実装**
+
+Create `behaviors/rangedBehavior.ts`（`updateRangedEnemy` 本体を 389-453行から逐語移動。`RANGED_PREFERRED_DISTANCE` も同梱）:
+
+```typescript
+/** RANGED 型敵のAI更新（適切な間合いを保つ） */
+import { Enemy, EnemyState, GameMap, Position } from '../../../types';
+import { GAME_BALANCE } from '../../../config/gameBalance';
+import { detectPlayer, shouldStopChase, getManhattanDistance } from '../aiGeometry';
+import { moveEnemyTowards, moveEnemyAway } from '../enemyMovement';
+
+/** RANGED敵が維持したい距離 */
+const RANGED_PREFERRED_DISTANCE = GAME_BALANCE.enemyAi.rangedPreferredDistance;
+
+export const updateRangedEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  const playerDetected = detectPlayer(enemy, player);
+
+  if (playerDetected) {
+    const distance = getManhattanDistance(enemy, player);
+
+    if (distance < RANGED_PREFERRED_DISTANCE) {
+      const moved = moveEnemyAway(enemy, player, map);
+      return { ...moved, state: EnemyState.CHASE, lastKnownPlayerPos: player, lastSeenAt: currentTime };
+    }
+
+    if (distance > enemy.attackRange) {
+      const moved = moveEnemyTowards(enemy, player, map);
+      return { ...moved, state: EnemyState.CHASE, lastKnownPlayerPos: player, lastSeenAt: currentTime };
+    }
+
+    return { ...enemy, state: EnemyState.CHASE, lastKnownPlayerPos: player, lastSeenAt: currentTime };
+  }
+
+  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.RETURN };
+  }
+
+  if (enemy.state === EnemyState.CHASE && enemy.lastKnownPlayerPos) {
+    return moveEnemyTowards(enemy, enemy.lastKnownPlayerPos, map);
+  }
+
+  if (enemy.state === EnemyState.RETURN) {
+    if (enemy.x === enemy.homePosition.x && enemy.y === enemy.homePosition.y) {
+      return { ...enemy, state: EnemyState.IDLE };
+    }
+    return moveEnemyTowards(enemy, enemy.homePosition, map);
+  }
+
+  return { ...enemy, state: EnemyState.IDLE };
+};
+```
+
+- [ ] **Step 2: `fleeBehavior.ts` を実装**
+
+Create `behaviors/fleeBehavior.ts`（`updateFleeEnemy` 本体を 355-378行から逐語移動）:
+
+```typescript
+/** SPECIMEN（標本）型敵のAI更新（プレイヤーから逃走） */
+import { Enemy, EnemyState, GameMap, Position } from '../../../types';
+import { detectPlayer, shouldStopChase } from '../aiGeometry';
+import { moveEnemyAway } from '../enemyMovement';
+
+export const updateFleeEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  if (detectPlayer(enemy, player)) {
+    const moved = moveEnemyAway(enemy, player, map);
+    return { ...moved, state: EnemyState.FLEE, lastKnownPlayerPos: player, lastSeenAt: currentTime };
+  }
+
+  if (enemy.state === EnemyState.FLEE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.IDLE };
+  }
+
+  return { ...enemy, state: EnemyState.IDLE };
+};
+```
+
+- [ ] **Step 3: `enemyAiFunctions.ts` を更新**
+
+`updateRangedEnemy` / `updateFleeEnemy` の定義（および `RANGED_PREFERRED_DISTANCE` 定数）を削除し、再公開:
+
+```typescript
+import { updateRangedEnemy } from './behaviors/rangedBehavior';
+import { updateFleeEnemy } from './behaviors/fleeBehavior';
+
+export { updateRangedEnemy, updateFleeEnemy };
+```
+
+- [ ] **Step 4: 既存テストが緑であることを確認**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS（特に `enemyAI.test.ts` の「遠隔攻撃型敵」5テスト・「標本型移動」テスト）
+
+- [ ] **Step 5: 型チェック＆コミット**
+
+Run: `npm run typecheck 2>&1 | tail -5`（エラーなし）
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/behaviors/rangedBehavior.ts \
+        src/features/ipne/domain/policies/enemyAi/behaviors/fleeBehavior.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵AIの RANGED/FLEE 更新を behaviors へ分離"
+```
+
+---
+
+## Task 7: `enemyOrchestrator.ts` を作成（一括更新を移動）
+
+**Files:**
+- Create: `src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts`
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+移動する要素: registry 構築（`enemyAiPolicyRegistry`）, `updateEnemyAI`(public),
+`EnemyUpdateResult`(public type), `toPositionKey`(private),
+`updateEnemies`(public), `updateEnemiesWithContact`(public)。本体は 455-571行を逐語移動。
+
+- [ ] **Step 1: `enemyOrchestrator.ts` を実装**
+
+Create `enemyOrchestrator.ts`:
+
+```typescript
+/**
+ * 敵の一括更新オーケストレーション
+ *
+ * Policy registry を通じてタイプ別 AI を適用し、移動間隔・衝突・接触/攻撃ダメージを解決する。
+ */
+import { Enemy, GameMap, Position } from '../../types';
+import { buildDefaultEnemyAiPolicyRegistry } from './policies';
+import {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
+  resolveKnockbackState,
+} from './attackState';
+import { updatePatrolEnemy } from './behaviors/patrolBehavior';
+import { updateChargeEnemy } from './behaviors/chargeBehavior';
+import { updateRangedEnemy } from './behaviors/rangedBehavior';
+import { updateFleeEnemy } from './behaviors/fleeBehavior';
+
+const enemyAiPolicyRegistry = buildDefaultEnemyAiPolicyRegistry({
+  updatePatrolEnemy,
+  updateChargeEnemy,
+  updateRangedEnemy,
+  updateFleeEnemy,
+});
+
+export const updateEnemyAI = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  const resolved = resolveKnockbackState(enemy, currentTime);
+  return enemyAiPolicyRegistry.update({ enemy: resolved, player, map, currentTime });
+};
+
+export interface EnemyUpdateResult {
+  enemies: Enemy[];
+  contactDamage: number;
+  contactEnemy?: Enemy;
+  attackDamage: number;
+  attackingEnemy?: Enemy;
+}
+
+const toPositionKey = (pos: Position): string => `${pos.x},${pos.y}`;
+
+export const updateEnemies = (
+  enemies: Enemy[],
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy[] => updateEnemiesWithContact(enemies, player, map, currentTime).enemies;
+
+export const updateEnemiesWithContact = (
+  enemies: Enemy[],
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): EnemyUpdateResult => {
+  const occupied = new Set<string>();
+  occupied.add(toPositionKey(player));
+  for (const enemy of enemies) {
+    occupied.add(toPositionKey(enemy));
+  }
+
+  const updatedEnemies: Enemy[] = [];
+  let contactDamage = 0;
+  let contactEnemy: Enemy | undefined;
+  let attackDamage = 0;
+  let attackingEnemy: Enemy | undefined;
+
+  for (const enemy of enemies) {
+    occupied.delete(toPositionKey(enemy));
+    let candidate = updateEnemyAI(enemy, player, map, currentTime);
+    const moveInterval = 1000 / Math.max(1, enemy.speed);
+    const canStep = currentTime - (enemy.lastMoveAt ?? 0) >= moveInterval;
+    if (!canStep) {
+      candidate = { ...candidate, x: enemy.x, y: enemy.y, lastMoveAt: enemy.lastMoveAt ?? 0 };
+    } else {
+      candidate = { ...candidate, lastMoveAt: currentTime };
+    }
+    const candidateKey = toPositionKey(candidate);
+    const playerKey = toPositionKey(player);
+
+    candidate = resolveEnemyAttackState(candidate, currentTime);
+
+    if (canEnemyAttack(candidate, player, currentTime)) {
+      if (candidate.damage > attackDamage) {
+        attackDamage = candidate.damage;
+        attackingEnemy = candidate;
+      }
+      candidate = setEnemyAttackCooldown(candidate, currentTime);
+      candidate = markEnemyAttacking(candidate, currentTime);
+    }
+
+    if (candidateKey === playerKey) {
+      if (enemy.damage >= contactDamage) {
+        contactDamage = enemy.damage;
+        contactEnemy = enemy;
+      }
+      candidate = markEnemyAttacking(candidate, currentTime);
+      updatedEnemies.push({ ...candidate, x: enemy.x, y: enemy.y });
+      occupied.add(toPositionKey(enemy));
+      continue;
+    }
+
+    if (occupied.has(candidateKey)) {
+      updatedEnemies.push({ ...candidate, x: enemy.x, y: enemy.y });
+      occupied.add(toPositionKey(enemy));
+      continue;
+    }
+
+    updatedEnemies.push(candidate);
+    occupied.add(candidateKey);
+  }
+
+  return { enemies: updatedEnemies, contactDamage, contactEnemy, attackDamage, attackingEnemy };
+};
+```
+
+- [ ] **Step 2: `enemyAiFunctions.ts` から orchestrator 定義を削除し re-export に置換**
+
+`enemyAiFunctions.ts` で registry 構築・`updateEnemyAI`・`EnemyUpdateResult`・`toPositionKey`・`updateEnemies`・`updateEnemiesWithContact` を削除し、再公開:
+
+```typescript
+import { updateEnemyAI, updateEnemies, updateEnemiesWithContact } from './enemyOrchestrator';
+import type { EnemyUpdateResult } from './enemyOrchestrator';
+
+export { updateEnemyAI, updateEnemies, updateEnemiesWithContact };
+export type { EnemyUpdateResult };
+```
+
+- [ ] **Step 3: 既存テストが緑であることを確認**
+
+Run: `npm test -- enemyAi enemyAI enemyAttackAnim 2>&1 | tail -15`
+Expected: PASS（`updateEnemiesWithContact` テスト・`EnemyUpdateResult` 型）
+
+- [ ] **Step 4: 型チェック＆コミット**
+
+Run: `npm run typecheck 2>&1 | tail -5`（エラーなし）
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE 敵の一括更新を enemyOrchestrator へ分離"
+```
+
+---
+
+## Task 8: `enemyAiFunctions.ts` を純粋 barrel に整形し最終検証
+
+**Files:**
+- Modify: `src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+
+この時点で `enemyAiFunctions.ts` には実装が残っていないはず。import＋export を整理し、
+冒頭コメントを barrel である旨に更新する。
+
+- [ ] **Step 1: `enemyAiFunctions.ts` を純粋 barrel として書き直す**
+
+`enemyAiFunctions.ts` の全内容を以下に置換:
+
+```typescript
+/**
+ * 敵AIロジック（barrel）
+ *
+ * 実装は責務別ファイルへ分割済み。本ファイルは後方互換のための re-export のみを行う。
+ * 公開 API（エクスポート名・シグネチャ）は分割前と完全一致を維持する。
+ * 設計: docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md
+ */
+export { setRandomProvider, resetRandomProvider } from './aiRandom';
+export {
+  AI_CONFIG,
+  detectPlayer,
+  shouldChase,
+  shouldStopChase,
+  calculateFleeDirection,
+  getDirectPathToPlayer,
+} from './aiGeometry';
+export {
+  moveEnemyTowards,
+  generatePatrolPath,
+  getNextPatrolPoint,
+} from './enemyMovement';
+export {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  ENEMY_ATTACK_ANIM_DURATION,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
+} from './attackState';
+export { updatePatrolEnemy } from './behaviors/patrolBehavior';
+export { updateChargeEnemy } from './behaviors/chargeBehavior';
+export { updateRangedEnemy } from './behaviors/rangedBehavior';
+export { updateFleeEnemy } from './behaviors/fleeBehavior';
+export { updateEnemyAI, updateEnemies, updateEnemiesWithContact } from './enemyOrchestrator';
+export type { EnemyUpdateResult } from './enemyOrchestrator';
+```
+
+- [ ] **Step 2: 公開エクスポートが分割前と一致することを確認**
+
+Run: `grep -oE "export (const|function|interface|\{[^}]*\}|type \{[^}]*\})" src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts`
+Expected: 「公開 API」セクションの24エクスポートと過不足なく一致（`getManhattanDistance`/`calculateStep` 等の private が混入していないこと）。
+
+- [ ] **Step 3: IPNE 全テストを実行（回帰確認）**
+
+Run: `npm test -- ipne 2>&1 | tail -20`
+Expected: PASS（IPNE 全テストスイート green。フレイキー対策済みのパフォーマンステスト含む）
+
+- [ ] **Step 4: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし
+
+- [ ] **Step 5: lint（警告ゼロ強制・未使用 import 検出）**
+
+Run: `npm run lint:ci 2>&1 | tail -20`
+Expected: エラー・警告なし（途中タスクで残った未使用 import があればここで検出 → 削除して再実行）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE enemyAiFunctions を純粋な barrel へ整形
+
+- 全実装を責務別ファイルへ移動完了
+- 24個の公開エクスポートを re-export で後方互換維持
+- Phase A（敵AIロジック責務分割）完了"
+```
+
+---
+
+## Task 9: README とロードマップの更新
+
+**Files:**
+- Modify: `src/features/ipne/README.md`
+
+- [ ] **Step 1: README の `policies/` 記述を更新**
+
+`README.md` 105-106行付近の `policies/` 説明を、新ファイル構成（`aiGeometry`/`aiRandom`/`enemyMovement`/`attackState`/`behaviors/`/`enemyOrchestrator`）を反映する形に更新する。`types.ts` の barrel 記述（66-67行付近）と同様に、`enemyAiFunctions.ts` が barrel である旨を1文追記する。
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add src/features/ipne/README.md
+git commit -m "docs: IPNE README に敵AIの責務分割後の構成を反映"
+```
+
+---
+
+## 完了の定義（Definition of Done）
+
+- [ ] `enemyAiFunctions.ts` が純粋 barrel（re-export のみ）
+- [ ] `aiRandom` / `aiGeometry` / `enemyMovement` / `attackState` / `enemyOrchestrator` ＋ `behaviors/`4ファイルに責務分割
+- [ ] `calculateStep` 新設、方向計算のコピペ5箇所が解消
+- [ ] 公開24エクスポートが分割前と完全一致（private の漏洩なし）
+- [ ] 参照元4ファイル（index.ts / tickGameState.ts / enemyAI.test.ts / enemyAttackAnim.test.ts）と `policies.ts` が無修正
+- [ ] `npm test -- ipne` / `npm run typecheck` / `npm run lint:ci` 全パス
+- [ ] README 更新済み
+- [ ] 既知の負債（`_random` の DI 化・`getManhattanDistance` の `shared/` 共通化）が spec に記録済み

--- a/docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md
+++ b/docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md
@@ -1,0 +1,181 @@
+# IPNE 敵AIロジックの責務分割 設計（Phase A）
+
+- 日付: 2026-06-14
+- 対象: `src/features/ipne/domain/policies/enemyAi/`
+- 種別: リファクタリング（**振る舞い不変** の構造分割）
+- 位置づけ: IPNE 包括リファクタリング・ロードマップの **Phase A**（最初のサブプロジェクト）
+
+## 1. 背景と目的
+
+IPNE は既に Phase 1〜7 のリファクタリングを経た成熟コードだが、調査の結果、
+ドメイン層の `enemyAiFunctions.ts`（600行）が **「Strategy パターンの皮を被った関数ダンプ」**
+になっていることが判明した。隣接する `EnemyAiPolicyRegistry.ts` / `policies.ts` / `types.ts`
+という Strategy 基盤は健全に整理されているのに、肝心の AI ロジック本体が
+7 つの異なる責務を 1 ファイルに同居させている。
+
+| 責務 | 該当関数 |
+|------|---------|
+| 乱数プロバイダ DI | `defaultRandom`, `setRandomProvider`, `resetRandomProvider`, `_random` |
+| 幾何・検知判定 | `getManhattanDistance`, `calculateFleeDirection`, `getDirectPathToPlayer`, `detectPlayer`, `shouldChase`, `shouldStopChase` |
+| 移動エンジン | `stepTowards`, `stepAway`, `stepRandom`, `attemptLunge`, `moveEnemyTowards/Away/Random`, `generatePatrolPath`, `getNextPatrolPoint` |
+| 攻撃・ノックバック状態 | `canEnemyAttack`, `setEnemyAttackCooldown`, `markEnemyAttacking`, `resolveEnemyAttackState`, `resolveKnockbackState`, `ENEMY_ATTACK_ANIM_DURATION`, `AI_CONFIG` |
+| 敵タイプ別 AI | `updatePatrolEnemy`, `updateChargeEnemy`, `updateRangedEnemy`, `updateFleeEnemy` |
+| 一括更新オーケストレーション | `updateEnemyAI`, `updateEnemies`, `updateEnemiesWithContact` |
+
+加えて、**方向計算 `dx, dy → stepX, stepY` のコピペが 5 箇所**（`stepTowards` /
+`stepAway` / `attemptLunge` / `getDirectPathToPlayer` / `calculateFleeDirection`）に存在し、
+DRY 違反となっている。
+
+本作業の目的:
+
+1. 600 行の単一ファイルを **責務単位のファイル群へ分割**し、可読性・拡張性を高める。
+2. 方向計算の DRY 違反を **単一の `calculateStep()`** に集約する。
+3. 公開 API・振る舞い・テストを **一切変えない**（純粋な構造リファクタリング）。
+
+### 非目標（YAGNI）
+
+- **`_random` のグローバル可変状態の DI 化は行わない。** これは明確な smell だが、
+  「構造分割」と「DI 変更」を同一フェーズで混ぜると、テスト失敗時の原因切り分けが
+  困難になる。本フェーズでは `aiRandom.ts` に隠蔽するに留め、グローバル可変状態の除去は
+  **別フェーズの課題**として §6 に記録する。
+- 敵 AI の挙動・バランス調整（移動確率、突進確率、検知範囲など）の変更。
+- `enemyAi/` 以外の領域（`tickGameState.ts` の整理等）。これらは後続フェーズ（B〜E）で扱う。
+
+## 2. 現状調査の要点
+
+- **参照元は 4 つだけ**（公開 API として維持すべき対象）:
+  - `src/features/ipne/index.ts`（barrel re-export）
+  - `src/features/ipne/application/engine/tickGameState.ts`（`updateEnemiesWithContact` 等）
+  - `src/features/ipne/__tests__/enemyAttackAnim.test.ts`
+  - `src/features/ipne/__tests__/enemyAI.test.ts`
+- **同ディレクトリのテスト**: `enemyAiFunctions.test.ts`（174行）がこのファイルを直接 import。
+- Strategy 基盤（`EnemyAiPolicyRegistry` / `policies.ts` / `types.ts`）は健全。今回は触らない。
+- `policies.ts` は `updatePatrol/Charge/Ranged/Flee` の 4 関数を注入して registry を構築する。
+  分割後もこの 4 関数のシグネチャは不変なので、`policies.ts` は無修正で動く。
+
+## 3. 後方互換の方針
+
+Phase 1 で `types.ts` を 9 分割しつつ `types.ts` 自体を re-export barrel として残し、
+後方互換を保った前例がある。同じ手法を採用する:
+
+- **`enemyAiFunctions.ts` を re-export barrel として残す。**
+  全エクスポート（型・関数・定数）を新ファイル群から re-export し、
+  **エクスポート名・シグネチャを 1 文字も変えない**。
+- これにより 4 つの参照元（index.ts / tickGameState.ts / 2 テスト）と
+  `policies.ts` は **無修正**のまま動作する。
+
+## 4. 分割後のファイル構成
+
+`src/features/ipne/domain/policies/enemyAi/` 配下に以下を新設する:
+
+```
+enemyAi/
+  enemyAiFunctions.ts        # ← barrel: 下記すべてを re-export（後方互換）
+  aiRandom.ts                # 乱数プロバイダ DI
+  aiGeometry.ts              # 幾何・検知判定（calculateStep を新規追加）
+  enemyMovement.ts           # 移動エンジン
+  attackState.ts             # 攻撃・ノックバック状態
+  enemyOrchestrator.ts       # 一括更新オーケストレーション
+  behaviors/
+    patrolBehavior.ts        # updatePatrolEnemy
+    chargeBehavior.ts        # updateChargeEnemy
+    rangedBehavior.ts        # updateRangedEnemy
+    fleeBehavior.ts          # updateFleeEnemy
+  # 既存（無修正）: EnemyAiPolicyRegistry.ts, policies.ts, types.ts
+```
+
+### 各ファイルの責務と移動関数
+
+| ファイル | 責務 | 移動/新設する要素 |
+|---------|------|------------------|
+| `aiRandom.ts` | 乱数プロバイダの保持と差し替え | `defaultRandom`, `setRandomProvider`, `resetRandomProvider`, 内部 `_random` と getter |
+| `aiGeometry.ts` | 純粋な幾何計算・検知判定 | **`calculateStep`（新規）**, `getManhattanDistance`, `calculateFleeDirection`, `getDirectPathToPlayer`, `detectPlayer`, `shouldChase`, `shouldStopChase`, `AI_CONFIG`(検知/追跡定数) |
+| `enemyMovement.ts` | マップ衝突を考慮した移動 | `stepTowards`, `stepAway`, `stepRandom`, `attemptLunge`, `moveEnemyTowards`, `moveEnemyAway`, `moveEnemyRandom`, `generatePatrolPath`, `getNextPatrolPoint` |
+| `attackState.ts` | 攻撃可否・状態アニメーション | `canEnemyAttack`, `setEnemyAttackCooldown`, `markEnemyAttacking`, `resolveEnemyAttackState`, `resolveKnockbackState`, `ENEMY_ATTACK_ANIM_DURATION` |
+| `behaviors/*.ts` | 敵タイプ別 AI（各1ファイル） | `updatePatrolEnemy` / `updateChargeEnemy` / `updateRangedEnemy` / `updateFleeEnemy` |
+| `enemyOrchestrator.ts` | 全敵の一括更新・接触判定 | `updateEnemyAI`, `updateEnemies`, `updateEnemiesWithContact`, `EnemyUpdateResult`, 内部 `toPositionKey`, registry 構築 |
+| `enemyAiFunctions.ts` | **barrel** | 上記すべてを `export ... from` で再公開 |
+
+> 注: `AI_CONFIG` は検知/追跡系の定数（`updateInterval`, `chaseTimeout`, `attackCooldown`）。
+> 検知判定（`shouldStopChase`）と攻撃（`setEnemyAttackCooldown`）の両方から参照されるため、
+> `aiGeometry.ts` に定義し `attackState.ts` から import する。`enemyAiFunctions.ts` からの
+> `export { AI_CONFIG }` は barrel 経由で維持する。
+
+### モジュール依存方向（循環なし）
+
+```
+aiRandom ──┐
+aiGeometry ─┼─→ enemyMovement ──→ behaviors/* ──→ enemyOrchestrator ──→ (barrel)
+            └─→ attackState ─────────────────────→ enemyOrchestrator
+```
+
+- `aiGeometry` / `aiRandom` は最も内側（他に依存しない、`collisionService` を除く）。
+- `behaviors/*` は `enemyMovement` / `aiGeometry` / `attackState` に依存。
+- `enemyOrchestrator` が registry を組み立て、`behaviors/*` と `attackState` を統合。
+
+## 5. DRY の核：`calculateStep` の抽出
+
+5 箇所に散る方向計算を 1 関数へ集約する:
+
+```typescript
+// aiGeometry.ts
+/** 2点間の各軸の単位ステップ（-1 / 0 / +1）を返す */
+export const calculateStep = (
+  from: Position,
+  to: Position
+): { stepX: number; stepY: number } => ({
+  stepX: Math.sign(to.x - from.x),
+  stepY: Math.sign(to.y - from.y),
+});
+```
+
+- 既存の `dx === 0 ? 0 : dx > 0 ? 1 : -1` は **`Math.sign` と挙動が完全一致**
+  （0→0, 正→+1, 負→-1。座標は整数なので小数・NaN は発生しない）。
+- `stepTowards` / `stepAway` / `attemptLunge` / `getDirectPathToPlayer` /
+  `calculateFleeDirection` は内部で `calculateStep` を呼ぶように書き換える。
+- **引数の向きに注意**: `stepTowards` は `to - from`（敵→ターゲット）、
+  `stepAway`/`calculateFleeDirection` は `from - to`（プレイヤー→敵 = 逃走方向）。
+  後者は `calculateStep(player, enemy)` として呼び、意味を保つ。
+
+## 6. 既知の負債（本フェーズでは触らず記録のみ）
+
+| 項目 | 内容 | 想定フェーズ |
+|------|------|-------------|
+| `_random` グローバル可変状態 | `setRandomProvider`/`resetRandomProvider` でモジュール変数を差し替える方式。テスト間の状態リークや並行性の懸念。関数引数 or context 経由の DI へ移行が望ましい | 後続（要 spec） |
+| `getManhattanDistance` の重複 | `gimmickPlacement/scoring.ts` にも同等ロジックあり。`shared/` への共通化候補 | Phase E（小物共通化） |
+
+## 7. 検証手順（refactor-safely）
+
+1 コミット = 1 ファイル分の責務移動を基本とし、各ステップで以下を実行する:
+
+```bash
+npm test -- enemyAi          # 当該ディレクトリのテスト（enemyAiFunctions.test / Registry.test）
+npm test -- enemyAI enemyAttackAnim   # 参照元テスト
+npm run typecheck            # 型整合（barrel 経由の re-export 含む）
+```
+
+全ファイル移動の完了後、最終確認として:
+
+```bash
+npm run lint:ci              # 警告ゼロ強制（未使用 import の検出含む）
+npm test                     # IPNE 全テスト（回帰確認）
+```
+
+### 完了の定義（Definition of Done）
+
+- [ ] `enemyAiFunctions.ts` が barrel（re-export のみ）になっている
+- [ ] 上記 6 ファイル（barrel 含む）+ `behaviors/` 4 ファイルに責務が分割されている
+- [ ] `calculateStep` が新設され、5 箇所のコピペが解消されている
+- [ ] 公開 API（エクスポート名・シグネチャ）が変更前と完全一致
+- [ ] 参照元 4 ファイル・`policies.ts` が無修正
+- [ ] `npm test` / `npm run typecheck` / `npm run lint:ci` が全てパス
+- [ ] 既知の負債（§6）が記録されている
+
+## 8. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| barrel の re-export 漏れで公開 API が欠落 | typecheck と参照元テストで検出。エクスポート一覧を移動前後で diff 確認 |
+| `calculateStep` 置換で方向計算の符号を誤る | 各呼び出しの引数の向き（§5）をテストで保証。既存テストが緑であることを必須条件にする |
+| 循環 import の発生 | §4 の依存方向を厳守（geometry/random を最内、orchestrator を最外） |
+| 移動の粒度が大きすぎて切り戻し困難 | 1 コミット = 1 ファイル移動に分割 |

--- a/src/features/ipne/README.md
+++ b/src/features/ipne/README.md
@@ -103,7 +103,15 @@ src/features/ipne/
       mapService.ts           #   マップ管理
       gimmickPlacement/       #   ギミック配置サービス
     policies/                 # ドメインポリシー（Strategy パターン）
-      enemyAi/                #   敵AIポリシー（patrol, charge, ranged, flee 等）
+      enemyAi/                #   敵AIポリシー（責務別に分割）
+        enemyAiFunctions.ts   #     barrel（後方互換の re-export のみ）
+        aiGeometry.ts         #     幾何計算・検知判定（calculateStep, 距離, detect/chase）
+        aiRandom.ts           #     乱数プロバイダ DI
+        enemyMovement.ts      #     移動エンジン（step/move, 突進, 巡回パス）
+        attackState.ts        #     攻撃可否・攻撃/ノックバック状態解決
+        behaviors/            #     敵タイプ別 AI（patrol/charge/ranged/flee を1ファイルずつ）
+        enemyOrchestrator.ts  #     全敵の一括更新・接触/攻撃ダメージ解決
+        policies.ts / EnemyAiPolicyRegistry.ts  # Strategy レジストリ
     config/                   # ドメイン定数
       stageConfig.ts          #   5ステージ設定データ
       gameBalance.ts          #   全バランス定数（マジックナンバー集約）

--- a/src/features/ipne/domain/policies/enemyAi/aiGeometry.test.ts
+++ b/src/features/ipne/domain/policies/enemyAi/aiGeometry.test.ts
@@ -1,0 +1,38 @@
+import { calculateStep, calculateFleeDirection, getDirectPathToPlayer } from './aiGeometry';
+import { createPatrolEnemy } from '../../entities/enemy';
+
+const mockIdGen = {
+  generateEnemyId: () => 'e1',
+  generateTrapId: () => 't1',
+  generateItemId: () => 'i1',
+  generateFeedbackId: () => 'f1',
+};
+
+describe('aiGeometry', () => {
+  describe('calculateStep', () => {
+    it('各軸の単位ステップ（-1/0/+1）を返す', () => {
+      expect(calculateStep({ x: 2, y: 2 }, { x: 5, y: 1 })).toEqual({ stepX: 1, stepY: -1 });
+    });
+    it('同一座標では 0 を返す', () => {
+      expect(calculateStep({ x: 3, y: 3 }, { x: 3, y: 3 })).toEqual({ stepX: 0, stepY: 0 });
+    });
+    it('負方向では -1 を返す', () => {
+      expect(calculateStep({ x: 5, y: 5 }, { x: 1, y: 1 })).toEqual({ stepX: -1, stepY: -1 });
+    });
+  });
+
+  describe('calculateFleeDirection', () => {
+    it('プレイヤーと反対方向の隣接マスを返す', () => {
+      const enemy = createPatrolEnemy(3, 3, mockIdGen);
+      expect(calculateFleeDirection(enemy, { x: 2, y: 3 })).toEqual({ x: 4, y: 3 });
+    });
+  });
+
+  describe('getDirectPathToPlayer', () => {
+    it('敵からプレイヤーへの直線パスを返す', () => {
+      const enemy = createPatrolEnemy(1, 1, mockIdGen);
+      const path = getDirectPathToPlayer(enemy, { x: 3, y: 1 });
+      expect(path).toEqual([{ x: 2, y: 1 }, { x: 3, y: 1 }]);
+    });
+  });
+});

--- a/src/features/ipne/domain/policies/enemyAi/aiGeometry.ts
+++ b/src/features/ipne/domain/policies/enemyAi/aiGeometry.ts
@@ -1,0 +1,76 @@
+/**
+ * 敵AIの幾何計算・検知判定
+ *
+ * 座標計算（方向ステップ・距離）とプレイヤー検知・追跡継続判定を提供する。
+ * 純粋関数のみ（マップ衝突や乱数には依存しない）。
+ */
+import { Enemy, Position } from '../../types';
+import { GAME_BALANCE } from '../../config/gameBalance';
+
+/** AI の検知・追跡・攻撃に関する時間定数 */
+export const AI_CONFIG = {
+  updateInterval: GAME_BALANCE.enemyAi.updateIntervalMs,
+  chaseTimeout: GAME_BALANCE.enemyAi.chaseTimeoutMs,
+  attackCooldown: GAME_BALANCE.enemyAi.attackCooldownMs,
+} as const;
+
+/** マンハッタン距離（barrel では非公開。モジュール間共有用） */
+export const getManhattanDistance = (a: Position, b: Position): number =>
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+
+/**
+ * 2点間の各軸の単位ステップ（-1 / 0 / +1）を返す。
+ * 座標は整数のため Math.sign は従来の `d>0?1:-1`（0→0）と挙動が一致する。
+ */
+export const calculateStep = (
+  from: Position,
+  to: Position
+): { stepX: number; stepY: number } => ({
+  stepX: Math.sign(to.x - from.x),
+  stepY: Math.sign(to.y - from.y),
+});
+
+/** プレイヤーが検知範囲内か */
+export const detectPlayer = (enemy: Enemy, player: Position): boolean =>
+  getManhattanDistance(enemy, player) <= enemy.detectionRange;
+
+/** 追跡を開始すべきか */
+export const shouldChase = (enemy: Enemy, player: Position): boolean => {
+  if (!detectPlayer(enemy, player)) return false;
+  if (enemy.chaseRange === undefined) return true;
+  return getManhattanDistance(enemy, player) <= enemy.chaseRange;
+};
+
+/** 追跡を中断すべきか */
+export const shouldStopChase = (enemy: Enemy, player: Position, currentTime: number): boolean => {
+  if (enemy.chaseRange !== undefined && getManhattanDistance(enemy, player) > enemy.chaseRange) {
+    return true;
+  }
+  if (enemy.lastSeenAt !== undefined && currentTime - enemy.lastSeenAt > AI_CONFIG.chaseTimeout) {
+    return true;
+  }
+  return false;
+};
+
+/** プレイヤーと反対方向の隣接マス（逃走方向） */
+export const calculateFleeDirection = (enemy: Enemy, player: Position): Position => {
+  const { stepX, stepY } = calculateStep(player, enemy);
+  return { x: enemy.x + stepX, y: enemy.y + stepY };
+};
+
+/** 敵からプレイヤーへの直線パス（L字: 先に横、次に縦） */
+export const getDirectPathToPlayer = (enemy: Enemy, player: Position): Position[] => {
+  const { stepX, stepY } = calculateStep(enemy, player);
+  const path: Position[] = [];
+  let currentX = enemy.x;
+  let currentY = enemy.y;
+  while (currentX !== player.x) {
+    currentX += stepX;
+    path.push({ x: currentX, y: currentY });
+  }
+  while (currentY !== player.y) {
+    currentY += stepY;
+    path.push({ x: currentX, y: currentY });
+  }
+  return path;
+};

--- a/src/features/ipne/domain/policies/enemyAi/aiRandom.ts
+++ b/src/features/ipne/domain/policies/enemyAi/aiRandom.ts
@@ -1,0 +1,37 @@
+/**
+ * 敵AIの乱数プロバイダ管理
+ *
+ * テスト時に setRandomProvider で決定的な乱数へ差し替えられる。
+ * NOTE: モジュールレベルの可変状態は既知の負債（spec §6）。Phase A では現状維持。
+ */
+import { RandomProvider } from '../../ports';
+
+/** デフォルトの乱数プロバイダー（Math.random ベース） */
+export const defaultRandom: RandomProvider = {
+  random: () => Math.random(),
+  randomInt: (min, max) => min + Math.floor(Math.random() * (max - min)),
+  pick: (array) => array[Math.floor(Math.random() * array.length)],
+  shuffle: (array) => {
+    const result = [...array];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  },
+};
+
+let _random: RandomProvider = defaultRandom;
+
+/** 現在の乱数プロバイダーを取得する（モジュール間共有用） */
+export const getRandom = (): RandomProvider => _random;
+
+/** 乱数プロバイダーを設定する（テスト用） */
+export function setRandomProvider(random: RandomProvider): void {
+  _random = random;
+}
+
+/** 乱数プロバイダーをデフォルトにリセットする */
+export function resetRandomProvider(): void {
+  _random = defaultRandom;
+}

--- a/src/features/ipne/domain/policies/enemyAi/attackState.ts
+++ b/src/features/ipne/domain/policies/enemyAi/attackState.ts
@@ -1,0 +1,57 @@
+/**
+ * 敵の攻撃可否・攻撃/ノックバックアニメーション状態の解決
+ */
+import { Enemy, EnemyState, EnemyType, Position } from '../../types';
+import { GAME_BALANCE } from '../../config/gameBalance';
+import { AI_CONFIG, getManhattanDistance } from './aiGeometry';
+
+/** 敵攻撃アニメーションの持続時間（ms） */
+export const ENEMY_ATTACK_ANIM_DURATION = GAME_BALANCE.enemyAi.attackAnimDurationMs;
+
+/** 敵が攻撃可能かどうか */
+export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
+  if (enemy.attackRange <= 0) return false;
+  if (currentTime < enemy.attackCooldownUntil) return false;
+  return getManhattanDistance(enemy, player) <= enemy.attackRange;
+};
+
+/** 敵の攻撃クールダウンを設定 */
+export const setEnemyAttackCooldown = (enemy: Enemy, currentTime: number): Enemy => {
+  const cooldown =
+    enemy.type === EnemyType.BOSS
+      ? GAME_BALANCE.enemyAi.bossAttackCooldownMs
+      : AI_CONFIG.attackCooldown;
+  return { ...enemy, attackCooldownUntil: currentTime + cooldown };
+};
+
+/**
+ * 敵を攻撃状態にマークする
+ * knockback 状態の敵には適用しない
+ */
+export const markEnemyAttacking = (enemy: Enemy, now: number): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+  return {
+    ...enemy,
+    state: EnemyState.ATTACK,
+    attackAnimUntil: now + ENEMY_ATTACK_ANIM_DURATION,
+  };
+};
+
+/**
+ * 敵の攻撃アニメーション状態を解決する
+ * 持続時間経過後に IDLE 状態に戻す
+ */
+export const resolveEnemyAttackState = (enemy: Enemy, now: number): Enemy => {
+  if (enemy.state !== EnemyState.ATTACK) return enemy;
+  if (enemy.attackAnimUntil === undefined) return { ...enemy, state: EnemyState.IDLE };
+  if (now < enemy.attackAnimUntil) return enemy;
+  return { ...enemy, state: EnemyState.IDLE, attackAnimUntil: undefined };
+};
+
+/** ノックバック状態を解決する（持続時間経過後に IDLE へ） */
+export const resolveKnockbackState = (enemy: Enemy, currentTime: number): Enemy => {
+  if (enemy.state !== EnemyState.KNOCKBACK) return enemy;
+  if (enemy.knockbackUntil === undefined) return { ...enemy, state: EnemyState.IDLE };
+  if (currentTime < enemy.knockbackUntil) return enemy;
+  return { ...enemy, state: EnemyState.IDLE, knockbackDirection: undefined, knockbackUntil: undefined };
+};

--- a/src/features/ipne/domain/policies/enemyAi/behaviors/chargeBehavior.ts
+++ b/src/features/ipne/domain/policies/enemyAi/behaviors/chargeBehavior.ts
@@ -1,0 +1,41 @@
+/** CHARGE/BOSS 型敵のAI更新 */
+import { Enemy, EnemyState, EnemyType, GameMap, Position } from '../../../types';
+import { shouldChase, shouldStopChase, getManhattanDistance } from '../aiGeometry';
+import { moveEnemyTowards, attemptLunge } from '../enemyMovement';
+
+export const updateChargeEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  if (shouldChase(enemy, player)) {
+    const moved = moveEnemyTowards(enemy, player, map);
+    return {
+      ...moved,
+      state: EnemyState.CHASE,
+      lastKnownPlayerPos: player,
+      lastSeenAt: currentTime,
+    };
+  }
+
+  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.IDLE };
+  }
+
+  if (enemy.state === EnemyState.CHASE) {
+    if (enemy.type === EnemyType.BOSS) {
+      const distance = getManhattanDistance(enemy, player);
+      const lungeChance = distance <= 2 ? 0.55 : distance <= 4 ? 0.4 : 0.25;
+      const lungeRange = distance <= 2 ? 3 : 4;
+      const lunge = attemptLunge(enemy, player, map, lungeRange, lungeChance);
+      return lunge ?? moveEnemyTowards(enemy, player, map);
+    }
+    const lunge = attemptLunge(enemy, player, map, 2, 0.2);
+    return lunge ?? moveEnemyTowards(enemy, player, map);
+  }
+
+  return { ...enemy, state: EnemyState.IDLE };
+};

--- a/src/features/ipne/domain/policies/enemyAi/behaviors/fleeBehavior.ts
+++ b/src/features/ipne/domain/policies/enemyAi/behaviors/fleeBehavior.ts
@@ -1,0 +1,31 @@
+/**
+ * SPECIMEN（標本）型敵のAI更新（プレイヤーから逃走）
+ */
+import { Enemy, EnemyState, GameMap, Position } from '../../../types';
+import { detectPlayer, shouldStopChase } from '../aiGeometry';
+import { moveEnemyAway } from '../enemyMovement';
+
+export const updateFleeEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  if (detectPlayer(enemy, player)) {
+    const moved = moveEnemyAway(enemy, player, map);
+    return {
+      ...moved,
+      state: EnemyState.FLEE,
+      lastKnownPlayerPos: player,
+      lastSeenAt: currentTime,
+    };
+  }
+
+  if (enemy.state === EnemyState.FLEE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.IDLE };
+  }
+
+  return { ...enemy, state: EnemyState.IDLE };
+};

--- a/src/features/ipne/domain/policies/enemyAi/behaviors/patrolBehavior.ts
+++ b/src/features/ipne/domain/policies/enemyAi/behaviors/patrolBehavior.ts
@@ -1,0 +1,63 @@
+/** PATROL 型敵のAI更新 */
+import { Enemy, EnemyState, GameMap, Position } from '../../../types';
+import { detectPlayer, shouldStopChase } from '../aiGeometry';
+import { moveEnemyTowards, moveEnemyRandom, attemptLunge, getNextPatrolPoint } from '../enemyMovement';
+
+export const updatePatrolEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  const playerDetected = detectPlayer(enemy, player);
+
+  // プレイヤー発見時：追跡開始
+  if (playerDetected) {
+    const updated = {
+      ...enemy,
+      state: EnemyState.CHASE,
+      lastKnownPlayerPos: player,
+      lastSeenAt: currentTime,
+    };
+    // 追跡中にまれに突進
+    const lunge = attemptLunge(updated, player, map, 2, 0.1);
+    return lunge ?? moveEnemyTowards(updated, player, map);
+  }
+
+  // 追跡中断判定
+  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.RETURN };
+  }
+
+  // 追跡中：プレイヤーに向かって移動
+  if (enemy.state === EnemyState.CHASE) {
+    const lunge = attemptLunge(enemy, player, map, 2, 0.1);
+    const updated = lunge ?? moveEnemyTowards(enemy, player, map);
+    return { ...updated, lastKnownPlayerPos: player, lastSeenAt: currentTime };
+  }
+
+  // 帰還中：ホームポジションに向かって移動
+  if (enemy.state === EnemyState.RETURN) {
+    if (enemy.x === enemy.homePosition.x && enemy.y === enemy.homePosition.y) {
+      return { ...enemy, state: EnemyState.PATROL };
+    }
+    return moveEnemyTowards(enemy, enemy.homePosition, map);
+  }
+
+  // 巡回中：パスがあればその経路、なければランダム移動
+  if (enemy.patrolPath && enemy.patrolPath.length > 0) {
+    const target = getNextPatrolPoint(enemy);
+    if (target) {
+      const moved = moveEnemyTowards(enemy, target, map);
+      if (moved.x === target.x && moved.y === target.y) {
+        const nextIndex = (enemy.patrolIndex ?? 0) + 1;
+        return { ...moved, patrolIndex: nextIndex % enemy.patrolPath.length };
+      }
+      return moved;
+    }
+  }
+
+  return moveEnemyRandom(enemy, map);
+};

--- a/src/features/ipne/domain/policies/enemyAi/behaviors/rangedBehavior.ts
+++ b/src/features/ipne/domain/policies/enemyAi/behaviors/rangedBehavior.ts
@@ -1,0 +1,82 @@
+/**
+ * RANGED 型敵のAI更新（適切な間合いを保つ）
+ */
+import { Enemy, EnemyState, GameMap, Position } from '../../../types';
+import { GAME_BALANCE } from '../../../config/gameBalance';
+import { detectPlayer, shouldStopChase, getManhattanDistance } from '../aiGeometry';
+import { moveEnemyTowards, moveEnemyAway } from '../enemyMovement';
+
+/** RANGED敵が維持したい距離 */
+const RANGED_PREFERRED_DISTANCE = GAME_BALANCE.enemyAi.rangedPreferredDistance;
+
+/**
+ * RANGED敵のAI更新
+ * - プレイヤーを検知したら追跡状態になる
+ * - 攻撃射程内で適切な距離を保つ
+ * - 近すぎたら後退、遠すぎたら接近
+ */
+export const updateRangedEnemy = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
+
+  const playerDetected = detectPlayer(enemy, player);
+
+  // プレイヤー発見時：追跡開始
+  if (playerDetected) {
+    const distance = getManhattanDistance(enemy, player);
+
+    // 距離が近すぎる場合は後退
+    if (distance < RANGED_PREFERRED_DISTANCE) {
+      const moved = moveEnemyAway(enemy, player, map);
+      return {
+        ...moved,
+        state: EnemyState.CHASE,
+        lastKnownPlayerPos: player,
+        lastSeenAt: currentTime,
+      };
+    }
+
+    // 攻撃射程外の場合は接近
+    if (distance > enemy.attackRange) {
+      const moved = moveEnemyTowards(enemy, player, map);
+      return {
+        ...moved,
+        state: EnemyState.CHASE,
+        lastKnownPlayerPos: player,
+        lastSeenAt: currentTime,
+      };
+    }
+
+    // 適切な距離内：その場で待機（攻撃待ち）
+    return {
+      ...enemy,
+      state: EnemyState.CHASE,
+      lastKnownPlayerPos: player,
+      lastSeenAt: currentTime,
+    };
+  }
+
+  // 追跡中断判定
+  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
+    return { ...enemy, state: EnemyState.RETURN };
+  }
+
+  // 追跡中：最後に見た位置へ
+  if (enemy.state === EnemyState.CHASE && enemy.lastKnownPlayerPos) {
+    return moveEnemyTowards(enemy, enemy.lastKnownPlayerPos, map);
+  }
+
+  // 帰還中：ホームポジションへ
+  if (enemy.state === EnemyState.RETURN) {
+    if (enemy.x === enemy.homePosition.x && enemy.y === enemy.homePosition.y) {
+      return { ...enemy, state: EnemyState.IDLE };
+    }
+    return moveEnemyTowards(enemy, enemy.homePosition, map);
+  }
+
+  return { ...enemy, state: EnemyState.IDLE };
+};

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -8,7 +8,6 @@ import { Enemy, EnemyState, EnemyType, GameMap, Position } from '../../types';
 import { canMove } from '../../services/collisionService';
 import { buildDefaultEnemyAiPolicyRegistry } from './policies';
 import { GAME_BALANCE } from '../../config/gameBalance';
-import { RandomProvider } from '../../ports';
 import {
   AI_CONFIG,
   getManhattanDistance,
@@ -18,41 +17,11 @@ import {
   calculateFleeDirection,
   getDirectPathToPlayer,
 } from './aiGeometry';
+import { getRandom, setRandomProvider, resetRandomProvider } from './aiRandom';
 
 // 公開 API（barrel）として再公開
 export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
-
-/** デフォルトの乱数プロバイダー（Math.random ベース） */
-const defaultRandom: RandomProvider = {
-  random: () => Math.random(),
-  randomInt: (min, max) => min + Math.floor(Math.random() * (max - min)),
-  pick: (array) => array[Math.floor(Math.random() * array.length)],
-  shuffle: (array) => {
-    const result = [...array];
-    for (let i = result.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [result[i], result[j]] = [result[j], result[i]];
-    }
-    return result;
-  },
-};
-
-/** モジュールで使用する乱数プロバイダー */
-let _random: RandomProvider = defaultRandom;
-
-/**
- * 乱数プロバイダーを設定する（テスト用）
- */
-export function setRandomProvider(random: RandomProvider): void {
-  _random = random;
-}
-
-/**
- * 乱数プロバイダーをデフォルトにリセットする
- */
-export function resetRandomProvider(): void {
-  _random = defaultRandom;
-}
+export { setRandomProvider, resetRandomProvider };
 
 /** 敵が攻撃可能かどうか */
 export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
@@ -126,7 +95,7 @@ const attemptLunge = (
 ): Enemy | null => {
   const distance = getManhattanDistance(enemy, target);
   if (distance > maxDistance) return null;
-  if (_random.random() > chance) return null;
+  if (getRandom().random() > chance) return null;
 
   const dx = target.x - enemy.x;
   const dy = target.y - enemy.y;
@@ -157,7 +126,7 @@ const stepRandom = (enemy: Enemy, map: GameMap): Position => {
   ];
 
   // ランダムにシャッフル
-  const shuffled = _random.shuffle(directions);
+  const shuffled = getRandom().shuffle(directions);
 
   for (const pos of shuffled) {
     if (canMove(map, pos.x, pos.y)) {
@@ -184,8 +153,8 @@ const moveEnemyRandom = (enemy: Enemy, map: GameMap): Enemy => {
 };
 
 export const generatePatrolPath = (origin: Position): Position[] => {
-  const length = _random.randomInt(4, 9); // 4-8
-  const horizontal = _random.random() > 0.5;
+  const length = getRandom().randomInt(4, 9); // 4-8
+  const horizontal = getRandom().random() > 0.5;
   const path: Position[] = [];
 
   for (let i = 0; i < length; i++) {

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -25,24 +25,25 @@ import {
   generatePatrolPath,
   getNextPatrolPoint,
 } from './enemyMovement';
+import {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  ENEMY_ATTACK_ANIM_DURATION,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
+  resolveKnockbackState,
+} from './attackState';
 
 // 公開 API（barrel）として再公開
 export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
 export { setRandomProvider, resetRandomProvider };
 export { moveEnemyTowards, generatePatrolPath, getNextPatrolPoint };
-
-/** 敵が攻撃可能かどうか */
-export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
-  if (enemy.attackRange <= 0) return false;
-  if (currentTime < enemy.attackCooldownUntil) return false;
-  const distance = getManhattanDistance(enemy, player);
-  return distance <= enemy.attackRange;
-};
-
-/** 敵の攻撃クールダウンを設定 */
-export const setEnemyAttackCooldown = (enemy: Enemy, currentTime: number): Enemy => {
-  const cooldown = enemy.type === EnemyType.BOSS ? GAME_BALANCE.enemyAi.bossAttackCooldownMs : AI_CONFIG.attackCooldown;
-  return { ...enemy, attackCooldownUntil: currentTime + cooldown };
+export {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  ENEMY_ATTACK_ANIM_DURATION,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
 };
 
 export const updatePatrolEnemy = (
@@ -248,13 +249,6 @@ const enemyAiPolicyRegistry = buildDefaultEnemyAiPolicyRegistry({
   updateFleeEnemy,
 });
 
-const resolveKnockbackState = (enemy: Enemy, currentTime: number): Enemy => {
-  if (enemy.state !== EnemyState.KNOCKBACK) return enemy;
-  if (enemy.knockbackUntil === undefined) return { ...enemy, state: EnemyState.IDLE };
-  if (currentTime < enemy.knockbackUntil) return enemy;
-  return { ...enemy, state: EnemyState.IDLE, knockbackDirection: undefined, knockbackUntil: undefined };
-};
-
 export const updateEnemyAI = (
   enemy: Enemy,
   player: Position,
@@ -358,31 +352,3 @@ export const updateEnemiesWithContact = (
 
   return { enemies: updatedEnemies, contactDamage, contactEnemy, attackDamage, attackingEnemy };
 };
-
-/** 敵攻撃アニメーションの持続時間（ms） */
-export const ENEMY_ATTACK_ANIM_DURATION = GAME_BALANCE.enemyAi.attackAnimDurationMs;
-
-/**
- * 敵を攻撃状態にマークする
- * knockback 状態の敵には適用しない
- */
-export const markEnemyAttacking = (enemy: Enemy, now: number): Enemy => {
-  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
-  return {
-    ...enemy,
-    state: EnemyState.ATTACK,
-    attackAnimUntil: now + ENEMY_ATTACK_ANIM_DURATION,
-  };
-};
-
-/**
- * 敵の攻撃アニメーション状態を解決する
- * 持続時間経過後に IDLE 状態に戻す
- */
-export const resolveEnemyAttackState = (enemy: Enemy, now: number): Enemy => {
-  if (enemy.state !== EnemyState.ATTACK) return enemy;
-  if (enemy.attackAnimUntil === undefined) return { ...enemy, state: EnemyState.IDLE };
-  if (now < enemy.attackAnimUntil) return enemy;
-  return { ...enemy, state: EnemyState.IDLE, attackAnimUntil: undefined };
-};
-

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -9,6 +9,18 @@ import { canMove } from '../../services/collisionService';
 import { buildDefaultEnemyAiPolicyRegistry } from './policies';
 import { GAME_BALANCE } from '../../config/gameBalance';
 import { RandomProvider } from '../../ports';
+import {
+  AI_CONFIG,
+  getManhattanDistance,
+  detectPlayer,
+  shouldChase,
+  shouldStopChase,
+  calculateFleeDirection,
+  getDirectPathToPlayer,
+} from './aiGeometry';
+
+// 公開 API（barrel）として再公開
+export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
 
 /** デフォルトの乱数プロバイダー（Math.random ベース） */
 const defaultRandom: RandomProvider = {
@@ -42,16 +54,6 @@ export function resetRandomProvider(): void {
   _random = defaultRandom;
 }
 
-const AI_CONFIG = {
-  updateInterval: GAME_BALANCE.enemyAi.updateIntervalMs,
-  chaseTimeout: GAME_BALANCE.enemyAi.chaseTimeoutMs,
-  attackCooldown: GAME_BALANCE.enemyAi.attackCooldownMs,
-} as const;
-
-const getManhattanDistance = (a: Position, b: Position): number => {
-  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
-};
-
 /** 敵が攻撃可能かどうか */
 export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
   if (enemy.attackRange <= 0) return false;
@@ -64,27 +66,6 @@ export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: numb
 export const setEnemyAttackCooldown = (enemy: Enemy, currentTime: number): Enemy => {
   const cooldown = enemy.type === EnemyType.BOSS ? GAME_BALANCE.enemyAi.bossAttackCooldownMs : AI_CONFIG.attackCooldown;
   return { ...enemy, attackCooldownUntil: currentTime + cooldown };
-};
-
-export const detectPlayer = (enemy: Enemy, player: Position): boolean => {
-  const distance = getManhattanDistance(enemy, player);
-  return distance <= enemy.detectionRange;
-};
-
-export const shouldChase = (enemy: Enemy, player: Position): boolean => {
-  if (!detectPlayer(enemy, player)) return false;
-  if (enemy.chaseRange === undefined) return true;
-  return getManhattanDistance(enemy, player) <= enemy.chaseRange;
-};
-
-export const shouldStopChase = (enemy: Enemy, player: Position, currentTime: number): boolean => {
-  if (enemy.chaseRange !== undefined && getManhattanDistance(enemy, player) > enemy.chaseRange) {
-    return true;
-  }
-  if (enemy.lastSeenAt !== undefined && currentTime - enemy.lastSeenAt > AI_CONFIG.chaseTimeout) {
-    return true;
-  }
-  return false;
 };
 
 const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => {
@@ -318,38 +299,6 @@ export const updateChargeEnemy = (
   }
 
   return { ...enemy, state: EnemyState.IDLE };
-};
-
-export const getDirectPathToPlayer = (enemy: Enemy, player: Position): Position[] => {
-  const path: Position[] = [];
-  const dx = player.x - enemy.x;
-  const dy = player.y - enemy.y;
-  const stepX = dx === 0 ? 0 : dx > 0 ? 1 : -1;
-  const stepY = dy === 0 ? 0 : dy > 0 ? 1 : -1;
-
-  let currentX = enemy.x;
-  let currentY = enemy.y;
-
-  while (currentX !== player.x) {
-    currentX += stepX;
-    path.push({ x: currentX, y: currentY });
-  }
-
-  while (currentY !== player.y) {
-    currentY += stepY;
-    path.push({ x: currentX, y: currentY });
-  }
-
-  return path;
-};
-
-export const calculateFleeDirection = (enemy: Enemy, player: Position): Position => {
-  const dx = enemy.x - player.x;
-  const dy = enemy.y - player.y;
-  return {
-    x: enemy.x + (dx === 0 ? 0 : dx > 0 ? 1 : -1),
-    y: enemy.y + (dy === 0 ? 0 : dy > 0 ? 1 : -1),
-  };
 };
 
 export const updateFleeEnemy = (
@@ -597,4 +546,3 @@ export const resolveEnemyAttackState = (enemy: Enemy, now: number): Enemy => {
   return { ...enemy, state: EnemyState.IDLE, attackAnimUntil: undefined };
 };
 
-export { AI_CONFIG };

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -4,12 +4,10 @@
  * 各敵タイプ別のAI更新関数と、敵の一括更新を行うオーケストレーション関数を提供する。
  * Policy パターンによりタイプ別のAI更新が統一的に管理される。
  */
-import { Enemy, EnemyState, GameMap, Position } from '../../types';
+import { Enemy, GameMap, Position } from '../../types';
 import { buildDefaultEnemyAiPolicyRegistry } from './policies';
-import { GAME_BALANCE } from '../../config/gameBalance';
 import {
   AI_CONFIG,
-  getManhattanDistance,
   detectPlayer,
   shouldChase,
   shouldStopChase,
@@ -19,7 +17,6 @@ import {
 import { setRandomProvider, resetRandomProvider } from './aiRandom';
 import {
   moveEnemyTowards,
-  moveEnemyAway,
   generatePatrolPath,
   getNextPatrolPoint,
 } from './enemyMovement';
@@ -33,6 +30,8 @@ import {
 } from './attackState';
 import { updatePatrolEnemy } from './behaviors/patrolBehavior';
 import { updateChargeEnemy } from './behaviors/chargeBehavior';
+import { updateRangedEnemy } from './behaviors/rangedBehavior';
+import { updateFleeEnemy } from './behaviors/fleeBehavior';
 
 // 公開 API（barrel）として再公開
 export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
@@ -45,107 +44,7 @@ export {
   markEnemyAttacking,
   resolveEnemyAttackState,
 };
-export { updatePatrolEnemy, updateChargeEnemy };
-
-export const updateFleeEnemy = (
-  enemy: Enemy,
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): Enemy => {
-  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
-
-  if (detectPlayer(enemy, player)) {
-    const moved = moveEnemyAway(enemy, player, map);
-    return {
-      ...moved,
-      state: EnemyState.FLEE,
-      lastKnownPlayerPos: player,
-      lastSeenAt: currentTime,
-    };
-  }
-
-  if (enemy.state === EnemyState.FLEE && shouldStopChase(enemy, player, currentTime)) {
-    return { ...enemy, state: EnemyState.IDLE };
-  }
-
-  return { ...enemy, state: EnemyState.IDLE };
-};
-
-/** RANGED敵が維持したい距離 */
-const RANGED_PREFERRED_DISTANCE = GAME_BALANCE.enemyAi.rangedPreferredDistance;
-
-/**
- * RANGED敵のAI更新
- * - プレイヤーを検知したら追跡状態になる
- * - 攻撃射程内で適切な距離を保つ
- * - 近すぎたら後退、遠すぎたら接近
- */
-export const updateRangedEnemy = (
-  enemy: Enemy,
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): Enemy => {
-  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
-
-  const playerDetected = detectPlayer(enemy, player);
-
-  // プレイヤー発見時：追跡開始
-  if (playerDetected) {
-    const distance = getManhattanDistance(enemy, player);
-
-    // 距離が近すぎる場合は後退
-    if (distance < RANGED_PREFERRED_DISTANCE) {
-      const moved = moveEnemyAway(enemy, player, map);
-      return {
-        ...moved,
-        state: EnemyState.CHASE,
-        lastKnownPlayerPos: player,
-        lastSeenAt: currentTime,
-      };
-    }
-
-    // 攻撃射程外の場合は接近
-    if (distance > enemy.attackRange) {
-      const moved = moveEnemyTowards(enemy, player, map);
-      return {
-        ...moved,
-        state: EnemyState.CHASE,
-        lastKnownPlayerPos: player,
-        lastSeenAt: currentTime,
-      };
-    }
-
-    // 適切な距離内：その場で待機（攻撃待ち）
-    return {
-      ...enemy,
-      state: EnemyState.CHASE,
-      lastKnownPlayerPos: player,
-      lastSeenAt: currentTime,
-    };
-  }
-
-  // 追跡中断判定
-  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
-    return { ...enemy, state: EnemyState.RETURN };
-  }
-
-  // 追跡中：最後に見た位置へ
-  if (enemy.state === EnemyState.CHASE && enemy.lastKnownPlayerPos) {
-    return moveEnemyTowards(enemy, enemy.lastKnownPlayerPos, map);
-  }
-
-  // 帰還中：ホームポジションへ
-  if (enemy.state === EnemyState.RETURN) {
-    if (enemy.x === enemy.homePosition.x && enemy.y === enemy.homePosition.y) {
-      return { ...enemy, state: EnemyState.IDLE };
-    }
-    return moveEnemyTowards(enemy, enemy.homePosition, map);
-  }
-
-  return { ...enemy, state: EnemyState.IDLE };
-};
+export { updatePatrolEnemy, updateChargeEnemy, updateRangedEnemy, updateFleeEnemy };
 
 const enemyAiPolicyRegistry = buildDefaultEnemyAiPolicyRegistry({
   updatePatrolEnemy,

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -4,7 +4,7 @@
  * 各敵タイプ別のAI更新関数と、敵の一括更新を行うオーケストレーション関数を提供する。
  * Policy パターンによりタイプ別のAI更新が統一的に管理される。
  */
-import { Enemy, EnemyState, EnemyType, GameMap, Position } from '../../types';
+import { Enemy, EnemyState, GameMap, Position } from '../../types';
 import { buildDefaultEnemyAiPolicyRegistry } from './policies';
 import { GAME_BALANCE } from '../../config/gameBalance';
 import {
@@ -20,8 +20,6 @@ import { setRandomProvider, resetRandomProvider } from './aiRandom';
 import {
   moveEnemyTowards,
   moveEnemyAway,
-  moveEnemyRandom,
-  attemptLunge,
   generatePatrolPath,
   getNextPatrolPoint,
 } from './enemyMovement';
@@ -33,6 +31,8 @@ import {
   resolveEnemyAttackState,
   resolveKnockbackState,
 } from './attackState';
+import { updatePatrolEnemy } from './behaviors/patrolBehavior';
+import { updateChargeEnemy } from './behaviors/chargeBehavior';
 
 // 公開 API（barrel）として再公開
 export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
@@ -45,102 +45,7 @@ export {
   markEnemyAttacking,
   resolveEnemyAttackState,
 };
-
-export const updatePatrolEnemy = (
-  enemy: Enemy,
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): Enemy => {
-  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
-
-  const playerDetected = detectPlayer(enemy, player);
-
-  // プレイヤー発見時：追跡開始
-  if (playerDetected) {
-    const updated = {
-      ...enemy,
-      state: EnemyState.CHASE,
-      lastKnownPlayerPos: player,
-      lastSeenAt: currentTime,
-    };
-    // 追跡中にまれに突進
-    const lunge = attemptLunge(updated, player, map, 2, 0.1);
-    return lunge ?? moveEnemyTowards(updated, player, map);
-  }
-
-  // 追跡中断判定
-  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
-    return { ...enemy, state: EnemyState.RETURN };
-  }
-
-  // 追跡中：プレイヤーに向かって移動
-  if (enemy.state === EnemyState.CHASE) {
-    const lunge = attemptLunge(enemy, player, map, 2, 0.1);
-    const updated = lunge ?? moveEnemyTowards(enemy, player, map);
-    return { ...updated, lastKnownPlayerPos: player, lastSeenAt: currentTime };
-  }
-
-  // 帰還中：ホームポジションに向かって移動
-  if (enemy.state === EnemyState.RETURN) {
-    if (enemy.x === enemy.homePosition.x && enemy.y === enemy.homePosition.y) {
-      return { ...enemy, state: EnemyState.PATROL };
-    }
-    return moveEnemyTowards(enemy, enemy.homePosition, map);
-  }
-
-  // 巡回中：パスがあればその経路、なければランダム移動
-  if (enemy.patrolPath && enemy.patrolPath.length > 0) {
-    const target = getNextPatrolPoint(enemy);
-    if (target) {
-      const moved = moveEnemyTowards(enemy, target, map);
-      if (moved.x === target.x && moved.y === target.y) {
-        const nextIndex = (enemy.patrolIndex ?? 0) + 1;
-        return { ...moved, patrolIndex: nextIndex % enemy.patrolPath.length };
-      }
-      return moved;
-    }
-  }
-
-  return moveEnemyRandom(enemy, map);
-};
-
-export const updateChargeEnemy = (
-  enemy: Enemy,
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): Enemy => {
-  if (enemy.state === EnemyState.KNOCKBACK) return enemy;
-
-  if (shouldChase(enemy, player)) {
-    const moved = moveEnemyTowards(enemy, player, map);
-    return {
-      ...moved,
-      state: EnemyState.CHASE,
-      lastKnownPlayerPos: player,
-      lastSeenAt: currentTime,
-    };
-  }
-
-  if (enemy.state === EnemyState.CHASE && shouldStopChase(enemy, player, currentTime)) {
-    return { ...enemy, state: EnemyState.IDLE };
-  }
-
-  if (enemy.state === EnemyState.CHASE) {
-    if (enemy.type === EnemyType.BOSS) {
-      const distance = getManhattanDistance(enemy, player);
-      const lungeChance = distance <= 2 ? 0.55 : distance <= 4 ? 0.4 : 0.25;
-      const lungeRange = distance <= 2 ? 3 : 4;
-      const lunge = attemptLunge(enemy, player, map, lungeRange, lungeChance);
-      return lunge ?? moveEnemyTowards(enemy, player, map);
-    }
-    const lunge = attemptLunge(enemy, player, map, 2, 0.2);
-    return lunge ?? moveEnemyTowards(enemy, player, map);
-  }
-
-  return { ...enemy, state: EnemyState.IDLE };
-};
+export { updatePatrolEnemy, updateChargeEnemy };
 
 export const updateFleeEnemy = (
   enemy: Enemy,

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -1,37 +1,25 @@
 /**
- * 敵AIロジック
+ * 敵AIロジック（公開 API barrel）
  *
- * 各敵タイプ別のAI更新関数と、敵の一括更新を行うオーケストレーション関数を提供する。
- * Policy パターンによりタイプ別のAI更新が統一的に管理される。
+ * 各サブモジュールから公開シンボルを re-export する。
+ * 外部からはこのファイル経由でのみアクセスする。
  */
-import { Enemy, GameMap, Position } from '../../types';
-import { buildDefaultEnemyAiPolicyRegistry } from './policies';
-import {
-  AI_CONFIG,
-  detectPlayer,
-  shouldChase,
-  shouldStopChase,
-  calculateFleeDirection,
-  getDirectPathToPlayer,
-} from './aiGeometry';
+import { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer } from './aiGeometry';
 import { setRandomProvider, resetRandomProvider } from './aiRandom';
-import {
-  moveEnemyTowards,
-  generatePatrolPath,
-  getNextPatrolPoint,
-} from './enemyMovement';
+import { moveEnemyTowards, generatePatrolPath, getNextPatrolPoint } from './enemyMovement';
 import {
   canEnemyAttack,
   setEnemyAttackCooldown,
   ENEMY_ATTACK_ANIM_DURATION,
   markEnemyAttacking,
   resolveEnemyAttackState,
-  resolveKnockbackState,
 } from './attackState';
 import { updatePatrolEnemy } from './behaviors/patrolBehavior';
 import { updateChargeEnemy } from './behaviors/chargeBehavior';
 import { updateRangedEnemy } from './behaviors/rangedBehavior';
 import { updateFleeEnemy } from './behaviors/fleeBehavior';
+import { updateEnemyAI, updateEnemies, updateEnemiesWithContact } from './enemyOrchestrator';
+import type { EnemyUpdateResult } from './enemyOrchestrator';
 
 // 公開 API（barrel）として再公開
 export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
@@ -45,114 +33,5 @@ export {
   resolveEnemyAttackState,
 };
 export { updatePatrolEnemy, updateChargeEnemy, updateRangedEnemy, updateFleeEnemy };
-
-const enemyAiPolicyRegistry = buildDefaultEnemyAiPolicyRegistry({
-  updatePatrolEnemy,
-  updateChargeEnemy,
-  updateRangedEnemy,
-  updateFleeEnemy,
-});
-
-export const updateEnemyAI = (
-  enemy: Enemy,
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): Enemy => {
-  const resolved = resolveKnockbackState(enemy, currentTime);
-  return enemyAiPolicyRegistry.update({
-    enemy: resolved,
-    player,
-    map,
-    currentTime,
-  });
-};
-
-export interface EnemyUpdateResult {
-  enemies: Enemy[];
-  contactDamage: number;
-  contactEnemy?: Enemy;
-  attackDamage: number;
-  attackingEnemy?: Enemy;
-}
-
-const toPositionKey = (pos: Position): string => `${pos.x},${pos.y}`;
-
-export const updateEnemies = (
-  enemies: Enemy[],
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): Enemy[] => {
-  return updateEnemiesWithContact(enemies, player, map, currentTime).enemies;
-};
-
-export const updateEnemiesWithContact = (
-  enemies: Enemy[],
-  player: Position,
-  map: GameMap,
-  currentTime: number
-): EnemyUpdateResult => {
-  const occupied = new Set<string>();
-  occupied.add(toPositionKey(player));
-  for (const enemy of enemies) {
-    occupied.add(toPositionKey(enemy));
-  }
-
-  const updatedEnemies: Enemy[] = [];
-  let contactDamage = 0;
-  let contactEnemy: Enemy | undefined;
-  let attackDamage = 0;
-  let attackingEnemy: Enemy | undefined;
-
-  for (const enemy of enemies) {
-    occupied.delete(toPositionKey(enemy));
-    let candidate = updateEnemyAI(enemy, player, map, currentTime);
-    const moveInterval = 1000 / Math.max(1, enemy.speed);
-    const canStep = currentTime - (enemy.lastMoveAt ?? 0) >= moveInterval;
-    if (!canStep) {
-      candidate = { ...candidate, x: enemy.x, y: enemy.y, lastMoveAt: enemy.lastMoveAt ?? 0 };
-    } else {
-      candidate = { ...candidate, lastMoveAt: currentTime };
-    }
-    const candidateKey = toPositionKey(candidate);
-    const playerKey = toPositionKey(player);
-
-    // 攻撃アニメーション状態解決
-    candidate = resolveEnemyAttackState(candidate, currentTime);
-
-    // 敵の攻撃判定（射程内でクールダウンが終わっている場合）
-    if (canEnemyAttack(candidate, player, currentTime)) {
-      if (candidate.damage > attackDamage) {
-        attackDamage = candidate.damage;
-        attackingEnemy = candidate;
-      }
-      candidate = setEnemyAttackCooldown(candidate, currentTime);
-      candidate = markEnemyAttacking(candidate, currentTime);
-    }
-
-    // 接触判定
-    if (candidateKey === playerKey) {
-      if (enemy.damage >= contactDamage) {
-        contactDamage = enemy.damage;
-        contactEnemy = enemy;
-      }
-      candidate = markEnemyAttacking(candidate, currentTime);
-      updatedEnemies.push({ ...candidate, x: enemy.x, y: enemy.y });
-      occupied.add(toPositionKey(enemy));
-      continue;
-    }
-
-    // 他の敵との衝突判定
-    if (occupied.has(candidateKey)) {
-      updatedEnemies.push({ ...candidate, x: enemy.x, y: enemy.y });
-      occupied.add(toPositionKey(enemy));
-      continue;
-    }
-
-    updatedEnemies.push(candidate);
-    occupied.add(candidateKey);
-  }
-
-  return { enemies: updatedEnemies, contactDamage, contactEnemy, attackDamage, attackingEnemy };
-};
+export { updateEnemyAI, updateEnemies, updateEnemiesWithContact };
+export type { EnemyUpdateResult };

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -5,7 +5,9 @@
  * 公開 API（エクスポート名・シグネチャ）は分割前と完全一致を維持する。
  * 設計: docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md
  */
+// 乱数プロバイダ DI
 export { setRandomProvider, resetRandomProvider } from './aiRandom';
+// 幾何計算・検知判定（純粋関数）
 export {
   AI_CONFIG,
   detectPlayer,
@@ -14,11 +16,13 @@ export {
   calculateFleeDirection,
   getDirectPathToPlayer,
 } from './aiGeometry';
+// 移動エンジン
 export {
   moveEnemyTowards,
   generatePatrolPath,
   getNextPatrolPoint,
 } from './enemyMovement';
+// 攻撃・アニメーション状態
 export {
   canEnemyAttack,
   setEnemyAttackCooldown,
@@ -26,9 +30,11 @@ export {
   markEnemyAttacking,
   resolveEnemyAttackState,
 } from './attackState';
+// 敵タイプ別 AI（Strategy）
 export { updatePatrolEnemy } from './behaviors/patrolBehavior';
 export { updateChargeEnemy } from './behaviors/chargeBehavior';
 export { updateRangedEnemy } from './behaviors/rangedBehavior';
 export { updateFleeEnemy } from './behaviors/fleeBehavior';
+// 一括更新オーケストレーション
 export { updateEnemyAI, updateEnemies, updateEnemiesWithContact } from './enemyOrchestrator';
 export type { EnemyUpdateResult } from './enemyOrchestrator';

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -5,7 +5,6 @@
  * Policy パターンによりタイプ別のAI更新が統一的に管理される。
  */
 import { Enemy, EnemyState, EnemyType, GameMap, Position } from '../../types';
-import { canMove } from '../../services/collisionService';
 import { buildDefaultEnemyAiPolicyRegistry } from './policies';
 import { GAME_BALANCE } from '../../config/gameBalance';
 import {
@@ -17,11 +16,20 @@ import {
   calculateFleeDirection,
   getDirectPathToPlayer,
 } from './aiGeometry';
-import { getRandom, setRandomProvider, resetRandomProvider } from './aiRandom';
+import { setRandomProvider, resetRandomProvider } from './aiRandom';
+import {
+  moveEnemyTowards,
+  moveEnemyAway,
+  moveEnemyRandom,
+  attemptLunge,
+  generatePatrolPath,
+  getNextPatrolPoint,
+} from './enemyMovement';
 
 // 公開 API（barrel）として再公開
 export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
 export { setRandomProvider, resetRandomProvider };
+export { moveEnemyTowards, generatePatrolPath, getNextPatrolPoint };
 
 /** 敵が攻撃可能かどうか */
 export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
@@ -35,143 +43,6 @@ export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: numb
 export const setEnemyAttackCooldown = (enemy: Enemy, currentTime: number): Enemy => {
   const cooldown = enemy.type === EnemyType.BOSS ? GAME_BALANCE.enemyAi.bossAttackCooldownMs : AI_CONFIG.attackCooldown;
   return { ...enemy, attackCooldownUntil: currentTime + cooldown };
-};
-
-const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => {
-  const dx = target.x - enemy.x;
-  const dy = target.y - enemy.y;
-  const stepX = dx === 0 ? 0 : dx > 0 ? 1 : -1;
-  const stepY = dy === 0 ? 0 : dy > 0 ? 1 : -1;
-
-  const tryHorizontal = Math.abs(dx) >= Math.abs(dy);
-
-  const candidates: Position[] = tryHorizontal
-    ? [
-        { x: enemy.x + stepX, y: enemy.y },
-        { x: enemy.x, y: enemy.y + stepY },
-      ]
-    : [
-        { x: enemy.x, y: enemy.y + stepY },
-        { x: enemy.x + stepX, y: enemy.y },
-      ];
-
-  for (const pos of candidates) {
-    if (canMove(map, pos.x, pos.y)) {
-      return pos;
-    }
-  }
-
-  return { x: enemy.x, y: enemy.y };
-};
-
-const stepAway = (enemy: Enemy, player: Position, map: GameMap): Position => {
-  const dx = enemy.x - player.x;
-  const dy = enemy.y - player.y;
-  const stepX = dx === 0 ? 0 : dx > 0 ? 1 : -1;
-  const stepY = dy === 0 ? 0 : dy > 0 ? 1 : -1;
-
-  const candidates: Position[] = [
-    { x: enemy.x + stepX, y: enemy.y },
-    { x: enemy.x, y: enemy.y + stepY },
-    { x: enemy.x - stepX, y: enemy.y },
-    { x: enemy.x, y: enemy.y - stepY },
-  ];
-
-  for (const pos of candidates) {
-    if (canMove(map, pos.x, pos.y)) {
-      return pos;
-    }
-  }
-
-  return { x: enemy.x, y: enemy.y };
-};
-
-const attemptLunge = (
-  enemy: Enemy,
-  target: Position,
-  map: GameMap,
-  maxDistance: number,
-  chance: number
-): Enemy | null => {
-  const distance = getManhattanDistance(enemy, target);
-  if (distance > maxDistance) return null;
-  if (getRandom().random() > chance) return null;
-
-  const dx = target.x - enemy.x;
-  const dy = target.y - enemy.y;
-  const stepX = dx === 0 ? 0 : dx > 0 ? 1 : -1;
-  const stepY = dy === 0 ? 0 : dy > 0 ? 1 : -1;
-  const preferHorizontal = Math.abs(dx) >= Math.abs(dy);
-
-  const firstStep = preferHorizontal
-    ? { x: enemy.x + stepX, y: enemy.y }
-    : { x: enemy.x, y: enemy.y + stepY };
-  const secondStep = preferHorizontal
-    ? { x: enemy.x + stepX * 2, y: enemy.y }
-    : { x: enemy.x, y: enemy.y + stepY * 2 };
-
-  if (!canMove(map, firstStep.x, firstStep.y)) return null;
-  if (!canMove(map, secondStep.x, secondStep.y)) return null;
-
-  return { ...enemy, x: secondStep.x, y: secondStep.y };
-};
-
-/** ランダムな方向に移動 */
-const stepRandom = (enemy: Enemy, map: GameMap): Position => {
-  const directions = [
-    { x: enemy.x + 1, y: enemy.y },
-    { x: enemy.x - 1, y: enemy.y },
-    { x: enemy.x, y: enemy.y + 1 },
-    { x: enemy.x, y: enemy.y - 1 },
-  ];
-
-  // ランダムにシャッフル
-  const shuffled = getRandom().shuffle(directions);
-
-  for (const pos of shuffled) {
-    if (canMove(map, pos.x, pos.y)) {
-      return pos;
-    }
-  }
-
-  return { x: enemy.x, y: enemy.y };
-};
-
-export const moveEnemyTowards = (enemy: Enemy, target: Position, map: GameMap): Enemy => {
-  const next = stepTowards(enemy, target, map);
-  return { ...enemy, x: next.x, y: next.y };
-};
-
-const moveEnemyAway = (enemy: Enemy, player: Position, map: GameMap): Enemy => {
-  const next = stepAway(enemy, player, map);
-  return { ...enemy, x: next.x, y: next.y };
-};
-
-const moveEnemyRandom = (enemy: Enemy, map: GameMap): Enemy => {
-  const next = stepRandom(enemy, map);
-  return { ...enemy, x: next.x, y: next.y };
-};
-
-export const generatePatrolPath = (origin: Position): Position[] => {
-  const length = getRandom().randomInt(4, 9); // 4-8
-  const horizontal = getRandom().random() > 0.5;
-  const path: Position[] = [];
-
-  for (let i = 0; i < length; i++) {
-    path.push({
-      x: origin.x + (horizontal ? i : 0),
-      y: origin.y + (horizontal ? 0 : i),
-    });
-  }
-
-  const back = [...path].reverse().slice(1);
-  return [...path, ...back];
-};
-
-export const getNextPatrolPoint = (enemy: Enemy): Position | undefined => {
-  if (!enemy.patrolPath || enemy.patrolPath.length === 0) return undefined;
-  const index = enemy.patrolIndex ?? 0;
-  return enemy.patrolPath[index];
 };
 
 export const updatePatrolEnemy = (

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -1,37 +1,34 @@
 /**
- * 敵AIロジック（公開 API barrel）
+ * 敵AIロジック（barrel）
  *
- * 各サブモジュールから公開シンボルを re-export する。
- * 外部からはこのファイル経由でのみアクセスする。
+ * 実装は責務別ファイルへ分割済み。本ファイルは後方互換のための re-export のみを行う。
+ * 公開 API（エクスポート名・シグネチャ）は分割前と完全一致を維持する。
+ * 設計: docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md
  */
-import { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer } from './aiGeometry';
-import { setRandomProvider, resetRandomProvider } from './aiRandom';
-import { moveEnemyTowards, generatePatrolPath, getNextPatrolPoint } from './enemyMovement';
-import {
-  canEnemyAttack,
-  setEnemyAttackCooldown,
-  ENEMY_ATTACK_ANIM_DURATION,
-  markEnemyAttacking,
-  resolveEnemyAttackState,
-} from './attackState';
-import { updatePatrolEnemy } from './behaviors/patrolBehavior';
-import { updateChargeEnemy } from './behaviors/chargeBehavior';
-import { updateRangedEnemy } from './behaviors/rangedBehavior';
-import { updateFleeEnemy } from './behaviors/fleeBehavior';
-import { updateEnemyAI, updateEnemies, updateEnemiesWithContact } from './enemyOrchestrator';
-import type { EnemyUpdateResult } from './enemyOrchestrator';
-
-// 公開 API（barrel）として再公開
-export { AI_CONFIG, detectPlayer, shouldChase, shouldStopChase, calculateFleeDirection, getDirectPathToPlayer };
-export { setRandomProvider, resetRandomProvider };
-export { moveEnemyTowards, generatePatrolPath, getNextPatrolPoint };
+export { setRandomProvider, resetRandomProvider } from './aiRandom';
+export {
+  AI_CONFIG,
+  detectPlayer,
+  shouldChase,
+  shouldStopChase,
+  calculateFleeDirection,
+  getDirectPathToPlayer,
+} from './aiGeometry';
+export {
+  moveEnemyTowards,
+  generatePatrolPath,
+  getNextPatrolPoint,
+} from './enemyMovement';
 export {
   canEnemyAttack,
   setEnemyAttackCooldown,
   ENEMY_ATTACK_ANIM_DURATION,
   markEnemyAttacking,
   resolveEnemyAttackState,
-};
-export { updatePatrolEnemy, updateChargeEnemy, updateRangedEnemy, updateFleeEnemy };
-export { updateEnemyAI, updateEnemies, updateEnemiesWithContact };
-export type { EnemyUpdateResult };
+} from './attackState';
+export { updatePatrolEnemy } from './behaviors/patrolBehavior';
+export { updateChargeEnemy } from './behaviors/chargeBehavior';
+export { updateRangedEnemy } from './behaviors/rangedBehavior';
+export { updateFleeEnemy } from './behaviors/fleeBehavior';
+export { updateEnemyAI, updateEnemies, updateEnemiesWithContact } from './enemyOrchestrator';
+export type { EnemyUpdateResult } from './enemyOrchestrator';

--- a/src/features/ipne/domain/policies/enemyAi/enemyMovement.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyMovement.ts
@@ -12,6 +12,8 @@ import { getRandom } from './aiRandom';
 /** ターゲットへ1歩近づく（横優先/縦優先を距離差で決定、塞がれたら停止） */
 const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => {
   const { stepX, stepY } = calculateStep(enemy, target);
+  // calculateStep は符号(stepX/stepY)のみを返すため、横優先/縦優先の判定に必要な
+  // 差分の絶対値はここで別途計算する
   const dx = target.x - enemy.x;
   const dy = target.y - enemy.y;
   const tryHorizontal = Math.abs(dx) >= Math.abs(dy);
@@ -34,6 +36,7 @@ const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => 
 
 /** プレイヤーから1歩離れる（4方向を順に試行） */
 const stepAway = (enemy: Enemy, player: Position, map: GameMap): Position => {
+  // 逃走方向（プレイヤーの反対）を得るため、from/to を逆順（player→enemy）で渡す
   const { stepX, stepY } = calculateStep(player, enemy);
   const candidates: Position[] = [
     { x: enemy.x + stepX, y: enemy.y },

--- a/src/features/ipne/domain/policies/enemyAi/enemyMovement.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyMovement.ts
@@ -1,0 +1,129 @@
+/**
+ * 敵の移動エンジン
+ *
+ * マップ衝突（collisionService）を考慮した1ステップ移動と巡回パス生成を提供する。
+ * 方向計算は aiGeometry.calculateStep に集約。
+ */
+import { Enemy, GameMap, Position } from '../../types';
+import { canMove } from '../../services/collisionService';
+import { calculateStep, getManhattanDistance } from './aiGeometry';
+import { getRandom } from './aiRandom';
+
+/** ターゲットへ1歩近づく（横優先/縦優先を距離差で決定、塞がれたら停止） */
+const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => {
+  const { stepX, stepY } = calculateStep(enemy, target);
+  const dx = target.x - enemy.x;
+  const dy = target.y - enemy.y;
+  const tryHorizontal = Math.abs(dx) >= Math.abs(dy);
+
+  const candidates: Position[] = tryHorizontal
+    ? [
+        { x: enemy.x + stepX, y: enemy.y },
+        { x: enemy.x, y: enemy.y + stepY },
+      ]
+    : [
+        { x: enemy.x, y: enemy.y + stepY },
+        { x: enemy.x + stepX, y: enemy.y },
+      ];
+
+  for (const pos of candidates) {
+    if (canMove(map, pos.x, pos.y)) return pos;
+  }
+  return { x: enemy.x, y: enemy.y };
+};
+
+/** プレイヤーから1歩離れる（4方向を順に試行） */
+const stepAway = (enemy: Enemy, player: Position, map: GameMap): Position => {
+  const { stepX, stepY } = calculateStep(player, enemy);
+  const candidates: Position[] = [
+    { x: enemy.x + stepX, y: enemy.y },
+    { x: enemy.x, y: enemy.y + stepY },
+    { x: enemy.x - stepX, y: enemy.y },
+    { x: enemy.x, y: enemy.y - stepY },
+  ];
+  for (const pos of candidates) {
+    if (canMove(map, pos.x, pos.y)) return pos;
+  }
+  return { x: enemy.x, y: enemy.y };
+};
+
+/** 突進（最大距離内かつ確率成立時、2マス先まで一気に移動） */
+export const attemptLunge = (
+  enemy: Enemy,
+  target: Position,
+  map: GameMap,
+  maxDistance: number,
+  chance: number
+): Enemy | null => {
+  const distance = getManhattanDistance(enemy, target);
+  if (distance > maxDistance) return null;
+  if (getRandom().random() > chance) return null;
+
+  const { stepX, stepY } = calculateStep(enemy, target);
+  const dx = target.x - enemy.x;
+  const dy = target.y - enemy.y;
+  const preferHorizontal = Math.abs(dx) >= Math.abs(dy);
+
+  const firstStep = preferHorizontal
+    ? { x: enemy.x + stepX, y: enemy.y }
+    : { x: enemy.x, y: enemy.y + stepY };
+  const secondStep = preferHorizontal
+    ? { x: enemy.x + stepX * 2, y: enemy.y }
+    : { x: enemy.x, y: enemy.y + stepY * 2 };
+
+  if (!canMove(map, firstStep.x, firstStep.y)) return null;
+  if (!canMove(map, secondStep.x, secondStep.y)) return null;
+  return { ...enemy, x: secondStep.x, y: secondStep.y };
+};
+
+/** ランダムな方向に1歩移動 */
+const stepRandom = (enemy: Enemy, map: GameMap): Position => {
+  const directions = [
+    { x: enemy.x + 1, y: enemy.y },
+    { x: enemy.x - 1, y: enemy.y },
+    { x: enemy.x, y: enemy.y + 1 },
+    { x: enemy.x, y: enemy.y - 1 },
+  ];
+  const shuffled = getRandom().shuffle(directions);
+  for (const pos of shuffled) {
+    if (canMove(map, pos.x, pos.y)) return pos;
+  }
+  return { x: enemy.x, y: enemy.y };
+};
+
+export const moveEnemyTowards = (enemy: Enemy, target: Position, map: GameMap): Enemy => {
+  const next = stepTowards(enemy, target, map);
+  return { ...enemy, x: next.x, y: next.y };
+};
+
+export const moveEnemyAway = (enemy: Enemy, player: Position, map: GameMap): Enemy => {
+  const next = stepAway(enemy, player, map);
+  return { ...enemy, x: next.x, y: next.y };
+};
+
+export const moveEnemyRandom = (enemy: Enemy, map: GameMap): Enemy => {
+  const next = stepRandom(enemy, map);
+  return { ...enemy, x: next.x, y: next.y };
+};
+
+/** 巡回パスを生成する（往路＋復路、長さ4-8マス） */
+export const generatePatrolPath = (origin: Position): Position[] => {
+  const length = getRandom().randomInt(4, 9); // 4-8
+  const horizontal = getRandom().random() > 0.5;
+  const path: Position[] = [];
+  for (let i = 0; i < length; i++) {
+    path.push({
+      x: origin.x + (horizontal ? i : 0),
+      y: origin.y + (horizontal ? 0 : i),
+    });
+  }
+  const back = [...path].reverse().slice(1);
+  return [...path, ...back];
+};
+
+/** 次の巡回ポイントを取得する */
+export const getNextPatrolPoint = (enemy: Enemy): Position | undefined => {
+  if (!enemy.patrolPath || enemy.patrolPath.length === 0) return undefined;
+  const index = enemy.patrolIndex ?? 0;
+  return enemy.patrolPath[index];
+};

--- a/src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts
@@ -1,0 +1,129 @@
+/**
+ * 敵の一括更新オーケストレーション
+ *
+ * Policy registry を通じてタイプ別 AI を適用し、移動間隔・衝突・接触/攻撃ダメージを解決する。
+ */
+import { Enemy, GameMap, Position } from '../../types';
+import { buildDefaultEnemyAiPolicyRegistry } from './policies';
+import {
+  canEnemyAttack,
+  setEnemyAttackCooldown,
+  markEnemyAttacking,
+  resolveEnemyAttackState,
+  resolveKnockbackState,
+} from './attackState';
+import { updatePatrolEnemy } from './behaviors/patrolBehavior';
+import { updateChargeEnemy } from './behaviors/chargeBehavior';
+import { updateRangedEnemy } from './behaviors/rangedBehavior';
+import { updateFleeEnemy } from './behaviors/fleeBehavior';
+
+const enemyAiPolicyRegistry = buildDefaultEnemyAiPolicyRegistry({
+  updatePatrolEnemy,
+  updateChargeEnemy,
+  updateRangedEnemy,
+  updateFleeEnemy,
+});
+
+export const updateEnemyAI = (
+  enemy: Enemy,
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy => {
+  const resolved = resolveKnockbackState(enemy, currentTime);
+  return enemyAiPolicyRegistry.update({
+    enemy: resolved,
+    player,
+    map,
+    currentTime,
+  });
+};
+
+export interface EnemyUpdateResult {
+  enemies: Enemy[];
+  contactDamage: number;
+  contactEnemy?: Enemy;
+  attackDamage: number;
+  attackingEnemy?: Enemy;
+}
+
+const toPositionKey = (pos: Position): string => `${pos.x},${pos.y}`;
+
+export const updateEnemies = (
+  enemies: Enemy[],
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): Enemy[] => {
+  return updateEnemiesWithContact(enemies, player, map, currentTime).enemies;
+};
+
+export const updateEnemiesWithContact = (
+  enemies: Enemy[],
+  player: Position,
+  map: GameMap,
+  currentTime: number
+): EnemyUpdateResult => {
+  const occupied = new Set<string>();
+  occupied.add(toPositionKey(player));
+  for (const enemy of enemies) {
+    occupied.add(toPositionKey(enemy));
+  }
+
+  const updatedEnemies: Enemy[] = [];
+  let contactDamage = 0;
+  let contactEnemy: Enemy | undefined;
+  let attackDamage = 0;
+  let attackingEnemy: Enemy | undefined;
+
+  for (const enemy of enemies) {
+    occupied.delete(toPositionKey(enemy));
+    let candidate = updateEnemyAI(enemy, player, map, currentTime);
+    const moveInterval = 1000 / Math.max(1, enemy.speed);
+    const canStep = currentTime - (enemy.lastMoveAt ?? 0) >= moveInterval;
+    if (!canStep) {
+      candidate = { ...candidate, x: enemy.x, y: enemy.y, lastMoveAt: enemy.lastMoveAt ?? 0 };
+    } else {
+      candidate = { ...candidate, lastMoveAt: currentTime };
+    }
+    const candidateKey = toPositionKey(candidate);
+    const playerKey = toPositionKey(player);
+
+    // 攻撃アニメーション状態解決
+    candidate = resolveEnemyAttackState(candidate, currentTime);
+
+    // 敵の攻撃判定（射程内でクールダウンが終わっている場合）
+    if (canEnemyAttack(candidate, player, currentTime)) {
+      if (candidate.damage > attackDamage) {
+        attackDamage = candidate.damage;
+        attackingEnemy = candidate;
+      }
+      candidate = setEnemyAttackCooldown(candidate, currentTime);
+      candidate = markEnemyAttacking(candidate, currentTime);
+    }
+
+    // 接触判定
+    if (candidateKey === playerKey) {
+      if (enemy.damage >= contactDamage) {
+        contactDamage = enemy.damage;
+        contactEnemy = enemy;
+      }
+      candidate = markEnemyAttacking(candidate, currentTime);
+      updatedEnemies.push({ ...candidate, x: enemy.x, y: enemy.y });
+      occupied.add(toPositionKey(enemy));
+      continue;
+    }
+
+    // 他の敵との衝突判定
+    if (occupied.has(candidateKey)) {
+      updatedEnemies.push({ ...candidate, x: enemy.x, y: enemy.y });
+      occupied.add(toPositionKey(enemy));
+      continue;
+    }
+
+    updatedEnemies.push(candidate);
+    occupied.add(candidateKey);
+  }
+
+  return { enemies: updatedEnemies, contactDamage, contactEnemy, attackDamage, attackingEnemy };
+};


### PR DESCRIPTION
## 概要

IPNE の敵AIロジック `enemyAiFunctions.ts`（600行・7責務が同居）を、責務単位のファイル群へ分割する**振る舞い不変リファクタリング**です。IPNE 包括リファクタリング・ロードマップの **Phase A** にあたります。

- 設計: `docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md`
- 計画: `docs/superpowers/plans/2026-06-14-ipne-enemyai-split.md`

## 変更内容

- **責務分割**: 600行の単一ファイルを以下へ分割
  - `aiGeometry.ts`（幾何計算・検知判定）/ `aiRandom.ts`（乱数プロバイダ DI）
  - `enemyMovement.ts`（移動エンジン）/ `attackState.ts`（攻撃・ノックバック状態）
  - `behaviors/`（patrol/charge/ranged/flee を1ファイルずつ）/ `enemyOrchestrator.ts`（一括更新）
- **DRY 解消**: 方向計算 `dx,dy → stepX,stepY` のコピペ5箇所を `calculateStep()`（`Math.sign` ベース）に集約
- **後方互換**: `enemyAiFunctions.ts` を `export … from` の re-export barrel として残し、**公開24エクスポートを完全維持**。参照元（`index.ts` / `tickGameState.ts` / 各テスト / `policies.ts`）は無修正
- **スコープ厳守**: `_random` のグローバル可変状態の DI 化、`getManhattanDistance` の共通化は「既知の負債」として spec に記録し、本フェーズでは手を付けず

## テスト方法

- [x] `npx jest ipne` — 83スイート / 1304テスト 全パス
- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint:ci` — 警告ゼロ（exit 0）
- [x] 新規 `calculateStep` に専用テスト（正/負/ゼロ）を追加
- [x] 公開24エクスポートが分割前と完全一致・private 混入ゼロを確認
- [ ] E2E（`npm run test:e2e`）— ローカル実行不可のため CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
