### PR TITLE
refactor: IPNE マンハッタン距離計算を共通化 (Phase E)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-ipne-manhattan-distance-shared.md
+++ b/docs/superpowers/plans/2026-06-16-ipne-manhattan-distance-shared.md
@@ -1,0 +1,253 @@
+# IPNE マンハッタン距離計算の共通化 実装計画（Phase E）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** マンハッタン距離の5重複を `domain/services/geometryService.ts` の `manhattanDistance` へ集約する（振る舞い不変）。
+
+**Architecture:** `manhattanDistance(a: Position, b: Position): number` を新設し TDD でテスト。5箇所（item/aiGeometry/collisionService/scoring/bossEffects）をそこへ置換。`aiGeometry` は `getManhattanDistance` を re-export して4消費者を無修正に保つ。各箇所の既存テスト＋typecheck が安全網（同一公式＝振る舞い不変）。
+
+**Tech Stack:** TypeScript, Jest (SWC), Clean Architecture + DDD（domain 層）。
+
+**設計の出典:** `docs/superpowers/specs/2026-06-16-ipne-manhattan-distance-shared-design.md`
+
+---
+
+## 対象ファイル
+
+| ファイル | 扱い | geometryService への相対パス |
+|---------|------|------------------------------|
+| `domain/services/geometryService.ts` | **新規** | — |
+| `domain/services/geometryService.test.ts` | **新規** | — |
+| `domain/entities/item.ts` | **変更**（getDistance 削除→import） | `../services/geometryService` |
+| `domain/policies/enemyAi/aiGeometry.ts` | **変更**（定義削除→import as getManhattanDistance＋re-export） | `../../services/geometryService` |
+| `domain/services/collisionService.ts` | **変更**（インライン置換） | `./geometryService` |
+| `domain/services/gimmickPlacement/scoring.ts` | **変更**（インライン置換） | `../geometryService` |
+| `presentation/effects/bossEffects.ts` | **変更**（インライン置換） | `../../domain/services/geometryService` |
+
+### 不変条件（厳守）
+
+- マンハッタン距離の公式（`Math.abs(a.x-b.x) + Math.abs(a.y-b.y)`）を変えない。
+- `aiGeometry` が `getManhattanDistance` を export し続け、4消費者（attackState/enemyMovement/chargeBehavior/rangedBehavior）が無修正で動く。
+- `tickGameState`・`combatEffects` は無変更。
+
+---
+
+## Task 0: ベースライン確認
+
+**Files:** なし
+
+- [ ] **Step 1: ブランチ確認**
+
+Run: `git branch --show-current`
+Expected: `refactor/ipne-manhattan-distance-shared`
+
+- [ ] **Step 2: 関連テスト緑＋typecheck**
+
+Run: `npx jest collision item scoring enemyAI bossEffects aiGeometry 2>&1 | tail -8`（PASS）
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし）
+
+---
+
+## Task 1: `geometryService.ts` を新設（TDD）
+
+**Files:**
+- Create: `src/features/ipne/domain/services/geometryService.ts`
+- Create: `src/features/ipne/domain/services/geometryService.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+Create `geometryService.test.ts`:
+
+```typescript
+import { manhattanDistance } from './geometryService';
+
+describe('manhattanDistance', () => {
+  it('同一座標は 0 を返す', () => {
+    expect(manhattanDistance({ x: 3, y: 5 }, { x: 3, y: 5 })).toBe(0);
+  });
+
+  it('各軸の差の絶対値の和を返す', () => {
+    expect(manhattanDistance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(7);
+  });
+
+  it('負方向（引数の順序）でも同じ値を返す（対称性）', () => {
+    const a = { x: 1, y: 2 };
+    const b = { x: 5, y: 9 };
+    expect(manhattanDistance(a, b)).toBe(manhattanDistance(b, a));
+    expect(manhattanDistance(a, b)).toBe(4 + 7);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `npx jest geometryService 2>&1 | tail -10`
+Expected: FAIL（`Cannot find module './geometryService'`）
+
+- [ ] **Step 3: `geometryService.ts` を実装**
+
+Create `geometryService.ts`:
+
+```typescript
+/**
+ * 幾何ユーティリティ（純粋関数）
+ */
+import { Position } from '../types';
+
+/** 2点間のマンハッタン距離（各軸の差の絶対値の和） */
+export const manhattanDistance = (a: Position, b: Position): number =>
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `npx jest geometryService 2>&1 | tail -8`
+Expected: PASS（3件）
+
+- [ ] **Step 5: 型チェック＆コミット**
+
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし）
+
+```bash
+git add src/features/ipne/domain/services/geometryService.ts \
+        src/features/ipne/domain/services/geometryService.test.ts
+git commit -m "feat: IPNE 幾何ユーティリティ geometryService.manhattanDistance を新設
+
+- マンハッタン距離の単一定義。後続タスクで5重複箇所を集約する
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 5箇所を `manhattanDistance` 利用へ置換
+
+**Files:**
+- Modify: `domain/entities/item.ts`, `domain/policies/enemyAi/aiGeometry.ts`,
+  `domain/services/collisionService.ts`, `domain/services/gimmickPlacement/scoring.ts`,
+  `presentation/effects/bossEffects.ts`
+
+- [ ] **Step 1: `item.ts` を変更**
+
+ローカル `getDistance`（92-94行）を削除し、import を追加、呼び出し（121行 `getDistance(tile, goalPos)`）を `manhattanDistance(tile, goalPos)` に置換。
+
+1. import 追加（既存 import 群の近く）:
+```typescript
+import { manhattanDistance } from '../services/geometryService';
+```
+2. `const getDistance = (a: Position, b: Position): number => { return Math.abs(...); };` を削除。
+3. `getDistance(tile, goalPos)` → `manhattanDistance(tile, goalPos)`。
+4. `Position` が他で使われていなければ未使用 import になるので lint で確認（getDistance 削除で Position の利用が減る可能性。typecheck/lint に従う）。
+
+- [ ] **Step 2: `aiGeometry.ts` を変更**
+
+ローカル定義（18-19行 `export const getManhattanDistance = (a, b) => Math.abs(...)`）を削除し、
+新 util を `getManhattanDistance` という名前で import＋re-export する（内部利用 35/41/46 行等は無修正で動く）。
+
+1. ファイル冒頭の import 群に追加:
+```typescript
+import { manhattanDistance as getManhattanDistance } from '../../services/geometryService';
+```
+2. `export const getManhattanDistance = (a: Position, b: Position): number => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);` の定義（18-19行）を削除。
+3. 消費者（attackState/enemyMovement/chargeBehavior/rangedBehavior）のために再公開:
+```typescript
+export { getManhattanDistance };
+```
+（import した `getManhattanDistance` を再 export。aiGeometry 内部の `getManhattanDistance(...)` 呼び出しは
+import 名と一致するため無修正で動く。）
+4. `Position` の import が `getManhattanDistance` 定義削除で未使用になるか確認。他の関数（detectPlayer 等は
+Position を引数に取る）で使われているので残るはず。lint に従う。
+
+- [ ] **Step 3: `collisionService.ts` を変更**
+
+`Position` は既に import 済み。`manhattanDistance` を import し、67行のインラインを置換。
+1. import 追加:
+```typescript
+import { manhattanDistance } from './geometryService';
+```
+2. `enemy => Math.abs(enemy.x - position.x) + Math.abs(enemy.y - position.y) <= range` を
+`enemy => manhattanDistance(enemy, position) <= range` に置換（`Enemy` は x/y を持ち `Position` 互換）。
+
+- [ ] **Step 4: `scoring.ts` を変更**
+
+ループ内インライン（10行）を置換。
+1. import 追加:
+```typescript
+import { manhattanDistance } from '../geometryService';
+```
+2. `const dist = Math.abs(p.x - pos.x) + Math.abs(p.y - pos.y);` を
+`const dist = manhattanDistance(p, pos);` に置換。
+
+- [ ] **Step 5: `bossEffects.ts` を変更**
+
+インライン（58行）を置換（presentation→domain の import）。
+1. import 追加:
+```typescript
+import { manhattanDistance } from '../../domain/services/geometryService';
+```
+2. `const distance = Math.abs(enemy.x - playerX) + Math.abs(enemy.y - playerY);` を
+`const distance = manhattanDistance(enemy, { x: playerX, y: playerY });` に置換
+（`enemy` は x/y を持ち `Position` 互換）。
+
+- [ ] **Step 6: 関連テスト＋型/lint を確認**
+
+Run: `npx jest collision item scoring enemyAI enemyAttackAnim bossEffects aiGeometry gimmickPlacement 2>&1 | tail -10`
+Expected: PASS（特に enemyAI/enemyAttackAnim は aiGeometry の re-export 経由で getManhattanDistance を使う）
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし）
+Run: `npx eslint src/features/ipne/ 2>&1 | tail -15`（エラーなし、未使用 import 削除）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/features/ipne/domain/entities/item.ts \
+        src/features/ipne/domain/policies/enemyAi/aiGeometry.ts \
+        src/features/ipne/domain/services/collisionService.ts \
+        src/features/ipne/domain/services/gimmickPlacement/scoring.ts \
+        src/features/ipne/presentation/effects/bossEffects.ts
+git commit -m "refactor: IPNE マンハッタン距離の5重複を geometryService へ集約
+
+- item/collisionService/scoring/bossEffects のインライン・ローカル定義を manhattanDistance に置換
+- aiGeometry は getManhattanDistance を re-export し4消費者を無修正維持
+- 公式不変につき各箇所の既存テストで振る舞い不変を確認
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 最終検証
+
+**Files:** なし
+
+- [ ] **Step 1: マンハッタン計算の重複が解消されたことを確認**
+
+Run: `grep -rn "Math.abs" src/features/ipne --include=*.ts 2>/dev/null | grep -v test | grep -E "Math\.abs.*\+.*Math\.abs"`
+Expected: `geometryService.ts` の1件のみ（他の4インライン＋2ローカル定義が消えている）。
+※ 方向計算（aiGeometry の calculateStep 等で `Math.abs(dx) >= Math.abs(dy)` のような**距離でない** abs 比較）が
+残るのは正常。マンハッタン距離（`abs + abs` の和）が geometryService 以外に残っていないことを確認する。
+
+- [ ] **Step 2: IPNE 全テスト**
+
+Run: `npx jest ipne 2>&1 | tail -6`
+Expected: PASS（IPNE 全スイート green）
+
+- [ ] **Step 3: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -3`
+Expected: エラーなし
+
+- [ ] **Step 4: lint:ci（警告ゼロ強制）**
+
+Run: `npm run lint:ci 2>&1 | tail -8`
+Expected: エラー・警告なし（exit 0）
+
+---
+
+## 完了の定義（Definition of Done）
+
+- [ ] `geometryService.ts` に `manhattanDistance` があり専用テストがある
+- [ ] 5箇所が `manhattanDistance` を利用、インライン・重複ローカル定義が解消
+- [ ] `aiGeometry` が `getManhattanDistance` を re-export し、4消費者が無修正
+- [ ] マンハッタン距離（`abs + abs`）の計算が geometryService 以外に残っていない
+- [ ] `tickGameState`・`combatEffects` は無変更
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス

--- a/docs/superpowers/specs/2026-06-16-ipne-manhattan-distance-shared-design.md
+++ b/docs/superpowers/specs/2026-06-16-ipne-manhattan-distance-shared-design.md
@@ -1,0 +1,125 @@
+# IPNE マンハッタン距離計算の共通化 設計（Phase E）
+
+- 日付: 2026-06-16
+- 対象: `src/features/ipne/`（domain/services・domain/entities・domain/policies・presentation/effects）
+- 種別: リファクタリング（**振る舞い不変**・DRY 解消）
+- 位置づけ: IPNE 包括リファクタリング・ロードマップの **Phase E**（仕上げ）
+
+## 1. 背景と目的
+
+マンハッタン距離 `Math.abs(a.x - b.x) + Math.abs(a.y - b.y)` の計算が、IPNE 内の **5箇所**に
+重複している（ローカル関数2つ＋インライン3つ）。
+
+| # | 箇所 | 形 |
+|---|------|----|
+| 1 | `domain/entities/item.ts:92` | ローカル `getDistance(a, b)` |
+| 2 | `domain/policies/enemyAi/aiGeometry.ts:18` | `getManhattanDistance(a, b)`（export、4ファイルが使用） |
+| 3 | `domain/services/collisionService.ts:67` | インライン（`enemy`/`position`） |
+| 4 | `domain/services/gimmickPlacement/scoring.ts:10` | インライン（`p`/`pos`、ループ内） |
+| 5 | `presentation/effects/bossEffects.ts:58` | インライン（`enemy`/`playerX`/`playerY`） |
+
+Phase A の spec §6 でも「`getManhattanDistance` の重複（`gimmickPlacement/scoring.ts` 等）」を
+Phase E の共通化候補として記録済み。
+
+本作業の目的:
+
+1. 単一の `manhattanDistance(a: Position, b: Position): number` を **`domain/services/geometryService.ts`**
+   に新設し、5箇所をそこへ集約する。
+2. 公式・振る舞いを一切変えない（同一の `Math.abs` 計算）。
+
+### 非目標（YAGNI）
+
+- **`tickGameState` の整理はしない。** 217行の10ステップは `resolveXxx` ユースケースを順に呼ぶ
+  綺麗な Facade で、オーケストレーション自体が責務。分割の価値が薄い。
+- **`combatEffects.ts` のインライン型 import 整理はしない**（些末・スコープ外）。
+- 距離計算の公式変更・最適化。
+
+## 2. 現状調査の要点
+
+- 5箇所すべて `{ x, y }` 対で計算。`bossEffects.ts` のみスカラー（`playerX`/`playerY`）だが
+  `{ x: playerX, y: playerY }` で包めば同一シグネチャで扱える。
+- `Position` 型は `domain/types/world.ts` 定義（`{ x: number; y: number }`）。`Enemy` は x/y を持つため
+  構造的に `Position` 互換（`manhattanDistance(enemy, ...)` がそのまま通る）。
+- 配置先の依存規則: 消費側は domain 4ファイル＋presentation 1ファイル。**domain → 外部依存なし /
+  presentation → domain は参照可** のため、共有 util は **domain 内**（`domain/services/`）に置く。
+  presentation/bossEffects から `domain/services/geometryService` を import するのは presentation→domain で合法。
+- `aiGeometry.getManhattanDistance` は **4ファイルが import**（`attackState.ts`/`enemyMovement.ts`/
+  `behaviors/chargeBehavior.ts`/`behaviors/rangedBehavior.ts`）。これらを無修正に保つため
+  aiGeometry は新 util を **re-export** する。
+- 既存テスト: collision/item/scoring/enemyAI/boss 系が各箇所をカバー。
+
+## 3. 変更後の構造
+
+### 新モジュール `domain/services/geometryService.ts`
+
+```typescript
+/**
+ * 幾何ユーティリティ（純粋関数）
+ */
+import { Position } from '../types';
+
+/** 2点間のマンハッタン距離 */
+export const manhattanDistance = (a: Position, b: Position): number =>
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+```
+
+### 5箇所の集約
+
+| 箇所 | 変更 |
+|------|------|
+| `item.ts` | ローカル `getDistance` を削除し、`manhattanDistance` を import。呼び出しを `manhattanDistance(...)` に置換 |
+| `collisionService.ts` | インラインを `manhattanDistance(enemy, position) <= range` に置換、import 追加 |
+| `scoring.ts` | ループ内インラインを `manhattanDistance(p, pos)` に置換、import 追加 |
+| `bossEffects.ts` | インラインを `manhattanDistance(enemy, { x: playerX, y: playerY })` に置換、import 追加（presentation→domain） |
+| `aiGeometry.ts` | ローカル `getManhattanDistance` 定義を削除し、`import { manhattanDistance } from '../../services/geometryService'`。内部利用は `manhattanDistance` に置換。**消費者保持のため `export { manhattanDistance as getManhattanDistance };` で再公開** |
+
+> `aiGeometry` の `getManhattanDistance` re-export により、4つの消費者（attackState/enemyMovement/
+> chargeBehavior/rangedBehavior）は**無修正**で動く。
+
+### 依存方向（循環なし）
+
+```
+geometryService.ts → domain/types（Position 型のみ）
+item / collisionService / scoring / aiGeometry → geometryService（domain 内）
+bossEffects（presentation）→ geometryService（domain）  ※ presentation→domain は合法
+```
+
+## 4. 安全網（振る舞い不変の証明）
+
+公式は同一（`Math.abs(a.x-b.x) + Math.abs(a.y-b.y)`）なので、各箇所の既存テストが緑のままであることが
+振る舞い不変の証明になる。
+
+- **新規 `geometryService.test.ts`**: `manhattanDistance` の振る舞い（0距離・正/負方向・対称性）を検証。
+- 既存テストを全工程で緑に保つ: `collision.test`/`item.test`/`scoring`（gimmickPlacement）/`enemyAI.test`/
+  `enemyAttackAnim.test`/`aiGeometry.test`/`bossEffects.test`。
+- `npm run typecheck`（型整合、特に `Enemy` を `Position` として渡せること、re-export の解決）。
+
+## 5. 検証手順（refactor-safely）
+
+1. `geometryService.ts` を新設し、`geometryService.test.ts` を TDD で追加。
+2. 5箇所を1つずつ `manhattanDistance` 利用へ置換（1コミット=1〜複数箇所）。各置換後に該当テスト＋typecheck。
+3. 最終確認:
+
+```bash
+npx jest ipne
+npm run typecheck
+npm run lint:ci
+```
+
+### 完了の定義（Definition of Done）
+
+- [ ] `domain/services/geometryService.ts` に `manhattanDistance` があり、専用テストがある
+- [ ] 5箇所（item/collisionService/scoring/bossEffects/aiGeometry）が `manhattanDistance` を利用
+- [ ] `aiGeometry` が `getManhattanDistance` を re-export し、4消費者が無修正で動く
+- [ ] マンハッタン距離のインライン計算・重複ローカル定義が解消（geometryService 以外に残らない）
+- [ ] `tickGameState`・`combatEffects` は無変更（YAGNI）
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス
+
+## 6. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| 置換時に引数の向き・スカラー包みを誤る | 公式は対称（`abs`）なので向きは無関係。bossEffects のスカラー包み `{x:playerX,y:playerY}` をテストで担保 |
+| aiGeometry の re-export 漏れで4消費者が壊れる | typecheck と enemyAI/enemyAttackAnim テストで検出。re-export の名前一致を確認 |
+| presentation→domain 参照が層規則違反では | 規則上 presentation→domain は合法（domain が外側を参照しないことが規則。逆は可） |
+| 距離の意味取り違え（マンハッタンと別物） | 5箇所すべて `abs+abs`＝マンハッタンであることを移植前に確認。別公式（ユークリッド等）は対象外 |

--- a/src/features/ipne/domain/entities/item.ts
+++ b/src/features/ipne/domain/entities/item.ts
@@ -1,7 +1,7 @@
 /**
  * アイテム管理モジュール
  */
-import { Enemy, Item, ItemType, ItemTypeValue, Player, Room } from '../types';
+import { Enemy, Item, ItemType, ItemTypeValue, Player, Position, Room } from '../types';
 import { healPlayer, getEffectiveHeal } from './player';
 import { IdGenerator, RandomProvider } from '../ports';
 import { manhattanDistance } from '../services/geometryService';

--- a/src/features/ipne/domain/entities/item.ts
+++ b/src/features/ipne/domain/entities/item.ts
@@ -1,9 +1,10 @@
 /**
  * アイテム管理モジュール
  */
-import { Enemy, Item, ItemType, ItemTypeValue, Player, Position, Room } from '../types';
+import { Enemy, Item, ItemType, ItemTypeValue, Player, Room } from '../types';
 import { healPlayer, getEffectiveHeal } from './player';
 import { IdGenerator, RandomProvider } from '../ports';
+import { manhattanDistance } from '../services/geometryService';
 
 const ITEM_CONFIGS = {
   [ItemType.HEALTH_SMALL]: { healAmount: 3 },
@@ -88,10 +89,6 @@ const getTotalMaxItems = (): number => {
   );
 };
 
-/** 2点間のマンハッタン距離を計算 */
-const getDistance = (a: Position, b: Position): number => {
-  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
-};
 
 export const spawnItems = (
   rooms: Room[],
@@ -118,7 +115,7 @@ export const spawnItems = (
 
       // 鍵アイテムはゴールから一定距離離れた場所にのみ配置
       if (minDistanceFromGoal && goalPos) {
-        const distance = getDistance(tile, goalPos);
+        const distance = manhattanDistance(tile, goalPos);
         if (distance < minDistanceFromGoal) continue;
       }
 

--- a/src/features/ipne/domain/entities/item.ts
+++ b/src/features/ipne/domain/entities/item.ts
@@ -89,7 +89,6 @@ const getTotalMaxItems = (): number => {
   );
 };
 
-
 export const spawnItems = (
   rooms: Room[],
   enemies: Enemy[],

--- a/src/features/ipne/domain/policies/enemyAi/aiGeometry.ts
+++ b/src/features/ipne/domain/policies/enemyAi/aiGeometry.ts
@@ -6,6 +6,7 @@
  */
 import { Enemy, Position } from '../../types';
 import { GAME_BALANCE } from '../../config/gameBalance';
+import { manhattanDistance as getManhattanDistance } from '../../services/geometryService';
 
 /** AI の検知・追跡・攻撃に関する時間定数 */
 export const AI_CONFIG = {
@@ -14,9 +15,8 @@ export const AI_CONFIG = {
   attackCooldown: GAME_BALANCE.enemyAi.attackCooldownMs,
 } as const;
 
-/** マンハッタン距離（barrel では非公開。モジュール間共有用） */
-export const getManhattanDistance = (a: Position, b: Position): number =>
-  Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+// 4消費者（attackState/enemyMovement/chargeBehavior/rangedBehavior）が依存するため再公開
+export { getManhattanDistance };
 
 /**
  * 2点間の各軸の単位ステップ（-1 / 0 / +1）を返す。

--- a/src/features/ipne/domain/services/collisionService.ts
+++ b/src/features/ipne/domain/services/collisionService.ts
@@ -3,6 +3,7 @@
  */
 
 import { Enemy, GameMap, Position, TileType, Wall, WallState, WallType } from '../types';
+import { manhattanDistance } from './geometryService';
 
 /**
  * 指定位置が壁かどうかを判定
@@ -64,6 +65,6 @@ export const getEnemiesInRange = (
   range: number
 ): Enemy[] => {
   return enemies.filter(
-    enemy => Math.abs(enemy.x - position.x) + Math.abs(enemy.y - position.y) <= range
+    enemy => manhattanDistance(enemy, position) <= range
   );
 };

--- a/src/features/ipne/domain/services/geometryService.test.ts
+++ b/src/features/ipne/domain/services/geometryService.test.ts
@@ -1,0 +1,18 @@
+import { manhattanDistance } from './geometryService';
+
+describe('manhattanDistance', () => {
+  it('同一座標は 0 を返す', () => {
+    expect(manhattanDistance({ x: 3, y: 5 }, { x: 3, y: 5 })).toBe(0);
+  });
+
+  it('各軸の差の絶対値の和を返す', () => {
+    expect(manhattanDistance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(7);
+  });
+
+  it('負方向（引数の順序）でも同じ値を返す（対称性）', () => {
+    const a = { x: 1, y: 2 };
+    const b = { x: 5, y: 9 };
+    expect(manhattanDistance(a, b)).toBe(manhattanDistance(b, a));
+    expect(manhattanDistance(a, b)).toBe(4 + 7);
+  });
+});

--- a/src/features/ipne/domain/services/geometryService.ts
+++ b/src/features/ipne/domain/services/geometryService.ts
@@ -1,0 +1,8 @@
+/**
+ * 幾何ユーティリティ（純粋関数）
+ */
+import { Position } from '../types';
+
+/** 2点間のマンハッタン距離（各軸の差の絶対値の和） */
+export const manhattanDistance = (a: Position, b: Position): number =>
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y);

--- a/src/features/ipne/domain/services/gimmickPlacement/scoring.ts
+++ b/src/features/ipne/domain/services/gimmickPlacement/scoring.ts
@@ -1,5 +1,6 @@
 import { calculateDistances, findPath, isConnected } from '../pathfinderService';
 import { GameMap, Position, TileType } from '../../types';
+import { manhattanDistance } from '../geometryService';
 import { findPenetrationShortcuts } from './candidateDetection';
 import { MultiWallCandidate, ScoredWallCandidate } from './types';
 
@@ -7,7 +8,7 @@ export const getDistanceFromPath = (path: Position[], pos: Position): number => 
   if (path.length === 0) return Infinity;
   let minDist = Infinity;
   for (const p of path) {
-    const dist = Math.abs(p.x - pos.x) + Math.abs(p.y - pos.y);
+    const dist = manhattanDistance(p, pos);
     if (dist < minDist) minDist = dist;
   }
   return minDist;

--- a/src/features/ipne/presentation/effects/bossEffects.ts
+++ b/src/features/ipne/presentation/effects/bossEffects.ts
@@ -5,6 +5,7 @@
  */
 
 import { Enemy, EnemyType, EnemyTypeValue } from '../../types';
+import { manhattanDistance } from '../../domain/services/geometryService';
 
 // ===== WARNING 演出 =====
 
@@ -55,7 +56,7 @@ export function shouldTriggerWarning(
   if (state.triggeredBossIds.includes(enemy.id)) return false;
 
   // マンハッタン距離でチェック
-  const distance = Math.abs(enemy.x - playerX) + Math.abs(enemy.y - playerY);
+  const distance = manhattanDistance(enemy, { x: playerX, y: playerY });
   return distance <= BOSS_DETECTION_RANGE;
 }
 


### PR DESCRIPTION
## 概要

IPNE 内に5箇所重複していたマンハッタン距離計算を、単一の `manhattanDistance` へ集約する**振る舞い不変リファクタリング**です。IPNE 包括リファクタリング・ロードマップの**最終フェーズ Phase E（仕上げ）**にあたります。

- 設計: `docs/superpowers/specs/2026-06-16-ipne-manhattan-distance-shared-design.md`
- 計画: `docs/superpowers/plans/2026-06-16-ipne-manhattan-distance-shared.md`

## 変更内容

- **共通化**: `domain/services/geometryService.ts` に `manhattanDistance(a: Position, b: Position)` を新設（TDD・専用テスト3件）
- **5重複を集約**:
  - `item.ts`（ローカル `getDistance` 削除）/ `collisionService.ts` / `gimmickPlacement/scoring.ts` / `bossEffects.ts`（インライン削除）→ `manhattanDistance` 利用
  - `aiGeometry.ts`: ローカル定義を削除し `import { manhattanDistance as getManhattanDistance }` ＋ `export { getManhattanDistance }` で **re-export** → 内部利用と4消費者（attackState/enemyMovement/chargeBehavior/rangedBehavior）を**無修正維持**
- **層規則準拠**: `bossEffects`(presentation)→`geometryService`(domain) は合法、`geometryService` は `domain/types` のみ依存（外部依存ゼロ）
- **スコープ厳守（YAGNI）**: `tickGameState`（綺麗な Facade）・`combatEffects` のインライン型 import は非対象

## テスト方法

- [x] マンハッタン距離（`abs+abs`）の計算が `geometryService.ts` の1件のみに集約（grep 確認）
- [x] `npx jest ipne` — 85スイート / 1327テスト全パス
- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint:ci` — 警告ゼロ（exit 0）
- [x] 公式不変につき各箇所の既存テスト（collision/item/scoring/enemyAI/boss）で振る舞い不変を確認
- [ ] E2E（`npm run test:e2e`）— ローカル実行不可のため CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
