### PR TITLE
refactor: IPNE エフェクト生成をファクトリー化 (Phase C)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-ipne-effect-factories.md
+++ b/docs/superpowers/plans/2026-06-15-ipne-effect-factories.md
@@ -1,0 +1,636 @@
+# IPNE エフェクト生成のファクトリー化 実装計画（Phase C）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `EffectManager.addEffect` の12ケース巨大switchを、`EffectType → 純粋ファクトリー` の registry（新規 `effectFactories.ts`）へ分離し、`addEffect` を薄い処理に縮小する（振る舞い不変）。
+
+**Architecture:** 各 case 本体を「`GameEffect` を返す純粋関数」へ逐語移植し `EFFECT_FACTORIES` registry に登録。`addEffect` は id 採番 → registry 引き → push → 追従エフェクト再帰 → `enforceParticleLimit` の薄い処理になる。ATTACK_HIT→SCREEN_SHAKE の合成は `followUps` 記述子で表現。既存 `effectManager.test.ts` ＋ 決定的フィールド検証の補強で振る舞い不変を担保。
+
+**Tech Stack:** TypeScript, Jest (SWC), Canvas 2D パーティクルエフェクト。
+
+**設計の出典:** `docs/superpowers/specs/2026-06-15-ipne-effect-factories-design.md`
+
+---
+
+## 対象ファイルと責務
+
+すべて `src/features/ipne/presentation/effects/` 配下。
+
+| ファイル | 役割 | 本計画での扱い |
+|---------|------|---------------|
+| `effectFactories.ts` | 型（`EffectFactory`/`EffectFactoryContext`/`FollowUpEffect`/`EffectBuildResult`）と12ファクトリー＋`EFFECT_FACTORIES` registry | **新規**（Task 1） |
+| `effectManager.test.ts`（220行） | 決定的フィールド検証を補強 | **変更**（Task 2） |
+| `effectManager.ts`（505行） | `addEffect` を registry 駆動へ置換 | **変更**（Task 3） |
+| `effectTypes.ts` / `particleSystem.ts` / `hitEffectScaling.ts` / `enemyDeath.ts` / `itemFeedback.ts` | 依存元 | **無変更** |
+
+### 不変条件（厳守）
+
+- `addEffect` は switch（現: factory ブロック）の **前で必ず** `effectIdCounter += 1` し id を採番。
+- switch（現: factory ブロック）の **後で必ず** `this.enforceParticleLimit()` を呼ぶ（未処理タイプでも実行）。
+- `LOW_HP_WARNING` は registry に登録しない（元の switch に case が無い＝未処理を保存）。
+- `ENEMY_DEATH(enemyType 未指定)` は effect を生成しない（`EffectBuildResult.effect` は optional）。
+- `ATTACK_HIT(hasShake)` は effect を push 後に SCREEN_SHAKE を追従追加（順序維持）。
+- 公開 API（`EffectManager` のメソッド・`resetEffectIdCounter`・`effects/index.ts` 再公開分）は不変。
+
+---
+
+## Task 0: ベースライン確認
+
+**Files:** なし（確認のみ）
+
+- [ ] **Step 1: ブランチ確認**
+
+Run: `git branch --show-current`
+Expected: `refactor/ipne-effect-factories`
+
+- [ ] **Step 2: effects テスト緑確認**
+
+Run: `npx jest effects 2>&1 | tail -8`
+Expected: PASS（`effectManager.test.ts` 等）
+
+- [ ] **Step 3: typecheck ベースライン**
+
+Run: `npm run typecheck 2>&1 | tail -3`
+Expected: エラーなし
+
+---
+
+## Task 1: `effectFactories.ts` を作成
+
+**Files:**
+- Create: `src/features/ipne/presentation/effects/effectFactories.ts`
+
+各ファクトリーは元の case 本体を逐語移植し、`this.effects.push({...})` を `return { effect: {...} }` に置換したもの。
+`type` フィールドは各ファクトリー固定の `EffectType.XXX` を使う（元 switch の case 変数 `type` と等価）。
+
+- [ ] **Step 1: `effectFactories.ts` を実装**
+
+Create `effectFactories.ts`:
+
+```typescript
+/**
+ * エフェクト生成ファクトリー
+ *
+ * EffectType ごとに GameEffect を構築する純粋関数群と、その registry を提供する。
+ * EffectManager.addEffect はこの registry を引いてエフェクトを生成する。
+ * パーティクル生成は particleSystem の共有関数へ委譲する（this に依存しない）。
+ */
+import { EffectType, EffectTypeValue, EffectOptions, GameEffect } from './effectTypes';
+import {
+  createRadialParticles,
+  createRisingParticles,
+  createSpiralParticles,
+  createPulseParticles,
+  createTrailParticles,
+} from './particleSystem';
+import { getHitEffectConfig } from './hitEffectScaling';
+import { getEnemyDeathParticleConfig } from './enemyDeath';
+import { getItemPickupEffectConfig } from './itemFeedback';
+
+/** ファクトリーに渡す生成コンテキスト */
+export interface EffectFactoryContext {
+  id: string;
+  x: number;
+  y: number;
+  now: number;
+  options?: EffectOptions;
+}
+
+/** 追従エフェクト（合成）の記述子 */
+export interface FollowUpEffect {
+  type: EffectTypeValue;
+  x: number;
+  y: number;
+  options?: EffectOptions;
+}
+
+/** ファクトリーの生成結果。effect は optional（ENEMY_DEATH の enemyType 未指定時は生成しない） */
+export interface EffectBuildResult {
+  effect?: GameEffect;
+  followUps?: FollowUpEffect[];
+}
+
+/** エフェクト生成ファクトリー（純粋関数。this に依存しない） */
+export type EffectFactory = (ctx: EffectFactoryContext) => EffectBuildResult;
+
+const createAttackHitEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const pl = options?.powerLevel ?? 1;
+  const combo = options?.comboMultiplier ?? 1.0;
+  const hitConfig = getHitEffectConfig(pl);
+  const count = Math.round(hitConfig.particleCount * combo);
+  const sizeMin = 2 * hitConfig.sizeMultiplier;
+  const sizeMax = 4 * hitConfig.sizeMultiplier;
+  const speedMin = 60 * hitConfig.speedMultiplier;
+  const speedMax = 150 * hitConfig.speedMultiplier;
+
+  const effect: GameEffect = {
+    id,
+    type: EffectType.ATTACK_HIT,
+    x,
+    y,
+    startTime: now,
+    duration: 300,
+    particles: createRadialParticles(
+      count, x, y,
+      ['#ffffff', '#ffffcc', '#ffff99'],
+      speedMin, speedMax,
+      sizeMin, sizeMax,
+      3.0
+    ),
+    ringRadius: hitConfig.hasShockwave ? 0 : undefined,
+    ringMaxRadius: hitConfig.hasShockwave ? (8 + pl * 4) : undefined,
+    flashAlpha: hitConfig.hasFlash ? 0.4 : undefined,
+  };
+
+  const followUps = hitConfig.hasShake
+    ? [{ type: EffectType.SCREEN_SHAKE, x: 0, y: 0, options: { damage: 3 } }]
+    : undefined;
+
+  return { effect, followUps };
+};
+
+const createDamageEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.DAMAGE,
+    x,
+    y,
+    startTime: now,
+    duration: 400,
+    particles: createRisingParticles(6, x, y, ['#ef4444', '#dc2626', '#ff6b6b'], 2, 4, 2.5),
+  },
+});
+
+const createTrapDamageEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.TRAP_DAMAGE,
+    x,
+    y,
+    startTime: now,
+    duration: 350,
+    particles: createRisingParticles(6, x, y, ['#dc2626', '#ef4444', '#f87171'], 2, 3, 2.8),
+  },
+});
+
+const createTrapSlowEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.TRAP_SLOW,
+    x,
+    y,
+    startTime: now,
+    duration: 500,
+    particles: createRadialParticles(8, x, y, ['#3b82f6', '#60a5fa', '#93c5fd'], 15, 40, 3, 5, 2.0),
+  },
+});
+
+const createTrapTeleportEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.TRAP_TELEPORT,
+    x,
+    y,
+    startTime: now,
+    duration: 400,
+    particles: createRadialParticles(10, x, y, ['#7c3aed', '#a78bfa', '#c4b5fd'], 30, 80, 2, 4, 2.5),
+    ringRadius: 0,
+    ringMaxRadius: 30,
+  },
+});
+
+const createItemPickupEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const itemType = options?.itemType;
+  const itemConfig = itemType ? getItemPickupEffectConfig(itemType) : undefined;
+  const pCount = itemConfig?.particleCount ?? 6;
+  const pColors = itemConfig?.colors ?? ['#fbbf24', '#fcd34d', '#fef08a'];
+  const pPattern = itemConfig?.pattern ?? 'rising';
+
+  const particles =
+    pPattern === 'spiral'
+      ? createSpiralParticles(pCount, x, y, pColors, 80, 1.5)
+      : pPattern === 'radial'
+      ? createRadialParticles(pCount, x, y, pColors, 40, 100, 2, 4, 2.0)
+      : createRisingParticles(pCount, x, y, pColors, 2, 3, 2.0);
+
+  return {
+    effect: {
+      id,
+      type: EffectType.ITEM_PICKUP,
+      x,
+      y,
+      startTime: now,
+      duration: 500,
+      particles,
+    },
+  };
+};
+
+const createLevelUpEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.LEVEL_UP,
+    x,
+    y,
+    startTime: now,
+    duration: 1500,
+    particles: createSpiralParticles(24, x, y, ['#fbbf24', '#fcd34d', '#fef08a', '#ffffff'], 100, 0.7),
+    ringRadius: 0,
+    ringMaxRadius: 40,
+    flashAlpha: 0.4,
+    flashColor: '#fbbf24',
+  },
+});
+
+const createBossKillEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.BOSS_KILL,
+    x,
+    y,
+    startTime: now,
+    duration: 1200,
+    particles: createRadialParticles(24, x, y, ['#dc2626', '#f97316', '#ffffff', '#fbbf24'], 80, 200, 3, 6, 0.8),
+    flashAlpha: 1.0,
+  },
+});
+
+const createEnemyAttackEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const variant = options?.variant ?? 'melee';
+  if (variant === 'boss') {
+    return {
+      effect: {
+        id,
+        type: EffectType.ENEMY_ATTACK,
+        x,
+        y,
+        startTime: now,
+        duration: 500,
+        particles: createPulseParticles(16, x, y, ['#dc2626', '#ef4444', '#f87171', '#ffffff'], 100, 2.0),
+      },
+    };
+  }
+  if (variant === 'ranged') {
+    return {
+      effect: {
+        id,
+        type: EffectType.ENEMY_ATTACK,
+        x,
+        y,
+        startTime: now,
+        duration: 400,
+        particles: createTrailParticles(8, x, y, 0, -1, ['#f97316', '#fdba74', '#fff7ed'], 120, 2.5),
+      },
+    };
+  }
+  // melee
+  return {
+    effect: {
+      id,
+      type: EffectType.ENEMY_ATTACK,
+      x,
+      y,
+      startTime: now,
+      duration: 300,
+      particles: createRadialParticles(8, x, y, ['#ef4444', '#dc2626', '#ff6b6b'], 50, 120, 2, 4, 3.0),
+    },
+  };
+};
+
+const createScreenShakeEffect: EffectFactory = ({ id, now, options }) => {
+  const intensity = Math.min(4, options?.damage ? options.damage * 0.5 : 2);
+  return {
+    effect: {
+      id,
+      type: EffectType.SCREEN_SHAKE,
+      x: 0,
+      y: 0,
+      startTime: now,
+      duration: 200,
+      particles: [],
+      shakeIntensity: intensity,
+      shakeDecay: intensity / 0.2,
+    },
+  };
+};
+
+const createStageClearEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const stageColors = [
+    ['#60a5fa', '#93c5fd', '#ffffff'],
+    ['#34d399', '#6ee7b7', '#ffffff'],
+    ['#fbbf24', '#fcd34d', '#ffffff'],
+    ['#f472b6', '#f9a8d4', '#ffffff'],
+    ['#a78bfa', '#c4b5fd', '#fbbf24', '#ffffff'],
+  ];
+  const stageIdx = Math.min((options?.stageNumber ?? 1) - 1, stageColors.length - 1);
+  return {
+    effect: {
+      id,
+      type: EffectType.STAGE_CLEAR,
+      x,
+      y,
+      startTime: now,
+      duration: 1500,
+      particles: createSpiralParticles(32, x, y, stageColors[stageIdx], 100, 0.7),
+      flashAlpha: 1.0,
+    },
+  };
+};
+
+const createEnemyDeathEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const enemyType = options?.enemyType;
+  if (!enemyType) {
+    return {}; // enemyType 未指定時はエフェクトを生成しない（元の挙動を保存）
+  }
+  const deathConfig = getEnemyDeathParticleConfig(enemyType);
+  const combo = options?.comboMultiplier ?? 1.0;
+  const count = Math.round(deathConfig.particleCount * combo);
+  return {
+    effect: {
+      id,
+      type: EffectType.ENEMY_DEATH,
+      x,
+      y,
+      startTime: now,
+      duration: deathConfig.duration,
+      particles: createRadialParticles(
+        count, x, y,
+        deathConfig.colors,
+        deathConfig.speedMin, deathConfig.speedMax,
+        deathConfig.sizeMin, deathConfig.sizeMax,
+        2.0
+      ),
+    },
+  };
+};
+
+/**
+ * EffectType → ファクトリーの registry。
+ * LOW_HP_WARNING は元の switch に case が無く未処理のため登録しない（Partial）。
+ */
+export const EFFECT_FACTORIES: Partial<Record<EffectTypeValue, EffectFactory>> = {
+  [EffectType.ATTACK_HIT]: createAttackHitEffect,
+  [EffectType.DAMAGE]: createDamageEffect,
+  [EffectType.TRAP_DAMAGE]: createTrapDamageEffect,
+  [EffectType.TRAP_SLOW]: createTrapSlowEffect,
+  [EffectType.TRAP_TELEPORT]: createTrapTeleportEffect,
+  [EffectType.ITEM_PICKUP]: createItemPickupEffect,
+  [EffectType.LEVEL_UP]: createLevelUpEffect,
+  [EffectType.BOSS_KILL]: createBossKillEffect,
+  [EffectType.ENEMY_ATTACK]: createEnemyAttackEffect,
+  [EffectType.SCREEN_SHAKE]: createScreenShakeEffect,
+  [EffectType.STAGE_CLEAR]: createStageClearEffect,
+  [EffectType.ENEMY_DEATH]: createEnemyDeathEffect,
+};
+```
+
+> 実装前に元 `effectManager.ts` の各 case（55-349行）と上記を照合し、色・速度・サイズ・duration・count・
+> 条件分岐が逐語一致することを確認すること。`GameEffect` の任意フィールド（ringRadius/flashAlpha/flashColor/
+> shakeIntensity/shakeDecay 等）が optional であることは既存コードのコンパイル実績で担保される。
+
+- [ ] **Step 2: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし（registry はまだ未使用だが型は通る）
+
+- [ ] **Step 3: lint**
+
+Run: `npx eslint src/features/ipne/presentation/effects/effectFactories.ts 2>&1 | tail -10`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/ipne/presentation/effects/effectFactories.ts
+git commit -m "feat: IPNE エフェクト生成ファクトリーと registry を新設
+
+- 12種の EffectType を純粋ファクトリー関数に分離し EFFECT_FACTORIES に集約
+- ATTACK_HIT は SCREEN_SHAKE 合成を followUps で表現
+- LOW_HP_WARNING は未登録（未処理を保存）、ENEMY_DEATH は effect optional
+- 後続タスクで addEffect がこの registry へ委譲する
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 既存テストに決定的フィールド検証を補強
+
+**Files:**
+- Modify: `src/features/ipne/presentation/effects/effectManager.test.ts`
+
+リファクタ前の現挙動に対して、パーティクル位置以外の決定的フィールドを検証するテストを追加する。
+これらは Task 3 のリファクタ後も緑のままでなければならない（特性化）。
+
+- [ ] **Step 1: 補強テストを追加**
+
+`effectManager.test.ts` の末尾（最後の `});`（describe 'EffectManager' の閉じ）の直前）に以下の describe を追加する。
+先頭の import に `EffectType` と型 `EffectTypeValue`（`./effectTypes` から。テストの相対パスに合わせる）が無ければ追加する。
+既存テストが `EffectManager`/`EffectType` をどこから import しているかを確認し、同じパスに揃えること。
+
+```typescript
+  describe('決定的フィールド検証（Phase C 特性化）', () => {
+    it('ATTACK_HIT は duration 300 で、powerLevel 4 では shockwave/flash/shake を伴う', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.ATTACK_HIT, 10, 20, 1000, { powerLevel: 4 });
+      const effects = m.getEffects();
+      const hit = effects.find((e) => e.type === EffectType.ATTACK_HIT);
+      expect(hit?.duration).toBe(300);
+      expect(hit?.ringMaxRadius).toBe(8 + 4 * 4);
+      expect(hit?.flashAlpha).toBe(0.4);
+      // hasShake により SCREEN_SHAKE が追従追加される
+      expect(effects.some((e) => e.type === EffectType.SCREEN_SHAKE)).toBe(true);
+    });
+
+    it('各エフェクト型の duration が規定値である', () => {
+      const cases: Array<[EffectTypeValue, number]> = [
+        [EffectType.DAMAGE, 400],
+        [EffectType.TRAP_DAMAGE, 350],
+        [EffectType.TRAP_SLOW, 500],
+        [EffectType.TRAP_TELEPORT, 400],
+        [EffectType.ITEM_PICKUP, 500],
+        [EffectType.LEVEL_UP, 1500],
+        [EffectType.BOSS_KILL, 1200],
+        [EffectType.STAGE_CLEAR, 1500], // stageNumber 未指定でも既定 1 で生成される
+      ];
+      for (const [type, duration] of cases) {
+        const m = new EffectManager();
+        m.addEffect(type, 0, 0, 1000);
+        const e = m.getEffects().find((ef) => ef.type === type);
+        expect(e?.duration).toBe(duration);
+      }
+    });
+
+    it('SCREEN_SHAKE は particles が空で shakeIntensity を持つ', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.SCREEN_SHAKE, 0, 0, 1000, { damage: 4 });
+      const e = m.getEffects().find((ef) => ef.type === EffectType.SCREEN_SHAKE);
+      expect(e?.particles.length).toBe(0);
+      expect(e?.shakeIntensity).toBe(Math.min(4, 4 * 0.5));
+    });
+
+    it('LOW_HP_WARNING は addEffect してもエフェクトを追加しない（未処理を保存）', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.LOW_HP_WARNING, 0, 0, 1000);
+      expect(m.getEffectCount()).toBe(0);
+    });
+
+    it('ENEMY_DEATH は enemyType 未指定だとエフェクトを追加しない', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.ENEMY_DEATH, 0, 0, 1000);
+      expect(m.getEffectCount()).toBe(0);
+    });
+  });
+```
+
+> 注: 既存テストが `new EffectManager()` をどう生成し `EffectType`/`resetEffectIdCounter` をどう import しているか
+> を確認し、スタイルを揃えること。`getEffects()`/`getEffectCount()` は既存の公開メソッド。
+
+- [ ] **Step 2: 補強テストが現コード（リファクタ前）で緑であることを確認**
+
+Run: `npx jest effectManager 2>&1 | tail -8`
+Expected: PASS（既存＋補強テストすべて green。ここが baseline）
+
+- [ ] **Step 3: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -3`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/ipne/presentation/effects/effectManager.test.ts
+git commit -m "test: IPNE effectManager に決定的フィールド検証を補強（Phase C 特性化）
+
+- duration/ringMaxRadius/flashAlpha/shakeIntensity・LOW_HP_WARNING 非追加・
+  ENEMY_DEATH(enemyType無) 非追加・ATTACK_HIT の SCREEN_SHAKE 追従を検証
+- リファクタ前後で振る舞い不変を担保する安全網
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `addEffect` を registry 駆動へ置換
+
+**Files:**
+- Modify: `src/features/ipne/presentation/effects/effectManager.ts`
+
+- [ ] **Step 1: 現状の `addEffect`（50-354行）を読む**
+
+特に switch 前の id 採番（51-52行）と switch 後の `this.enforceParticleLimit()`（353行）を確認する。
+
+- [ ] **Step 2: import を追加**
+
+`effectManager.ts` の冒頭 import 群（8-20行）を整理する。
+1. `EFFECT_FACTORIES` を import に追加:
+
+```typescript
+import { EFFECT_FACTORIES } from './effectFactories';
+```
+
+2. switch 本体を削除した結果、`effectManager.ts` で **不要になった import を削除**する。
+   `createRadialParticles`/`createRisingParticles`/`createSpiralParticles`/`createPulseParticles`/
+   `createTrailParticles`（particleSystem からの生成系）、`getHitEffectConfig`、`getEnemyDeathParticleConfig`、
+   `getItemPickupEffectConfig` は addEffect 内でのみ使われているため、移植後は未使用になる見込み。
+   ただし `updateParticles`/`drawParticles`（particleSystem）は `update`/`draw` で使うため残す。
+   `EffectType`/`EffectTypeValue`/`EffectOptions`/`GameEffect` は他メソッドでも使うため残す。
+   → typecheck/lint の未使用検出に従って正確に削除する。
+
+- [ ] **Step 3: `addEffect` メソッド本体を置換**
+
+現在の `addEffect`（51行の `effectIdCounter += 1;` から 354行のメソッド閉じ `}` まで）の本体を以下に置換:
+
+```typescript
+  addEffect(type: EffectTypeValue, x: number, y: number, now: number = Date.now(), options?: EffectOptions): void {
+    // 未処理タイプ(LOW_HP_WARNING)でも id カウンタは進める（元の挙動を保存）
+    effectIdCounter += 1;
+    const id = `effect-${effectIdCounter}`;
+
+    const factory = EFFECT_FACTORIES[type];
+    if (factory) {
+      const { effect, followUps } = factory({ id, x, y, now, options });
+      // ENEMY_DEATH(enemyType 未指定) のように effect を生成しないケースを保存
+      if (effect) {
+        this.effects.push(effect);
+      }
+      // 合成: 親エフェクトを push してから追従(SCREEN_SHAKE)を追加（元の順序を維持）
+      followUps?.forEach((f) => this.addEffect(f.type, f.x, f.y, now, f.options));
+    }
+
+    // 元と同じく factory ブロックの後で常に呼ぶ（未処理タイプでも実行）
+    this.enforceParticleLimit();
+  }
+```
+
+注意:
+- `effectIdCounter` はモジュール変数（既存）。`enforceParticleLimit` は既存の private メソッド。両者は無変更。
+- メソッドの JSDoc（42-49行）は残してよい。
+- switch・各 case（54-350行）は完全に削除される。
+
+- [ ] **Step 4: 補強テストを含む effectManager テストが緑であることを確認（振る舞い不変の証明）**
+
+Run: `npx jest effectManager 2>&1 | tail -8`
+Expected: PASS（既存＋Task 2 の補強テストすべて green）
+
+- [ ] **Step 5: effects ディレクトリ全テスト＋levelUpEffect を確認**
+
+Run: `npx jest effects levelUpEffect 2>&1 | tail -8`
+Expected: PASS（`performance.test.ts`・`levelUpEffect.test.ts` 含む）
+
+- [ ] **Step 6: 型チェック＆lint**
+
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし）
+Run: `npx eslint src/features/ipne/presentation/effects/ 2>&1 | tail -10`（エラーなし、未使用 import は削除）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/ipne/presentation/effects/effectManager.ts
+git commit -m "refactor: IPNE addEffect を effectFactories registry 駆動へ置換
+
+- 12ケース巨大switchを EFFECT_FACTORIES 引きに置換し addEffect を薄い処理に縮小
+- id 採番の位置・enforceParticleLimit の常時呼び出し・追従順序を逐語的に保存
+- 不要になった particle/config 生成系の import を削除
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 最終検証
+
+**Files:** なし（確認のみ）
+
+- [ ] **Step 1: switch が消えたことを確認**
+
+Run: `grep -n "switch\|case EffectType" src/features/ipne/presentation/effects/effectManager.ts || echo "(switch なし ✓)"`
+Expected: `(switch なし ✓)`（addEffect から switch が消えている。update/draw 内の三項・if は残ってよい）
+
+- [ ] **Step 2: IPNE 全テスト（回帰確認）**
+
+Run: `npx jest ipne 2>&1 | tail -8`
+Expected: PASS（IPNE 全スイート green）
+
+- [ ] **Step 3: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -3`
+Expected: エラーなし
+
+- [ ] **Step 4: lint（警告ゼロ強制）**
+
+Run: `npm run lint:ci 2>&1 | tail -10`
+Expected: エラー・警告なし（exit 0）
+
+---
+
+## 完了の定義（Definition of Done）
+
+- [ ] `effectFactories.ts` に 12 ファクトリーと `EFFECT_FACTORIES` registry がある
+- [ ] `addEffect` が registry 駆動の薄い処理に縮小されている（id 採番位置を保存）
+- [ ] `enforceParticleLimit()` が早期 return されず常に呼ばれる
+- [ ] `ATTACK_HIT` の SCREEN_SHAKE 合成が `followUps` で再現され、追加順序が元と一致
+- [ ] `LOW_HP_WARNING` が未処理（非追加・カウンタ加算のみ）、`ENEMY_DEATH(enemyType 無)` が非追加のまま保存
+- [ ] `update`/`draw`/`getShakeOffset` は据え置き、公開 API 不変
+- [ ] 既存＋補強テストが緑、決定的フィールドが検証されている
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス

--- a/docs/superpowers/specs/2026-06-15-ipne-effect-factories-design.md
+++ b/docs/superpowers/specs/2026-06-15-ipne-effect-factories-design.md
@@ -80,9 +80,9 @@ export interface FollowUpEffect {
   options?: EffectOptions;
 }
 
-/** ファクトリーの生成結果 */
+/** ファクトリーの生成結果。effect は optional（ENEMY_DEATH の enemyType 未指定時は生成しない） */
 export interface EffectBuildResult {
-  effect: GameEffect;
+  effect?: GameEffect;
   followUps?: FollowUpEffect[];
 }
 
@@ -127,7 +127,8 @@ addEffect(type: EffectTypeValue, x: number, y: number, now: number = Date.now(),
   const factory = EFFECT_FACTORIES[type];
   if (factory) {
     const { effect, followUps } = factory({ id, x, y, now, options });
-    this.effects.push(effect);
+    // ENEMY_DEATH(enemyType 未指定) のように effect を生成しないケースを保存
+    if (effect) this.effects.push(effect);
     // 合成: ATTACK_HIT を push してから追従(SCREEN_SHAKE)を追加（元の順序を維持）
     followUps?.forEach((f) => this.addEffect(f.type, f.x, f.y, now, f.options));
   }

--- a/docs/superpowers/specs/2026-06-15-ipne-effect-factories-design.md
+++ b/docs/superpowers/specs/2026-06-15-ipne-effect-factories-design.md
@@ -1,0 +1,203 @@
+# IPNE エフェクト生成のファクトリー化 設計（Phase C）
+
+- 日付: 2026-06-15
+- 対象: `src/features/ipne/presentation/effects/effectManager.ts`
+- 種別: リファクタリング（**振る舞い不変**・巨大 switch のファクトリー分離）
+- 位置づけ: IPNE 包括リファクタリング・ロードマップの **Phase C**
+
+## 1. 背景と目的
+
+`effectManager.ts`（505行）の `EffectManager.addEffect`（50〜360行・約310行）は、
+`EffectType` で分岐する **12 ケースの巨大 switch** になっている。各 case は
+「設定値を組み立てて `GameEffect` を生成し `this.effects.push` する」純粋な構築ロジックで、
+パーティクル生成は `particleSystem` の共有関数（`createRadialParticles` 等）に委譲済み。
+
+新エフェクト種別の追加や個別エフェクトの調整のたびにこの巨大メソッドを編集する必要があり、
+責務が一箇所に凝集している。IPNE には既に同型の解（`EnemyAiPolicyRegistry`：型→関数の registry、
+Phase A で確認）があるため、同じパターンでファクトリー化する。
+
+本作業の目的:
+
+1. 各 case を **純粋なエフェクトファクトリー関数**へ切り出し、`EffectType → ファクトリー` の
+   registry（`effectFactories.ts`）に集約する。
+2. `addEffect` を **registry 引き + push + 追従エフェクト処理**の薄い処理（〜15行）に縮小する。
+3. 公開 API・エフェクトの生成結果（振る舞い）を **一切変えない**。
+
+### 非目標（YAGNI）
+
+- `update` / `draw` / `getShakeOffset` 内の小さな型分岐（重力の有無、`LEVEL_UP` の strokeStyle、
+  `SCREEN_SHAKE` のオフセット判定）は **据え置く**。これらは描画・更新ロジックに密着しており、
+  生成ロジックとは別関心。本フェーズのスコープ外。
+- パーティクル生成関数（`createRadialParticles` 等）・config ヘルパー（`getHitEffectConfig` 等）の変更。
+- 新しいエフェクト種別の追加や既存エフェクトのパラメータ調整。
+
+## 2. 現状調査の要点
+
+- `addEffect(type, x, y, now = Date.now(), options?)` は **switch の前で必ず**
+  `effectIdCounter += 1` と `id = \`effect-${effectIdCounter}\`` を行う（51-52行）。
+- switch には **12 ケース**: `ATTACK_HIT`, `DAMAGE`, `TRAP_DAMAGE`, `TRAP_SLOW`, `TRAP_TELEPORT`,
+  `ITEM_PICKUP`, `LEVEL_UP`, `BOSS_KILL`, `ENEMY_ATTACK`, `SCREEN_SHAKE`, `STAGE_CLEAR`, `ENEMY_DEATH`。
+- **`EffectType` は13値**だが `LOW_HP_WARNING` は switch に **無く未処理**（default 句も無い）。
+  → `addEffect(LOW_HP_WARNING, ...)` は **id カウンタだけ進めて何もしない**。この副作用も保存対象。
+- `ATTACK_HIT` の case は `hitConfig.hasShake` 時に `this.addEffect(EffectType.SCREEN_SHAKE, 0, 0, now, { damage: 3 })`
+  を**再帰呼び**する（合成）。先に ATTACK_HIT を push してから SCREEN_SHAKE を追加する順序。
+- `addEffect` は switch の **後（353行）で常に** `this.enforceParticleLimit()`（private、496行）を呼ぶ。
+  これは `total > MAX_PARTICLES(200) && effects.length > 1` の間、古いエフェクトを `shift()` で削除する。
+  **未処理タイプ（LOW_HP_WARNING）でもこの呼び出しは走る**ため、ファクトリー化後も常に呼ぶ必要がある。
+- 依存（ファクトリーへ渡す必要あり）: `createRadialParticles`/`createRisingParticles`/`createSpiralParticles`/
+  `createPulseParticles`/`createTrailParticles`（particleSystem）, `getHitEffectConfig`,
+  `getEnemyDeathParticleConfig`, `getItemPickupEffectConfig`。いずれもモジュール関数で `this` に依存しない。
+- ファクトリーが触る状態は `this.effects.push`（生成結果）と `id`（採番済みを受け取る）のみ。
+- 公開 API: `EffectManager` クラス（`addEffect`/`update`/`draw`/`getShakeOffset`/`clear`/`getEffectCount`/
+  `getEffects`/`getTotalParticleCount`）と `resetEffectIdCounter`。`effects/index.ts` 経由で公開。
+- 安全網: `effectManager.test.ts`（220行）が **型ごとのパーティクル数・振る舞い**を検証
+  （ATTACK_HIT の powerLevel 0=4個/4=24個・コンボ倍率、ENEMY_DEATH の敵型別、SCREEN_SHAKE はパーティクルなし、
+  STAGE_CLEAR の螺旋、パーティクル上限超過の削除、update の期限切れ削除 等）。
+  ただし非パーティクルの決定的フィールド（duration/ringRadius/flashAlpha/shakeIntensity）は一部未検証。
+
+## 3. ファクトリー化後の構造
+
+### 新モジュール `effectFactories.ts`
+
+```typescript
+import { EffectType, EffectTypeValue, EffectOptions, GameEffect } from './effectTypes';
+// particleSystem / config ヘルパーの import
+
+/** ファクトリーに渡す生成コンテキスト */
+export interface EffectFactoryContext {
+  id: string;
+  x: number;
+  y: number;
+  now: number;
+  options?: EffectOptions;
+}
+
+/** 追従エフェクト（合成）の記述子 */
+export interface FollowUpEffect {
+  type: EffectTypeValue;
+  x: number;
+  y: number;
+  options?: EffectOptions;
+}
+
+/** ファクトリーの生成結果 */
+export interface EffectBuildResult {
+  effect: GameEffect;
+  followUps?: FollowUpEffect[];
+}
+
+/** エフェクト生成ファクトリー（純粋関数。this に依存しない） */
+export type EffectFactory = (ctx: EffectFactoryContext) => EffectBuildResult;
+
+// 各 case 本体を逐語移植したファクトリー関数（createAttackHitEffect 等）
+
+/**
+ * EffectType → ファクトリーの registry。
+ * LOW_HP_WARNING は元の switch に case が無く未処理のため、ここにも登録しない（Partial）。
+ */
+export const EFFECT_FACTORIES: Partial<Record<EffectTypeValue, EffectFactory>> = {
+  [EffectType.ATTACK_HIT]: createAttackHitEffect,
+  [EffectType.DAMAGE]: createDamageEffect,
+  // ... 12 ケース分
+};
+```
+
+- 各ファクトリーは元の case 本体を **逐語移植**し、`this.effects.push({...})` の代わりに
+  `return { effect: {...} }` を返す。`id`/`x`/`y`/`now`/`options` は ctx から受け取る。
+- `ATTACK_HIT` ファクトリーは合成を `followUps` で表現:
+
+```typescript
+const createAttackHitEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  // ... hitConfig 計算と effect 構築（元の case 本体を逐語移植）
+  const followUps = hitConfig.hasShake
+    ? [{ type: EffectType.SCREEN_SHAKE, x: 0, y: 0, options: { damage: 3 } }]
+    : undefined;
+  return { effect, followUps };
+};
+```
+
+### `addEffect` の置換
+
+```typescript
+addEffect(type: EffectTypeValue, x: number, y: number, now: number = Date.now(), options?: EffectOptions): void {
+  // 元の挙動を保存: 未処理タイプ(LOW_HP_WARNING)でも id カウンタは進める
+  effectIdCounter += 1;
+  const id = `effect-${effectIdCounter}`;
+
+  const factory = EFFECT_FACTORIES[type];
+  if (factory) {
+    const { effect, followUps } = factory({ id, x, y, now, options });
+    this.effects.push(effect);
+    // 合成: ATTACK_HIT を push してから追従(SCREEN_SHAKE)を追加（元の順序を維持）
+    followUps?.forEach((f) => this.addEffect(f.type, f.x, f.y, now, f.options));
+  }
+
+  // 元と同じく switch(現: factory ブロック)の後で常に呼ぶ。未処理タイプでも実行される
+  this.enforceParticleLimit();
+}
+```
+
+> 重要: `enforceParticleLimit()` は **早期 return せず常に呼ぶ**こと。元の `addEffect` は switch の後
+> （353行）で無条件に `this.enforceParticleLimit()` を呼んでおり、未処理タイプ(LOW_HP_WARNING)でも実行される。
+> `if (!factory) return;` のように早期 return すると上限処理がスキップされ挙動が変わる。
+> 追従エフェクトの再帰（SCREEN_SHAKE）はそれ自身の `enforceParticleLimit` を実行し、その後で外側の
+> `addEffect` が再度 `enforceParticleLimit` を呼ぶ — この二重呼び出し順序も元と一致する。
+
+### 依存方向（循環なし）
+
+```
+effectFactories.ts → particleSystem / hitEffectScaling / enemyDeath / itemFeedback / effectTypes
+effectManager.ts   → effectFactories
+```
+
+`effectManager.ts` に残る `MAX_PARTICLES` 定数・`effectIdCounter`・`update`/`draw` 等はそのまま。
+
+## 4. 安全網（振る舞い不変の証明）
+
+パーティクルは `Math.random` 依存で位置が非決定的なため、Phase B のような全出力スナップショットは使えない。
+代わりに既存テスト＋決定的フィールド検証で守る。
+
+- **既存 `effectManager.test.ts` を全工程で緑に保つ**（型ごとのパーティクル数・振る舞い・上限・update）。
+- **決定的フィールドのアサーションを補強する**（恒久）。各エフェクト型について、パーティクル位置以外の
+  決定的な生成結果を `effectManager.test.ts` に追加検証する:
+  - `ATTACK_HIT`: `duration === 300`、`hasShockwave` 時の `ringMaxRadius`、`hasFlash` 時の `flashAlpha`、
+    `hasShake`（powerLevel 4 等）時に SCREEN_SHAKE が追従追加されること。
+  - 各型の `duration`（DAMAGE=400, TRAP_DAMAGE=350 等）と `type` フィールド。
+  - `SCREEN_SHAKE`: `shakeIntensity` が設定され particles が空であること。
+  - `LOW_HP_WARNING`: `addEffect` してもエフェクトが追加されないこと（未処理の保存）。
+- 加えて全工程で `npm run typecheck` を緑に保つ。
+
+## 5. 検証手順（refactor-safely）
+
+1. `effectFactories.ts` を作成し、12 ケースのファクトリーと registry を実装（各 case を逐語移植）。
+2. 既存テストの補強（決定的フィールド検証）を追加。
+3. `addEffect` を registry 駆動へ置換。
+4. 各ステップで以下を実行:
+
+```bash
+npx jest effectManager levelUpEffect 2>&1 | tail -8
+npm run typecheck
+```
+
+5. 最終確認: `npx jest effects`（effects ディレクトリ全テスト）/ `npx jest ipne` / `npm run lint:ci` 全パス。
+
+### 完了の定義（Definition of Done）
+
+- [ ] `effectFactories.ts` に 12 ファクトリーと `EFFECT_FACTORIES` registry がある
+- [ ] `addEffect` が registry 駆動の薄い処理に縮小されている（id カウンタ加算の位置・タイミングを保存）
+- [ ] `ATTACK_HIT` の SCREEN_SHAKE 合成が `followUps` で再現され、追加順序が元と一致
+- [ ] `LOW_HP_WARNING` が未処理（エフェクト非追加・カウンタ加算のみ）のまま保存されている
+- [ ] `enforceParticleLimit()` が早期 return されず常に呼ばれる（未処理タイプでも実行・上限処理を保存）
+- [ ] `update`/`draw`/`getShakeOffset` は据え置き、公開 API 不変
+- [ ] 既存テスト＋補強テストが緑、決定的フィールドが検証されている
+- [ ] `npx jest effects` / `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス
+
+## 6. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| case 移植時にパラメータ（色・速度・duration・count）を取り違える | 元 case を逐語移植。決定的フィールドのアサーションと既存パーティクル数テストで検出 |
+| ATTACK_HIT→SCREEN_SHAKE の追加順序/id 採番が変わる | followUps を push 後に処理し元の順序を維持。補強テストで追従追加を検証 |
+| LOW_HP_WARNING の未処理挙動を取りこぼす | Partial record で未登録にし、カウンタ加算は lookup 前に行う。補強テストで非追加を確認 |
+| パーティクル上限処理の位置がずれる | 元 addEffect の該当処理を逐語維持。上限テストで担保 |
+| 循環 import | effectManager → effectFactories の一方向を厳守 |

--- a/src/features/ipne/presentation/effects/effectFactories.ts
+++ b/src/features/ipne/presentation/effects/effectFactories.ts
@@ -270,7 +270,9 @@ const createStageClearEffect: EffectFactory = ({ id, x, y, now, options }) => {
 const createEnemyDeathEffect: EffectFactory = ({ id, x, y, now, options }) => {
   const enemyType = options?.enemyType;
   if (!enemyType) {
-    return {}; // enemyType 未指定時はエフェクトを生成しない（元の挙動を保存）
+    // enemyType が渡されない場合は旧 switch の `if (enemyType)` ガードと同様、
+    // effect を生成せず何も追加しない（effect 省略 = push されない）
+    return {};
   }
   const deathConfig = getEnemyDeathParticleConfig(enemyType);
   const combo = options?.comboMultiplier ?? 1.0;

--- a/src/features/ipne/presentation/effects/effectFactories.ts
+++ b/src/features/ipne/presentation/effects/effectFactories.ts
@@ -1,0 +1,314 @@
+/**
+ * エフェクト生成ファクトリー
+ *
+ * EffectType ごとに GameEffect を構築する純粋関数群と、その registry を提供する。
+ * EffectManager.addEffect はこの registry を引いてエフェクトを生成する。
+ * パーティクル生成は particleSystem の共有関数へ委譲する（this に依存しない）。
+ */
+import { EffectType, EffectTypeValue, EffectOptions, GameEffect } from './effectTypes';
+import {
+  createRadialParticles,
+  createRisingParticles,
+  createSpiralParticles,
+  createPulseParticles,
+  createTrailParticles,
+} from './particleSystem';
+import { getHitEffectConfig } from './hitEffectScaling';
+import { getEnemyDeathParticleConfig } from './enemyDeath';
+import { getItemPickupEffectConfig } from './itemFeedback';
+
+/** ファクトリーに渡す生成コンテキスト */
+export interface EffectFactoryContext {
+  id: string;
+  x: number;
+  y: number;
+  now: number;
+  options?: EffectOptions;
+}
+
+/** 追従エフェクト（合成）の記述子 */
+export interface FollowUpEffect {
+  type: EffectTypeValue;
+  x: number;
+  y: number;
+  options?: EffectOptions;
+}
+
+/** ファクトリーの生成結果。effect は optional（ENEMY_DEATH の enemyType 未指定時は生成しない） */
+export interface EffectBuildResult {
+  effect?: GameEffect;
+  followUps?: FollowUpEffect[];
+}
+
+/** エフェクト生成ファクトリー（純粋関数。this に依存しない） */
+export type EffectFactory = (ctx: EffectFactoryContext) => EffectBuildResult;
+
+const createAttackHitEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const pl = options?.powerLevel ?? 1;
+  const combo = options?.comboMultiplier ?? 1.0;
+  const hitConfig = getHitEffectConfig(pl);
+  const count = Math.round(hitConfig.particleCount * combo);
+  const sizeMin = 2 * hitConfig.sizeMultiplier;
+  const sizeMax = 4 * hitConfig.sizeMultiplier;
+  const speedMin = 60 * hitConfig.speedMultiplier;
+  const speedMax = 150 * hitConfig.speedMultiplier;
+
+  const effect: GameEffect = {
+    id,
+    type: EffectType.ATTACK_HIT,
+    x,
+    y,
+    startTime: now,
+    duration: 300,
+    particles: createRadialParticles(
+      count, x, y,
+      ['#ffffff', '#ffffcc', '#ffff99'],
+      speedMin, speedMax,
+      sizeMin, sizeMax,
+      3.0
+    ),
+    ringRadius: hitConfig.hasShockwave ? 0 : undefined,
+    ringMaxRadius: hitConfig.hasShockwave ? (8 + pl * 4) : undefined,
+    flashAlpha: hitConfig.hasFlash ? 0.4 : undefined,
+  };
+
+  const followUps = hitConfig.hasShake
+    ? [{ type: EffectType.SCREEN_SHAKE, x: 0, y: 0, options: { damage: 3 } }]
+    : undefined;
+
+  return { effect, followUps };
+};
+
+const createDamageEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.DAMAGE,
+    x,
+    y,
+    startTime: now,
+    duration: 400,
+    particles: createRisingParticles(6, x, y, ['#ef4444', '#dc2626', '#ff6b6b'], 2, 4, 2.5),
+  },
+});
+
+const createTrapDamageEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.TRAP_DAMAGE,
+    x,
+    y,
+    startTime: now,
+    duration: 350,
+    particles: createRisingParticles(6, x, y, ['#dc2626', '#ef4444', '#f87171'], 2, 3, 2.8),
+  },
+});
+
+const createTrapSlowEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.TRAP_SLOW,
+    x,
+    y,
+    startTime: now,
+    duration: 500,
+    particles: createRadialParticles(8, x, y, ['#3b82f6', '#60a5fa', '#93c5fd'], 15, 40, 3, 5, 2.0),
+  },
+});
+
+const createTrapTeleportEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.TRAP_TELEPORT,
+    x,
+    y,
+    startTime: now,
+    duration: 400,
+    particles: createRadialParticles(10, x, y, ['#7c3aed', '#a78bfa', '#c4b5fd'], 30, 80, 2, 4, 2.5),
+    ringRadius: 0,
+    ringMaxRadius: 30,
+  },
+});
+
+const createItemPickupEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const itemType = options?.itemType;
+  const itemConfig = itemType ? getItemPickupEffectConfig(itemType) : undefined;
+  const pCount = itemConfig?.particleCount ?? 6;
+  const pColors = itemConfig?.colors ?? ['#fbbf24', '#fcd34d', '#fef08a'];
+  const pPattern = itemConfig?.pattern ?? 'rising';
+
+  const particles =
+    pPattern === 'spiral'
+      ? createSpiralParticles(pCount, x, y, pColors, 80, 1.5)
+      : pPattern === 'radial'
+      ? createRadialParticles(pCount, x, y, pColors, 40, 100, 2, 4, 2.0)
+      : createRisingParticles(pCount, x, y, pColors, 2, 3, 2.0);
+
+  return {
+    effect: {
+      id,
+      type: EffectType.ITEM_PICKUP,
+      x,
+      y,
+      startTime: now,
+      duration: 500,
+      particles,
+    },
+  };
+};
+
+const createLevelUpEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.LEVEL_UP,
+    x,
+    y,
+    startTime: now,
+    duration: 1500,
+    particles: createSpiralParticles(24, x, y, ['#fbbf24', '#fcd34d', '#fef08a', '#ffffff'], 100, 0.7),
+    ringRadius: 0,
+    ringMaxRadius: 40,
+    flashAlpha: 0.4,
+    flashColor: '#fbbf24',
+  },
+});
+
+const createBossKillEffect: EffectFactory = ({ id, x, y, now }) => ({
+  effect: {
+    id,
+    type: EffectType.BOSS_KILL,
+    x,
+    y,
+    startTime: now,
+    duration: 1200,
+    particles: createRadialParticles(24, x, y, ['#dc2626', '#f97316', '#ffffff', '#fbbf24'], 80, 200, 3, 6, 0.8),
+    flashAlpha: 1.0,
+  },
+});
+
+const createEnemyAttackEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const variant = options?.variant ?? 'melee';
+  if (variant === 'boss') {
+    return {
+      effect: {
+        id,
+        type: EffectType.ENEMY_ATTACK,
+        x,
+        y,
+        startTime: now,
+        duration: 500,
+        particles: createPulseParticles(16, x, y, ['#dc2626', '#ef4444', '#f87171', '#ffffff'], 100, 2.0),
+      },
+    };
+  }
+  if (variant === 'ranged') {
+    return {
+      effect: {
+        id,
+        type: EffectType.ENEMY_ATTACK,
+        x,
+        y,
+        startTime: now,
+        duration: 400,
+        particles: createTrailParticles(8, x, y, 0, -1, ['#f97316', '#fdba74', '#fff7ed'], 120, 2.5),
+      },
+    };
+  }
+  // melee
+  return {
+    effect: {
+      id,
+      type: EffectType.ENEMY_ATTACK,
+      x,
+      y,
+      startTime: now,
+      duration: 300,
+      particles: createRadialParticles(8, x, y, ['#ef4444', '#dc2626', '#ff6b6b'], 50, 120, 2, 4, 3.0),
+    },
+  };
+};
+
+const createScreenShakeEffect: EffectFactory = ({ id, now, options }) => {
+  const intensity = Math.min(4, options?.damage ? options.damage * 0.5 : 2);
+  return {
+    effect: {
+      id,
+      type: EffectType.SCREEN_SHAKE,
+      x: 0,
+      y: 0,
+      startTime: now,
+      duration: 200,
+      particles: [],
+      shakeIntensity: intensity,
+      shakeDecay: intensity / 0.2,
+    },
+  };
+};
+
+const createStageClearEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const stageColors = [
+    ['#60a5fa', '#93c5fd', '#ffffff'],
+    ['#34d399', '#6ee7b7', '#ffffff'],
+    ['#fbbf24', '#fcd34d', '#ffffff'],
+    ['#f472b6', '#f9a8d4', '#ffffff'],
+    ['#a78bfa', '#c4b5fd', '#fbbf24', '#ffffff'],
+  ];
+  const stageIdx = Math.min((options?.stageNumber ?? 1) - 1, stageColors.length - 1);
+  return {
+    effect: {
+      id,
+      type: EffectType.STAGE_CLEAR,
+      x,
+      y,
+      startTime: now,
+      duration: 1500,
+      particles: createSpiralParticles(32, x, y, stageColors[stageIdx], 100, 0.7),
+      flashAlpha: 1.0,
+    },
+  };
+};
+
+const createEnemyDeathEffect: EffectFactory = ({ id, x, y, now, options }) => {
+  const enemyType = options?.enemyType;
+  if (!enemyType) {
+    return {}; // enemyType 未指定時はエフェクトを生成しない（元の挙動を保存）
+  }
+  const deathConfig = getEnemyDeathParticleConfig(enemyType);
+  const combo = options?.comboMultiplier ?? 1.0;
+  const count = Math.round(deathConfig.particleCount * combo);
+  return {
+    effect: {
+      id,
+      type: EffectType.ENEMY_DEATH,
+      x,
+      y,
+      startTime: now,
+      duration: deathConfig.duration,
+      particles: createRadialParticles(
+        count, x, y,
+        deathConfig.colors,
+        deathConfig.speedMin, deathConfig.speedMax,
+        deathConfig.sizeMin, deathConfig.sizeMax,
+        2.0
+      ),
+    },
+  };
+};
+
+/**
+ * EffectType → ファクトリーの registry。
+ * LOW_HP_WARNING は元の switch に case が無く未処理のため登録しない（Partial）。
+ */
+export const EFFECT_FACTORIES: Partial<Record<EffectTypeValue, EffectFactory>> = {
+  [EffectType.ATTACK_HIT]: createAttackHitEffect,
+  [EffectType.DAMAGE]: createDamageEffect,
+  [EffectType.TRAP_DAMAGE]: createTrapDamageEffect,
+  [EffectType.TRAP_SLOW]: createTrapSlowEffect,
+  [EffectType.TRAP_TELEPORT]: createTrapTeleportEffect,
+  [EffectType.ITEM_PICKUP]: createItemPickupEffect,
+  [EffectType.LEVEL_UP]: createLevelUpEffect,
+  [EffectType.BOSS_KILL]: createBossKillEffect,
+  [EffectType.ENEMY_ATTACK]: createEnemyAttackEffect,
+  [EffectType.SCREEN_SHAKE]: createScreenShakeEffect,
+  [EffectType.STAGE_CLEAR]: createStageClearEffect,
+  [EffectType.ENEMY_DEATH]: createEnemyDeathEffect,
+};

--- a/src/features/ipne/presentation/effects/effectManager.test.ts
+++ b/src/features/ipne/presentation/effects/effectManager.test.ts
@@ -231,23 +231,32 @@ describe('EffectManager', () => {
       expect(effects.some((e) => e.type === EffectType.SCREEN_SHAKE)).toBe(true);
     });
 
-    it('各エフェクト型の duration が規定値である', () => {
-      const cases: Array<[EffectTypeValue, number]> = [
-        [EffectType.DAMAGE, 400],
-        [EffectType.TRAP_DAMAGE, 350],
-        [EffectType.TRAP_SLOW, 500],
-        [EffectType.TRAP_TELEPORT, 400],
-        [EffectType.ITEM_PICKUP, 500],
-        [EffectType.LEVEL_UP, 1500],
-        [EffectType.BOSS_KILL, 1200],
-        [EffectType.STAGE_CLEAR, 1500], // stageNumber 未指定でも既定 1 で生成される
-      ];
-      for (const [type, duration] of cases) {
-        const m = new EffectManager();
-        m.addEffect(type, 0, 0, 1000);
-        const e = m.getEffects().find((ef) => ef.type === type);
-        expect(e?.duration).toBe(duration);
-      }
+    // stageNumber 未指定でも既定 1 で生成される（STAGE_CLEAR）
+    it.each<[EffectTypeValue, number]>([
+      [EffectType.DAMAGE, 400],
+      [EffectType.TRAP_DAMAGE, 350],
+      [EffectType.TRAP_SLOW, 500],
+      [EffectType.TRAP_TELEPORT, 400],
+      [EffectType.ITEM_PICKUP, 500],
+      [EffectType.LEVEL_UP, 1500],
+      [EffectType.BOSS_KILL, 1200],
+      [EffectType.STAGE_CLEAR, 1500],
+    ])('%s の duration が %d である', (type, duration) => {
+      const m = new EffectManager();
+      m.addEffect(type, 0, 0, 1000);
+      const e = m.getEffects().find((ef) => ef.type === type);
+      expect(e?.duration).toBe(duration);
+    });
+
+    it('TRAP_TELEPORT と LEVEL_UP は ringMaxRadius を持つ', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.TRAP_TELEPORT, 0, 0, 1000);
+      m.addEffect(EffectType.LEVEL_UP, 0, 0, 1000);
+      const teleport = m.getEffects().find((e) => e.type === EffectType.TRAP_TELEPORT);
+      const levelUp = m.getEffects().find((e) => e.type === EffectType.LEVEL_UP);
+      expect(teleport?.ringMaxRadius).toBe(30);
+      expect(levelUp?.ringMaxRadius).toBe(40);
+      expect(levelUp?.flashColor).toBe('#fbbf24');
     });
 
     it('SCREEN_SHAKE は particles が空で shakeIntensity を持つ', () => {
@@ -255,7 +264,7 @@ describe('EffectManager', () => {
       m.addEffect(EffectType.SCREEN_SHAKE, 0, 0, 1000, { damage: 4 });
       const e = m.getEffects().find((ef) => ef.type === EffectType.SCREEN_SHAKE);
       expect(e?.particles.length).toBe(0);
-      expect(e?.shakeIntensity).toBe(Math.min(4, 4 * 0.5));
+      expect(e?.shakeIntensity).toBe(2); // damage=4 → Math.min(4, 4*0.5) = 2
     });
 
     it('LOW_HP_WARNING は addEffect してもエフェクトを追加しない（未処理を保存）', () => {

--- a/src/features/ipne/presentation/effects/effectManager.test.ts
+++ b/src/features/ipne/presentation/effects/effectManager.test.ts
@@ -1,5 +1,5 @@
 import { EffectManager, resetEffectIdCounter } from './effectManager';
-import { EffectType } from './effectTypes';
+import { EffectType, EffectTypeValue } from './effectTypes';
 import { EnemyType } from '../../types';
 
 describe('EffectManager', () => {
@@ -215,6 +215,59 @@ describe('EffectManager', () => {
 
       // 上限 200 を超えないようにエフェクトが削減されている
       expect(manager.getTotalParticleCount()).toBeLessThanOrEqual(200);
+    });
+  });
+
+  describe('決定的フィールド検証（Phase C 特性化）', () => {
+    it('ATTACK_HIT は duration 300 で、powerLevel 4 では shockwave/flash/shake を伴う', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.ATTACK_HIT, 10, 20, 1000, { powerLevel: 4 });
+      const effects = m.getEffects();
+      const hit = effects.find((e) => e.type === EffectType.ATTACK_HIT);
+      expect(hit?.duration).toBe(300);
+      expect(hit?.ringMaxRadius).toBe(8 + 4 * 4);
+      expect(hit?.flashAlpha).toBe(0.4);
+      // hasShake により SCREEN_SHAKE が追従追加される
+      expect(effects.some((e) => e.type === EffectType.SCREEN_SHAKE)).toBe(true);
+    });
+
+    it('各エフェクト型の duration が規定値である', () => {
+      const cases: Array<[EffectTypeValue, number]> = [
+        [EffectType.DAMAGE, 400],
+        [EffectType.TRAP_DAMAGE, 350],
+        [EffectType.TRAP_SLOW, 500],
+        [EffectType.TRAP_TELEPORT, 400],
+        [EffectType.ITEM_PICKUP, 500],
+        [EffectType.LEVEL_UP, 1500],
+        [EffectType.BOSS_KILL, 1200],
+        [EffectType.STAGE_CLEAR, 1500], // stageNumber 未指定でも既定 1 で生成される
+      ];
+      for (const [type, duration] of cases) {
+        const m = new EffectManager();
+        m.addEffect(type, 0, 0, 1000);
+        const e = m.getEffects().find((ef) => ef.type === type);
+        expect(e?.duration).toBe(duration);
+      }
+    });
+
+    it('SCREEN_SHAKE は particles が空で shakeIntensity を持つ', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.SCREEN_SHAKE, 0, 0, 1000, { damage: 4 });
+      const e = m.getEffects().find((ef) => ef.type === EffectType.SCREEN_SHAKE);
+      expect(e?.particles.length).toBe(0);
+      expect(e?.shakeIntensity).toBe(Math.min(4, 4 * 0.5));
+    });
+
+    it('LOW_HP_WARNING は addEffect してもエフェクトを追加しない（未処理を保存）', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.LOW_HP_WARNING, 0, 0, 1000);
+      expect(m.getEffectCount()).toBe(0);
+    });
+
+    it('ENEMY_DEATH は enemyType 未指定だとエフェクトを追加しない', () => {
+      const m = new EffectManager();
+      m.addEffect(EffectType.ENEMY_DEATH, 0, 0, 1000);
+      expect(m.getEffectCount()).toBe(0);
     });
   });
 });

--- a/src/features/ipne/presentation/effects/effectManager.ts
+++ b/src/features/ipne/presentation/effects/effectManager.ts
@@ -7,17 +7,10 @@
 
 import { EffectType, EffectTypeValue, EffectOptions, GameEffect } from './effectTypes';
 import {
-  createRadialParticles,
-  createRisingParticles,
-  createSpiralParticles,
-  createPulseParticles,
-  createTrailParticles,
   updateParticles,
   drawParticles,
 } from './particleSystem';
-import { getHitEffectConfig } from './hitEffectScaling';
-import { getEnemyDeathParticleConfig } from './enemyDeath';
-import { getItemPickupEffectConfig } from './itemFeedback';
+import { EFFECT_FACTORIES } from './effectFactories';
 
 /** パーティクル上限数 */
 const MAX_PARTICLES = 200;
@@ -48,308 +41,22 @@ export class EffectManager {
    * @param now - 現在時刻（ミリ秒）
    */
   addEffect(type: EffectTypeValue, x: number, y: number, now: number = Date.now(), options?: EffectOptions): void {
+    // 未処理タイプ(LOW_HP_WARNING)でも id カウンタは進める（元の挙動を保存）
     effectIdCounter += 1;
     const id = `effect-${effectIdCounter}`;
 
-    switch (type) {
-      case EffectType.ATTACK_HIT: {
-        const pl = options?.powerLevel ?? 1;
-        const combo = options?.comboMultiplier ?? 1.0;
-        const hitConfig = getHitEffectConfig(pl);
-        const count = Math.round(hitConfig.particleCount * combo);
-        const sizeMin = 2 * hitConfig.sizeMultiplier;
-        const sizeMax = 4 * hitConfig.sizeMultiplier;
-        const speedMin = 60 * hitConfig.speedMultiplier;
-        const speedMax = 150 * hitConfig.speedMultiplier;
-
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 300,
-          particles: createRadialParticles(
-            count, x, y,
-            ['#ffffff', '#ffffcc', '#ffff99'],
-            speedMin, speedMax,
-            sizeMin, sizeMax,
-            3.0
-          ),
-          ringRadius: hitConfig.hasShockwave ? 0 : undefined,
-          ringMaxRadius: hitConfig.hasShockwave ? (8 + pl * 4) : undefined,
-          flashAlpha: hitConfig.hasFlash ? 0.4 : undefined,
-        });
-
-        // 画面シェイク追加（powerLevel 4）
-        if (hitConfig.hasShake) {
-          this.addEffect(EffectType.SCREEN_SHAKE, 0, 0, now, { damage: 3 });
-        }
-        break;
+    const factory = EFFECT_FACTORIES[type];
+    if (factory) {
+      const { effect, followUps } = factory({ id, x, y, now, options });
+      // ENEMY_DEATH(enemyType 未指定) のように effect を生成しないケースを保存
+      if (effect) {
+        this.effects.push(effect);
       }
-
-      case EffectType.DAMAGE:
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 400,
-          particles: createRisingParticles(
-            6, x, y,
-            ['#ef4444', '#dc2626', '#ff6b6b'],
-            2, 4,
-            2.5
-          ),
-        });
-        break;
-
-      case EffectType.TRAP_DAMAGE:
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 350,
-          particles: createRisingParticles(
-            6, x, y,
-            ['#dc2626', '#ef4444', '#f87171'],
-            2, 3,
-            2.8
-          ),
-        });
-        break;
-
-      case EffectType.TRAP_SLOW:
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 500,
-          particles: createRadialParticles(
-            8, x, y,
-            ['#3b82f6', '#60a5fa', '#93c5fd'],
-            15, 40,
-            3, 5,
-            2.0
-          ),
-        });
-        break;
-
-      case EffectType.TRAP_TELEPORT:
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 400,
-          particles: createRadialParticles(
-            10, x, y,
-            ['#7c3aed', '#a78bfa', '#c4b5fd'],
-            30, 80,
-            2, 4,
-            2.5
-          ),
-          ringRadius: 0,
-          ringMaxRadius: 30,
-        });
-        break;
-
-      case EffectType.ITEM_PICKUP: {
-        const itemType = options?.itemType;
-        const itemConfig = itemType ? getItemPickupEffectConfig(itemType) : undefined;
-        const pCount = itemConfig?.particleCount ?? 6;
-        const pColors = itemConfig?.colors ?? ['#fbbf24', '#fcd34d', '#fef08a'];
-        const pPattern = itemConfig?.pattern ?? 'rising';
-
-        const particles =
-          pPattern === 'spiral'
-            ? createSpiralParticles(pCount, x, y, pColors, 80, 1.5)
-            : pPattern === 'radial'
-            ? createRadialParticles(pCount, x, y, pColors, 40, 100, 2, 4, 2.0)
-            : createRisingParticles(pCount, x, y, pColors, 2, 3, 2.0);
-
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 500,
-          particles,
-        });
-        break;
-      }
-
-      case EffectType.LEVEL_UP:
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 1500,
-          particles: createSpiralParticles(
-            24, x, y,
-            ['#fbbf24', '#fcd34d', '#fef08a', '#ffffff'],
-            100,
-            0.7
-          ),
-          ringRadius: 0,
-          ringMaxRadius: 40,
-          flashAlpha: 0.4,
-          flashColor: '#fbbf24',
-        });
-        break;
-
-      case EffectType.BOSS_KILL:
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 1200,
-          particles: createRadialParticles(
-            24, x, y,
-            ['#dc2626', '#f97316', '#ffffff', '#fbbf24'],
-            80, 200,
-            3, 6,
-            0.8
-          ),
-          flashAlpha: 1.0,
-        });
-        break;
-
-      case EffectType.ENEMY_ATTACK: {
-        const variant = options?.variant ?? 'melee';
-        if (variant === 'boss') {
-          this.effects.push({
-            id,
-            type,
-            x,
-            y,
-            startTime: now,
-            duration: 500,
-            particles: createPulseParticles(
-              16, x, y,
-              ['#dc2626', '#ef4444', '#f87171', '#ffffff'],
-              100,
-              2.0
-            ),
-          });
-        } else if (variant === 'ranged') {
-          this.effects.push({
-            id,
-            type,
-            x,
-            y,
-            startTime: now,
-            duration: 400,
-            particles: createTrailParticles(
-              8, x, y,
-              0, -1,
-              ['#f97316', '#fdba74', '#fff7ed'],
-              120,
-              2.5
-            ),
-          });
-        } else {
-          // melee
-          this.effects.push({
-            id,
-            type,
-            x,
-            y,
-            startTime: now,
-            duration: 300,
-            particles: createRadialParticles(
-              8, x, y,
-              ['#ef4444', '#dc2626', '#ff6b6b'],
-              50, 120,
-              2, 4,
-              3.0
-            ),
-          });
-        }
-        break;
-      }
-
-      case EffectType.SCREEN_SHAKE: {
-        const intensity = Math.min(4, options?.damage ? options.damage * 0.5 : 2);
-        this.effects.push({
-          id,
-          type,
-          x: 0,
-          y: 0,
-          startTime: now,
-          duration: 200,
-          particles: [],
-          shakeIntensity: intensity,
-          shakeDecay: intensity / 0.2,
-        });
-        break;
-      }
-
-      case EffectType.STAGE_CLEAR: {
-        const stageColors = [
-          ['#60a5fa', '#93c5fd', '#ffffff'],
-          ['#34d399', '#6ee7b7', '#ffffff'],
-          ['#fbbf24', '#fcd34d', '#ffffff'],
-          ['#f472b6', '#f9a8d4', '#ffffff'],
-          ['#a78bfa', '#c4b5fd', '#fbbf24', '#ffffff'],
-        ];
-        const stageIdx = Math.min((options?.stageNumber ?? 1) - 1, stageColors.length - 1);
-        this.effects.push({
-          id,
-          type,
-          x,
-          y,
-          startTime: now,
-          duration: 1500,
-          particles: createSpiralParticles(
-            32, x, y,
-            stageColors[stageIdx],
-            100,
-            0.7
-          ),
-          flashAlpha: 1.0,
-        });
-        break;
-      }
-
-      case EffectType.ENEMY_DEATH: {
-        const enemyType = options?.enemyType;
-        if (enemyType) {
-          const deathConfig = getEnemyDeathParticleConfig(enemyType);
-          const combo = options?.comboMultiplier ?? 1.0;
-          const count = Math.round(deathConfig.particleCount * combo);
-          this.effects.push({
-            id,
-            type,
-            x,
-            y,
-            startTime: now,
-            duration: deathConfig.duration,
-            particles: createRadialParticles(
-              count, x, y,
-              deathConfig.colors,
-              deathConfig.speedMin, deathConfig.speedMax,
-              deathConfig.sizeMin, deathConfig.sizeMax,
-              2.0
-            ),
-          });
-        }
-        break;
-      }
+      // 合成: 親エフェクトを push してから追従(SCREEN_SHAKE)を追加（元の順序を維持）
+      followUps?.forEach((f) => this.addEffect(f.type, f.x, f.y, now, f.options));
     }
 
-    // パーティクル上限を超えた場合、古いエフェクトから削除
+    // 元と同じく factory ブロックの後で常に呼ぶ（未処理タイプでも実行）
     this.enforceParticleLimit();
   }
 


### PR DESCRIPTION
## 概要

IPNE の `effectManager.ts` の `addEffect`（12ケース・約310行の巨大switch）を、`EffectType → 純粋ファクトリー` の registry（新規 `effectFactories.ts`）へ分離する**振る舞い不変リファクタリング**です。IPNE 包括リファクタリング・ロードマップの **Phase C** にあたります。

- 設計: `docs/superpowers/specs/2026-06-15-ipne-effect-factories-design.md`
- 計画: `docs/superpowers/plans/2026-06-15-ipne-effect-factories.md`

## 変更内容

- **ファクトリー化**: 12種の EffectType を純粋ファクトリー関数（`this` 非依存）へ分離し、新規 `effectFactories.ts` の `EFFECT_FACTORIES` registry に集約（IPNE の `EnemyAiPolicyRegistry` と同型）
- **`addEffect` の縮小**: 約310行の switch → registry 引き＋push＋追従再帰の **16行**に縮小
- **合成の表現**: `ATTACK_HIT`→`SCREEN_SHAKE` の追従を `followUps` 記述子で表現（ファクトリーを純粋関数に保つ）
- **微妙な挙動の保存**: id 採番位置（未処理タイプでもカウンタ加算）、`enforceParticleLimit` の常時呼び出し、`ENEMY_DEATH(enemyType無)` の effect 非生成、`LOW_HP_WARNING` の未処理（registry 未登録）、追従の追加順序
- **スコープ厳守（YAGNI）**: `update`/`draw`/`getShakeOffset` の型分岐は据え置き
- **後方互換**: 公開 API（`EffectManager` のメソッド・`resetEffectIdCounter`・`effects/index.ts`）は不変
- **安全網**: 決定的フィールド検証（duration/ring/flash/shake・LOW_HP_WARNING/ENEMY_DEATH 非追加・追従）を `effectManager.test.ts` に補強（パーティクルは `Math.random` 依存で位置がスナップショット不可のため）

## テスト方法

- [x] `npx jest effectManager` — 41テスト全パス（既存＋補強した決定的フィールド検証）
- [x] `npx jest ipne` — 84スイート / 1324テスト全パス
- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint:ci` — 警告ゼロ（exit 0）
- [x] `addEffect` から switch が消えたことを確認
- [ ] E2E（`npm run test:e2e`）— ローカル実行不可のため CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
