### PR TITLE
refactor: IPNE UseGameRenderParams を RenderContext から型導出 (Phase D-2)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-ipne-render-params-derive.md
+++ b/docs/superpowers/plans/2026-06-16-ipne-render-params-derive.md
@@ -1,0 +1,180 @@
+# IPNE UseGameRenderParams 型導出 実装計画（Phase D-2）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `useGameRender.ts` の `UseGameRenderParams` を `RenderContext` から `Omit` 導出し、約27フィールドの手書き重複と未使用 import を解消する（振る舞い不変）。
+
+**Architecture:** `UseGameRenderParams = Omit<RenderContext, 'ctx' | 'canvas' | 'now'> & { canvasRef; renderTime }` に型導出。フック本体は `{ ...rest, ctx, canvas, now: renderTime }` で `RenderContext` を再構築。依存配列は元と完全に同一。`Game.test.tsx`（GameScreen を render）＋ typecheck が安全網。
+
+**Tech Stack:** React 19, TypeScript, Jest (SWC)。
+
+**設計の出典:** `docs/superpowers/specs/2026-06-16-ipne-render-params-derive-design.md`
+
+---
+
+## 対象ファイル
+
+| ファイル | 扱い |
+|---------|------|
+| `src/features/ipne/presentation/screens/useGameRender.ts`（135行） | **変更**（型導出＋フック本体＋import 整理。約35行へ） |
+| `render/renderContext.ts` / `render/*` / `Game.tsx` | **無変更**（RenderContext・各層・useGameRender 呼び出しは触らない） |
+
+### 不変条件（厳守）
+
+- `useGameRender` の useEffect 依存配列を1要素も変えない（再描画挙動不変）。
+- `renderGameFrame` に渡る `RenderContext` の中身が従来と同一であること。
+- `UseGameRenderParams` の公開名・公開フィールド（外部から見た型）が実質同一であること（Game.tsx の呼び出しが無修正で通る）。
+
+---
+
+## Task 0: ベースライン確認
+
+**Files:** なし
+
+- [ ] **Step 1: ブランチ確認**
+
+Run: `git branch --show-current`
+Expected: `refactor/ipne-render-params-derive`
+
+- [ ] **Step 2: Game テスト緑＋typecheck**
+
+Run: `npx jest Game.test 2>&1 | tail -6`（PASS）
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし）
+
+---
+
+## Task 1: `useGameRender.ts` を型導出に書き換え
+
+**Files:**
+- Modify: `src/features/ipne/presentation/screens/useGameRender.ts`
+
+- [ ] **Step 1: ファイル全体を以下に置換**
+
+`useGameRender.ts` の内容を**丸ごと**以下に置き換える（個別型 import の削除・型導出・フック本体のスプレッド化を一括で行う）:
+
+```typescript
+/**
+ * Canvas描画フック
+ *
+ * Game.tsx の Canvas描画 useEffect を移設したもの。
+ * canvas/ctx ガード後に renderGameFrame で1フレームを描画する。
+ * 依存配列・描画ロジックは元 effect と完全に同一。
+ */
+import React, { useEffect } from 'react';
+import { renderGameFrame } from './render/renderGameFrame';
+import type { RenderContext } from './render/renderContext';
+
+/**
+ * useGameRender に渡すパラメータ。
+ * RenderContext の生入力から導出する（ctx/canvas/now はフック内で canvasRef/renderTime から導出）。
+ */
+export type UseGameRenderParams = Omit<RenderContext, 'ctx' | 'canvas' | 'now'> & {
+  /** canvas 要素の ref（フック内で .current から canvas/ctx を導出） */
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  /** 描画タイムスタンプ（RenderContext.now の供給元） */
+  renderTime: number;
+};
+
+export function useGameRender(params: UseGameRenderParams): void {
+  const { canvasRef, renderTime, ...rest } = params;
+  // 依存配列用に reactive 値を明示分割代入（可読性のため）
+  const {
+    map, player, enemies, items, traps, walls, mapState, goalPos, debugState,
+    attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+    spriteRenderer, isDying,
+  } = params;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    renderGameFrame({ ...rest, ctx, canvas, now: renderTime });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    map, player, enemies, items, traps, walls, mapState, goalPos, debugState, renderTime,
+    attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+    spriteRenderer, isDying,
+  ]);
+}
+```
+
+注意:
+- `rest` は `Omit<RenderContext, 'ctx' | 'canvas' | 'now'>`（`canvasWrapperRef` を含む）。
+  `{ ...rest, ctx, canvas, now: renderTime }` で完全な `RenderContext` になる。
+- 依存配列は元（135行目）と**完全に同一**: `[map, player, enemies, items, traps, walls, mapState,
+  goalPos, debugState, renderTime, attackEffect, lastDamageAt, effectQueueRef,
+  floatingTextManagerRef, comboStateRef, spriteRenderer, isDying]`。
+- `UseGameRenderParams` を `interface` から `type`（交差型）に変更する点に注意（`export type`）。
+- 旧ファイルの個別型 import（GameMap/Player/Enemy/.../EffectEvent 等）は全て削除済みの状態にする
+  （上記が最終形）。`React`/`useEffect`/`renderGameFrame`/`RenderContext` のみ import。
+
+- [ ] **Step 2: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -5`
+Expected: エラーなし。特に:
+- `renderGameFrame({ ...rest, ctx, canvas, now: renderTime })` が `RenderContext` を満たす。
+- `Game.tsx` の `useGameRender({...})` 呼び出しが新 `UseGameRenderParams` を満たす（無修正で通る）。
+もし型エラーが出たら、`canvasWrapperRef` が RenderContext 側にあること（Omit 対象に含めない）を再確認する。
+
+- [ ] **Step 3: Game テスト（振る舞い不変の確認）**
+
+Run: `npx jest Game.test 2>&1 | tail -6`
+Expected: PASS（GameScreen が render され useGameRender が実行される）
+
+- [ ] **Step 4: lint**
+
+Run: `npx eslint src/features/ipne/presentation/screens/useGameRender.ts 2>&1 | tail -10`
+Expected: エラーなし（未使用 import が残っていないこと）
+
+- [ ] **Step 5: 行数が縮小したことを確認**
+
+Run: `wc -l src/features/ipne/presentation/screens/useGameRender.ts`
+Expected: 135行から大幅減（約35行）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/ipne/presentation/screens/useGameRender.ts
+git commit -m "refactor: IPNE UseGameRenderParams を RenderContext から型導出
+
+- 約27フィールドの手書き重複を Omit<RenderContext,'ctx'|'canvas'|'now'>＋{canvasRef,renderTime} で解消
+- フック本体は ...rest 再構築に簡潔化、未使用の個別型 import を削除（135→約35行）
+- 依存配列・公開 props は不変
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 最終検証
+
+**Files:** なし
+
+- [ ] **Step 1: IPNE 全テスト**
+
+Run: `npx jest ipne 2>&1 | tail -6`
+Expected: PASS（IPNE 全スイート green）
+
+- [ ] **Step 2: lint:ci（警告ゼロ強制）**
+
+Run: `npm run lint:ci 2>&1 | tail -8`
+Expected: エラー・警告なし（exit 0）
+
+- [ ] **Step 3: 依存配列が元と同一であることを目視確認**
+
+`git show HEAD:src/features/ipne/presentation/screens/useGameRender.ts` と旧版（`git show HEAD~1:...`）の
+依存配列を比較し、要素・順序が完全一致であることを確認。
+
+---
+
+## 完了の定義（Definition of Done）
+
+- [ ] `UseGameRenderParams` が `Omit<RenderContext, 'ctx'|'canvas'|'now'> & { canvasRef; renderTime }` に導出されている
+- [ ] フック本体が `{ ...rest, ctx, canvas, now: renderTime }` で再構築（フィールド手書き列挙が消滅）
+- [ ] 依存配列が元と完全に同一
+- [ ] 未使用の個別型 import が削除され useGameRender.ts が縮小（135→約35行）
+- [ ] `RenderContext`・`render/` 各層・`Game.tsx` の useGameRender 呼び出しは無変更
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス

--- a/docs/superpowers/specs/2026-06-16-ipne-render-params-derive-design.md
+++ b/docs/superpowers/specs/2026-06-16-ipne-render-params-derive-design.md
@@ -1,0 +1,140 @@
+# IPNE UseGameRenderParams の型導出 設計（Phase D-2）
+
+- 日付: 2026-06-16
+- 対象: `src/features/ipne/presentation/screens/useGameRender.ts`
+- 種別: リファクタリング（**振る舞い不変**・型重複の解消）
+- 位置づけ: IPNE 包括リファクタリング・ロードマップの **Phase D-2**（D-1 の後続）
+
+## 1. 背景と目的
+
+Phase D-1 で描画ロジックを `useGameRender` フック＋`render/` の5層へ抽出した。その過程で
+`useGameRender.ts` の `UseGameRenderParams` インターフェースが、`render/renderContext.ts` の
+`RenderContext` から `ctx`/`canvas`/`now` を除いた約27フィールドを**手書きで再列挙**している。
+
+`RenderContext`（正準）と `UseGameRenderParams`（ほぼ複製）の2つの型で同じフィールド群を
+重複定義しており、片方を変更するともう片方の更新漏れが起こる DRY 違反である。
+
+本作業の目的:
+
+1. `UseGameRenderParams` を `RenderContext` から **`Omit` で型導出**し、約27フィールドの
+   手書き重複を解消する。
+2. フックの `renderGameFrame` 再構築をスプレッドで簡潔にし、未使用になる import を削除する。
+3. **依存配列・描画の振る舞いを一切変えない**。
+
+### 非目標（YAGNI）
+
+- **refs のグルーピング**（`effectRefs`/`timingRefs` 等の入れ子化）はしない。5層全ての参照書き換えが
+  必要で高リスク・低価値（refs は綺麗にグループ化しづらい）。Phase D-2 のスコープ外。
+- `RenderContext` 型・`render/` の各層・`Game.tsx` の `useGameRender` 呼び出し（shorthand）は変更しない。
+- 依存配列の内容変更。
+
+## 2. 現状調査の要点
+
+- `useGameRender.ts`（135行）: `UseGameRenderParams` が `canvasRef`/`renderTime` ＋ RenderContext の
+  生入力相当（map/player/.../全 ref）を手書き列挙。型 import も個別に約12個（GameMap/Player/
+  EffectManager/DeathEffect/...）。
+- `RenderContext`（renderContext.ts）との対応:
+  `UseGameRenderParams` ≡ `Omit<RenderContext, 'ctx' | 'canvas' | 'now'>` ＋ `{ canvasRef; renderTime }`。
+  - `canvasWrapperRef` は両方にあり同型 → Omit 基底に残り継承される。
+  - `canvas`(HTMLCanvasElement)/`ctx`/`now` はフック内で `canvasRef.current` / `getContext` /
+    `renderTime` から導出されるため UseGameRenderParams には無い。
+- フック本体は現在、全 params を分割代入し `renderGameFrame({ ...全フィールド列挙... })` で再構築。
+- 依存配列（要維持・元と同一）:
+  `[map, player, enemies, items, traps, walls, mapState, goalPos, debugState, renderTime,
+  attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+  spriteRenderer, isDying]`。
+- 安全網: `Game.test.tsx`（GameScreen を render → `useGameRender` を実行）が存在。IPNE 1324テスト。
+
+## 3. 変更後の構造
+
+### `UseGameRenderParams` の型導出
+
+```typescript
+import type { RenderContext } from './render/renderContext';
+
+/** useGameRender に渡すパラメータ（RenderContext の生入力から導出） */
+export type UseGameRenderParams = Omit<RenderContext, 'ctx' | 'canvas' | 'now'> & {
+  /** canvas 要素の ref（フック内で .current から canvas/ctx を導出） */
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  /** 描画タイムスタンプ（RenderContext.now の供給元） */
+  renderTime: number;
+};
+```
+
+### フック本体（スプレッドで再構築）
+
+```typescript
+export function useGameRender(params: UseGameRenderParams): void {
+  const { canvasRef, renderTime, ...rest } = params;
+  // 依存配列用に reactive 値を明示分割代入（可読性のため）
+  const {
+    map, player, enemies, items, traps, walls, mapState, goalPos, debugState,
+    attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+    spriteRenderer, isDying,
+  } = params;
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    renderGameFrame({ ...rest, ctx, canvas, now: renderTime });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    map, player, enemies, items, traps, walls, mapState, goalPos, debugState, renderTime,
+    attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+    spriteRenderer, isDying,
+  ]);
+}
+```
+
+- `rest` ＝ `Omit<RenderContext, 'ctx' | 'canvas' | 'now'>`。`{ ...rest, ctx, canvas, now: renderTime }`
+  で完全な `RenderContext` になる（従来の再構築と同一内容）。
+- 依存配列は**元と完全に同一**（順序・要素とも）。
+
+### import の整理
+
+`UseGameRenderParams` が `RenderContext` 由来になるため、個別の型 import（`GameMap`/`Player`/
+`Enemy`/`Item`/`Trap`/`Wall`/`AutoMapState`/`Position`/`StageNumber`/`DebugState`/`MovementState`/
+`SpriteRenderer`/`EffectManager`/`DeathEffect`/`BossWarningState`/`AfterImageManager`/
+`RewardEffectFlags`/`FloatingTextManager`/`ComboState`/`EffectEvent` 等）が**未使用になり削除可能**。
+import は `RenderContext`（`./render/renderContext`）＋ `React`/`useEffect`/`renderGameFrame` に絞られ、
+ファイルが 135行 → 約35行に縮小する。typecheck/lint の未使用検出に従って正確に削除する。
+
+## 4. 安全網（振る舞い不変の証明）
+
+- **`npm run typecheck`**: 型導出（`Omit` ＋ 交差型）が `RenderContext` と整合し、フックの
+  `renderGameFrame({ ...rest, ctx, canvas, now })` が `RenderContext` を満たすことを保証。
+  Game.tsx の `useGameRender({...})` 呼び出しが新 `UseGameRenderParams` を満たすことも検証される。
+- **`Game.test.tsx`**: GameScreen を render し `useGameRender` を実行する統合テストが緑のまま。
+- 依存配列が元と同一であることを目視確認（再描画挙動の不変）。
+
+## 5. 検証手順（refactor-safely）
+
+1. `UseGameRenderParams` を `Omit` 導出に変更し、フック本体を `...rest` 再構築に書き換え、未使用 import を削除。
+2. 検証:
+
+```bash
+npm run typecheck
+npx jest Game.test
+npx eslint src/features/ipne/presentation/screens/useGameRender.ts
+```
+
+3. 最終確認: `npx jest ipne` / `npm run lint:ci` 全パス。
+
+### 完了の定義（Definition of Done）
+
+- [ ] `UseGameRenderParams` が `Omit<RenderContext, 'ctx'|'canvas'|'now'> & { canvasRef; renderTime }` に導出されている
+- [ ] フック本体が `{ ...rest, ctx, canvas, now: renderTime }` で再構築し、フィールド手書き列挙が消えている
+- [ ] 依存配列が元と完全に同一
+- [ ] 未使用になった個別型 import が削除され useGameRender.ts が縮小（135→約35行）
+- [ ] `RenderContext`・`render/` 各層・`Game.tsx` の useGameRender 呼び出しは無変更
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス
+
+## 6. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| `Omit`/交差型の導出が RenderContext とズレて型エラー | typecheck で検出。`canvasWrapperRef` が両型にある点に注意（Omit 基底に残す） |
+| `{ ...rest, ctx, canvas, now }` が RenderContext を満たさない（フィールド漏れ） | rest が Omit 基底＝必要十分。typecheck で渡り先 `renderGameFrame(rc: RenderContext)` が検証 |
+| 依存配列の取りこぼし | 元の依存配列をそのままコピー。目視確認＋ Game.test |
+| import 削除で必要な型まで消す | typecheck/lint の未使用検出に従い、消しすぎは型エラーで即検出 |

--- a/src/features/ipne/presentation/screens/useGameRender.ts
+++ b/src/features/ipne/presentation/screens/useGameRender.ts
@@ -1,118 +1,32 @@
 /**
- * ゲーム描画フック
+ * Canvas描画フック
  *
  * Game.tsx の Canvas描画 useEffect を移設したもの。
- * canvas へ renderGameFrame で1フレーム描画する。
+ * canvas/ctx ガード後に renderGameFrame で1フレームを描画する。
  * 依存配列・描画ロジックは元 effect と完全に同一。
  */
 import React, { useEffect } from 'react';
 import { renderGameFrame } from './render/renderGameFrame';
-import type {
-  GameMap,
-  Player,
-  Enemy,
-  Item,
-  Trap,
-  Wall,
-  AutoMapState,
-  Position,
-  StageNumber,
-  DebugState,
-  MovementState,
-} from '../../index';
-import type { SpriteRenderer } from '../sprites';
-import type { EffectManager } from '../effects/effectManager';
-import type { DeathEffect } from '../effects/deathEffect';
-import type { BossWarningState } from '../effects/bossEffects';
-import type { AfterImageManager, RewardEffectFlags } from '../effects/stageVisual';
-import type { FloatingTextManager } from '../effects/floatingText';
-import type { ComboState } from '../../domain/services/comboService';
-import type { EffectEvent } from './GameModals';
-
-/** useGameRender に渡すパラメータ（RenderContext の生入力相当） */
-export interface UseGameRenderParams {
-  /** canvas 要素の ref */
-  canvasRef: React.RefObject<HTMLCanvasElement | null>;
-  /** canvas を包む div の ref（サイズ取得用） */
-  canvasWrapperRef: React.RefObject<HTMLDivElement | null>;
-  /** 描画タイムスタンプ（renderTime state の値） */
-  renderTime: number;
-  /** ゲームマップ */
-  map: GameMap;
-  /** プレイヤー */
-  player: Player;
-  /** 敵一覧 */
-  enemies: Enemy[];
-  /** アイテム一覧 */
-  items: Item[];
-  /** 罠一覧 */
-  traps: Trap[];
-  /** 特殊壁一覧 */
-  walls: Wall[];
-  /** 自動マップ状態 */
-  mapState: AutoMapState;
-  /** ゴール座標 */
-  goalPos: { x: number; y: number };
-  /** デバッグ状態 */
-  debugState: DebugState;
-  /** 攻撃エフェクト（位置・有効期限） */
-  attackEffect?: { position: Position; until: number };
-  /** 最終ダメージ受付タイムスタンプ（props 値） */
-  lastDamageAt: number;
-  /** 死亡アニメーション中フラグ */
-  isDying: boolean;
-  /** 現在ステージ番号 */
-  currentStage?: StageNumber;
-  /** 最大レベル */
-  maxLevel: number;
-  /** ステージ報酬エフェクトフラグ */
-  rewardEffects: RewardEffectFlags;
-  /** スプライトレンダラー */
-  spriteRenderer: SpriteRenderer;
-  /** 移動状態 ref */
-  movementStateRef: React.MutableRefObject<MovementState>;
-  /** エフェクトマネージャー ref */
-  effectManagerRef: React.MutableRefObject<EffectManager>;
-  /** 死亡エフェクト ref */
-  deathEffectRef: React.MutableRefObject<DeathEffect>;
-  /** ボス WARNING 状態 ref */
-  bossWarningRef: React.MutableRefObject<BossWarningState>;
-  /** 残像マネージャー ref */
-  afterImageManagerRef: React.MutableRefObject<AfterImageManager>;
-  /** ステージ開始演出タイムスタンプ ref */
-  stageStartTimeRef: React.MutableRefObject<number>;
-  /** ゲームオーバー遷移タイムスタンプ ref */
-  dyingStartTimeRef: React.MutableRefObject<number>;
-  /** プレイヤー攻撃アニメーション終了時刻 ref */
-  playerAttackUntilRef: React.MutableRefObject<number>;
-  /** プレイヤー被弾フレーム終了時刻 ref */
-  playerDamageUntilRef: React.MutableRefObject<number>;
-  /** 最後に発火した攻撃エフェクトのキー ref */
-  lastAttackEffectKeyRef: React.MutableRefObject<string | null>;
-  /** 最終ダメージ受付タイムスタンプ ref（前回値との比較用） */
-  lastDamageAtRef: React.MutableRefObject<number>;
-  /** フローティングテキストマネージャー ref（省略可） */
-  floatingTextManagerRef?: React.MutableRefObject<FloatingTextManager>;
-  /** コンボ状態 ref（省略可） */
-  comboStateRef?: React.MutableRefObject<ComboState>;
-  /** 外部エフェクトキュー ref（省略可） */
-  effectQueueRef?: React.MutableRefObject<EffectEvent[]>;
-}
+import type { RenderContext } from './render/renderContext';
 
 /**
- * Canvas描画フック
- *
- * canvas/ctx ガード後に renderGameFrame を呼び出して1フレームを描画する。
- * 依存配列は Game.tsx の元 effect と完全に同一。
+ * useGameRender に渡すパラメータ。
+ * RenderContext の生入力から導出する（ctx/canvas/now はフック内で canvasRef/renderTime から導出）。
  */
+export type UseGameRenderParams = Omit<RenderContext, 'ctx' | 'canvas' | 'now'> & {
+  /** canvas 要素の ref（フック内で .current から canvas/ctx を導出） */
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  /** 描画タイムスタンプ（RenderContext.now の供給元） */
+  renderTime: number;
+};
+
 export function useGameRender(params: UseGameRenderParams): void {
+  const { canvasRef, renderTime, ...rest } = params;
+  // 依存配列用に reactive 値を明示分割代入（可読性のため）
   const {
-    canvasRef, canvasWrapperRef, renderTime, map, player, enemies, items, traps, walls,
-    mapState, goalPos, debugState, attackEffect, lastDamageAt, isDying, currentStage, maxLevel,
-    rewardEffects, spriteRenderer, movementStateRef, effectManagerRef, deathEffectRef,
-    bossWarningRef, afterImageManagerRef, stageStartTimeRef, dyingStartTimeRef,
-    playerAttackUntilRef, playerDamageUntilRef, lastAttackEffectKeyRef, lastDamageAtRef,
-    floatingTextManagerRef, comboStateRef, effectQueueRef,
+    map, player, enemies, items, traps, walls, mapState, goalPos, debugState,
+    attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+    spriteRenderer, isDying,
   } = params;
 
   useEffect(() => {
@@ -122,14 +36,11 @@ export function useGameRender(params: UseGameRenderParams): void {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    renderGameFrame({
-      ctx, canvas, canvasWrapperRef, now: renderTime, map, player, enemies, items, traps, walls,
-      mapState, goalPos, debugState, attackEffect, lastDamageAt, isDying, currentStage, maxLevel,
-      rewardEffects, spriteRenderer, movementStateRef, effectManagerRef, deathEffectRef,
-      bossWarningRef, afterImageManagerRef, stageStartTimeRef, dyingStartTimeRef,
-      playerAttackUntilRef, playerDamageUntilRef, lastAttackEffectKeyRef, lastDamageAtRef,
-      floatingTextManagerRef, comboStateRef, effectQueueRef,
-    });
+    renderGameFrame({ ...rest, ctx, canvas, now: renderTime });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, player, enemies, items, traps, walls, mapState, goalPos, debugState, renderTime, attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef, spriteRenderer, isDying]);
+  }, [
+    map, player, enemies, items, traps, walls, mapState, goalPos, debugState, renderTime,
+    attackEffect, lastDamageAt, effectQueueRef, floatingTextManagerRef, comboStateRef,
+    spriteRenderer, isDying,
+  ]);
 }


### PR DESCRIPTION
## 概要

Phase D-1 の描画抽出で生じた型の重複を解消する小さなリファクタリングです。`useGameRender.ts` の `UseGameRenderParams` が `RenderContext` から約27フィールドを手書きで再列挙していた DRY 違反を、型導出で解消します。IPNE 包括リファクタリング・ロードマップの **Phase D-2** にあたります。

- 設計: `docs/superpowers/specs/2026-06-16-ipne-render-params-derive-design.md`
- 計画: `docs/superpowers/plans/2026-06-16-ipne-render-params-derive.md`

## 変更内容（1ファイル: `useGameRender.ts`）

- **型導出**: `UseGameRenderParams` を `Omit<RenderContext, 'ctx' | 'canvas' | 'now'> & { canvasRef; renderTime }` に導出し、手書き27フィールド重複を解消
- **フック本体**: `renderGameFrame({ ...rest, ctx, canvas, now: renderTime })` でスプレッド再構築（フィールド手書き列挙を解消）
- **import 整理**: 不要になった個別型 import（GameMap/Player/EffectManager 等14種）を削除 → `RenderContext` ＋ React に集約
- **行数**: 135行 → 46行
- **スコープ厳守（YAGNI）**: refs のグルーピング（入れ子化）は高リスク・低価値のため非対象。`RenderContext`・`render/` 各層・`Game.tsx` の useGameRender 呼び出しは無変更

## テスト方法

- [x] 依存配列が元と**完全に同一**（再描画挙動不変）
- [x] `npx jest ipne` — 84スイート / 1324テスト全パス
- [x] `npm run typecheck` — エラーなし（`{ ...rest, ctx, canvas, now }` が RenderContext を満たすことを検証）
- [x] `npm run lint:ci` — 警告ゼロ（exit 0）
- [ ] E2E（`npm run test:e2e`）— ローカル実行不可のため CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
