### PR TITLE
refactor: IPNE aiRandom の可変モジュール状態を除去

### DIFF
--- a/docs/superpowers/plans/2026-06-16-ipne-airandom-immutable.md
+++ b/docs/superpowers/plans/2026-06-16-ipne-airandom-immutable.md
@@ -1,0 +1,187 @@
+# IPNE aiRandom 可変モジュール状態の除去 実装計画（フォローアップ）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `aiRandom.ts` の可変モジュール状態（`let _random` ＋ 未使用 setter）を削除し、`defaultRandom`（const）の直接利用へ置き換える（振る舞い不変）。
+
+**Architecture:** 未使用の `setRandomProvider`/`resetRandomProvider`/`getRandom`/`let _random` を削除し `defaultRandom` のみ残す。`enemyMovement.ts` の `getRandom()` 4箇所を `defaultRandom` に置換。`enemyAiFunctions.ts` の死んだ barrel 再公開を削除。`getRandom()` は常に `defaultRandom` を返していたため挙動は完全同一。既存テスト＋typecheck が安全網。
+
+**Tech Stack:** TypeScript, Jest (SWC), Clean Architecture + DDD（domain 層）。
+
+**設計の出典:** `docs/superpowers/specs/2026-06-16-ipne-airandom-immutable-design.md`
+
+---
+
+## 対象ファイル（3ファイル）
+
+| ファイル | 扱い |
+|---------|------|
+| `domain/policies/enemyAi/aiRandom.ts` | **変更**（可変機構削除、defaultRandom のみ残す） |
+| `domain/policies/enemyAi/enemyMovement.ts` | **変更**（getRandom→defaultRandom、4箇所） |
+| `domain/policies/enemyAi/enemyAiFunctions.ts` | **変更**（barrel 再公開1行削除） |
+
+### 不変条件（厳守）
+
+- `defaultRandom` の実装（random/randomInt/pick/shuffle）を逐語維持。
+- 敵AIの乱数挙動を変えない（getRandom() は常に defaultRandom を返していた）。
+- `index.ts` の公開 API は無変更（setter/getRandom は元々 export していない）。
+- フル DI（random 引数注入）はしない。
+
+---
+
+## Task 0: ベースライン確認
+
+**Files:** なし
+
+- [ ] **Step 1: ブランチ確認**
+
+Run: `git branch --show-current`
+Expected: `refactor/ipne-airandom-immutable`
+
+- [ ] **Step 2: 関連テスト緑＋typecheck**
+
+Run: `npx jest enemyAI enemyAiFunctions enemyAttackAnim 2>&1 | tail -6`（PASS）
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし）
+
+---
+
+## Task 1: 可変機構の削除と defaultRandom 直接利用
+
+**Files:**
+- Modify: `domain/policies/enemyAi/aiRandom.ts`
+- Modify: `domain/policies/enemyAi/enemyMovement.ts`
+- Modify: `domain/policies/enemyAi/enemyAiFunctions.ts`
+
+- [ ] **Step 1: `aiRandom.ts` を defaultRandom のみに**
+
+`src/features/ipne/domain/policies/enemyAi/aiRandom.ts` の内容を**丸ごと**以下に置換（`defaultRandom` の実装は現行と逐語同一、`let _random`/`getRandom`/`setRandomProvider`/`resetRandomProvider` を削除）:
+
+```typescript
+/**
+ * 敵AIの乱数プロバイダ
+ *
+ * Math.random ベースの不変プロバイダを提供する。
+ */
+import { RandomProvider } from '../../ports';
+
+/** デフォルトの乱数プロバイダー（Math.random ベース） */
+export const defaultRandom: RandomProvider = {
+  random: () => Math.random(),
+  randomInt: (min, max) => min + Math.floor(Math.random() * (max - min)),
+  pick: (array) => array[Math.floor(Math.random() * array.length)],
+  shuffle: (array) => {
+    const result = [...array];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  },
+};
+```
+
+- [ ] **Step 2: `enemyMovement.ts` を defaultRandom 直接利用へ**
+
+`src/features/ipne/domain/policies/enemyAi/enemyMovement.ts`:
+1. import を変更: `import { getRandom } from './aiRandom';` → `import { defaultRandom } from './aiRandom';`
+2. 4箇所の `getRandom()` を `defaultRandom` に置換:
+   - `attemptLunge`（63行付近）: `if (getRandom().random() > chance) return null;` → `if (defaultRandom.random() > chance) return null;`
+   - `stepRandom`（90行付近）: `const shuffled = getRandom().shuffle(directions);` → `const shuffled = defaultRandom.shuffle(directions);`
+   - `generatePatrolPath`（114行付近）: `const length = getRandom().randomInt(4, 9); // 4-8` → `const length = defaultRandom.randomInt(4, 9); // 4-8`
+   - `generatePatrolPath`（115行付近）: `const horizontal = getRandom().random() > 0.5;` → `const horizontal = defaultRandom.random() > 0.5;`
+
+> 注: `getRandom()` の出現は上記4箇所のみ（事前 grep で確認済み）。`grep -n "getRandom" enemyMovement.ts` で残存ゼロを確認すること。
+
+- [ ] **Step 3: `enemyAiFunctions.ts` の死んだ barrel 再公開を削除**
+
+`src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts` の9行目を削除:
+```typescript
+export { setRandomProvider, resetRandomProvider } from './aiRandom';
+```
+（消費者ゼロ・index.ts にも無いため安全。削除後、enemyAiFunctions の他の export は無変更。）
+
+- [ ] **Step 4: 削除した識別子の参照が残っていないことを確認**
+
+Run: `grep -rn "getRandom\|setRandomProvider\|resetRandomProvider\|_random" src/features/ipne 2>/dev/null | grep -v test | grep -v "getRandomPassableTile\|getRandomRoom\|README"`
+Expected: 出力なし（`getRandomPassableTile`/`getRandomRoom` は別関数なので除外。`_random` も消滅）。
+
+- [ ] **Step 5: 関連テスト＋型/lint**
+
+Run: `npx jest enemyAI enemyAiFunctions enemyAttackAnim 2>&1 | tail -8`
+Expected: PASS（enemyMovement の attemptLunge/stepRandom/generatePatrolPath を間接的にカバー。挙動は defaultRandom で従来同一）
+Run: `npm run typecheck 2>&1 | tail -3`（エラーなし＝削除した getRandom/setter の未定義参照が無い）
+Run: `npx eslint src/features/ipne/domain/policies/enemyAi/ 2>&1 | tail -10`（エラーなし、未使用 import なし）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/ipne/domain/policies/enemyAi/aiRandom.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyMovement.ts \
+        src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+git commit -m "refactor: IPNE aiRandom の可変モジュール状態を除去
+
+- 未使用の setRandomProvider/resetRandomProvider/let _random/getRandom を削除し defaultRandom(const) のみに
+- enemyMovement は defaultRandom を直接利用（getRandom は常に defaultRandom を返していたため挙動同一）
+- 死んだ barrel 再公開を削除。Phase A spec §6 の可変モジュール状態の負債を解消
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: README 更新（任意・軽微）
+
+**Files:**
+- Modify: `src/features/ipne/README.md`
+
+- [ ] **Step 1: aiRandom.ts の記述を更新**
+
+`README.md` の `aiRandom.ts # 乱数プロバイダ DI`（109行付近）の記述を、可変状態除去後の実態
+（不変の Math.random プロバイダ）に合わせて更新する。例: `aiRandom.ts # 乱数プロバイダ（不変・Math.random ベース）`。
+（該当行の正確な文言は README を確認して整える。）
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add src/features/ipne/README.md
+git commit -m "docs: IPNE README の aiRandom 記述を可変状態除去後に更新
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 最終検証
+
+**Files:** なし
+
+- [ ] **Step 1: 可変モジュール状態が消えたことを確認**
+
+Run: `grep -rn "let _random\|setRandomProvider\|resetRandomProvider\|getRandom\b" src/features/ipne 2>/dev/null | grep -v test`
+Expected: 出力なし（可変状態・未使用 setter・getRandom が IPNE から消滅。`getRandomPassableTile`/`getRandomRoom` は `\b` 境界で除外される別名）。
+
+- [ ] **Step 2: IPNE 全テスト**
+
+Run: `npx jest ipne 2>&1 | tail -6`
+Expected: PASS（IPNE 全スイート green）
+
+- [ ] **Step 3: 型チェック**
+
+Run: `npm run typecheck 2>&1 | tail -3`
+Expected: エラーなし
+
+- [ ] **Step 4: lint:ci（警告ゼロ強制）**
+
+Run: `npm run lint:ci 2>&1 | tail -8`
+Expected: エラー・警告なし（exit 0）
+
+---
+
+## 完了の定義（Definition of Done）
+
+- [ ] `aiRandom.ts` が `defaultRandom`（const）のみ。`let _random`/`getRandom`/setter が消滅
+- [ ] `enemyMovement.ts` が `defaultRandom` を直接利用（4箇所）
+- [ ] `enemyAiFunctions.ts` の死んだ barrel 再公開が削除
+- [ ] 可変モジュール状態が IPNE から消えている
+- [ ] 敵AIの挙動・公開 API は不変
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス

--- a/docs/superpowers/specs/2026-06-16-ipne-airandom-immutable-design.md
+++ b/docs/superpowers/specs/2026-06-16-ipne-airandom-immutable-design.md
@@ -1,0 +1,138 @@
+# IPNE aiRandom の可変モジュール状態を除去 設計（フォローアップ）
+
+- 日付: 2026-06-16
+- 対象: `src/features/ipne/domain/policies/enemyAi/`（aiRandom.ts / enemyMovement.ts / enemyAiFunctions.ts）
+- 種別: リファクタリング（**振る舞い不変**・可変モジュール状態の除去）
+- 位置づけ: IPNE 包括リファクタリング（A〜E 完了）の**残フォローアップ**。Phase A spec §6 の既知の負債を解消。
+
+## 1. 背景と目的
+
+`aiRandom.ts` は敵AIの乱数プロバイダを **モジュールレベルの可変変数 `let _random`** で保持し、
+`setRandomProvider`/`resetRandomProvider` で差し替え、`getRandom()` で取得する設計になっている。
+Phase A の spec §6 で「モジュールレベルの可変状態は既知の負債」と記録された箇所。
+
+調査で判明した事実:
+
+- **`setRandomProvider` / `resetRandomProvider` は誰も呼んでいない**（テストも本番も。`index.ts` の公開 API にも無い）。
+  → 「差し替えるための可変状態」なのに一度も差し替えられていない、**死んだ差し替え機構**。
+- `getRandom()` を本番で使うのは `enemyMovement.ts` の3関数（`attemptLunge`/`stepRandom`/`generatePatrolPath`）のみ。
+  いずれも `getRandom()` は常に `defaultRandom`（Math.random ベース）を返す。
+- `generatePatrolPath` は本番から呼ばれずテスト専用。
+
+負債の実体は **「可変性」**（`let` ＋ setter）。注入の実需要はゼロ。よって最小変更で可変性だけを除去する。
+
+### 非目標（YAGNI）
+
+- **フル DI（`random` 引数を context/オーケストレータ/3関数へ7層に通す）はしない。** 誰も注入しない以上、
+  注入口の plumbing は過剰投資。プロジェクトの DI 規約（trap/mazeGenerator が `random` を引数で受ける）には
+  揃わないが、本件は「可変状態の除去」が目的で、注入機能の追加は別問題。
+- `tickGameState` の `random` を敵AIへ接続しない（現状は分断。接続するとテスト挙動が変わるため別判断）。
+- 乱数公式・敵AIの挙動の変更。
+
+## 2. 現状調査の要点
+
+- `aiRandom.ts`: `export const defaultRandom`（Math.random プロバイダ）/ `let _random = defaultRandom` /
+  `export const getRandom = () => _random` / `setRandomProvider` / `resetRandomProvider`。
+- 利用: `enemyMovement.ts:10` `import { getRandom } from './aiRandom'`、`getRandom()` を 63/90/114/115 行で使用。
+  `enemyAiFunctions.ts:9` が `setRandomProvider`/`resetRandomProvider` を barrel 再公開（**消費者なし**）。
+- `index.ts` に setRandomProvider/resetRandomProvider/getRandom の export は**無い**（公開 API に影響なし）。
+- 既存テスト: enemyAI / enemyAiFunctions / enemyAttackAnim が enemyMovement 経由の乱数挙動をカバー
+  （default の Math.random で動作）。
+
+## 3. 変更後の構造
+
+### `aiRandom.ts`（可変機構を削除し defaultRandom のみ残す）
+
+```typescript
+/**
+ * 敵AIの乱数プロバイダ
+ *
+ * Math.random ベースの不変プロバイダを提供する。
+ */
+import { RandomProvider } from '../../ports';
+
+/** デフォルトの乱数プロバイダー（Math.random ベース） */
+export const defaultRandom: RandomProvider = {
+  random: () => Math.random(),
+  randomInt: (min, max) => min + Math.floor(Math.random() * (max - min)),
+  pick: (array) => array[Math.floor(Math.random() * array.length)],
+  shuffle: (array) => {
+    const result = [...array];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  },
+};
+```
+
+削除: `let _random`、`getRandom`、`setRandomProvider`、`resetRandomProvider`。`defaultRandom` の実装は逐語維持。
+
+### `enemyMovement.ts`（getRandom → defaultRandom）
+
+- `import { getRandom } from './aiRandom';` を `import { defaultRandom } from './aiRandom';` に変更。
+- 4箇所の `getRandom()` を `defaultRandom` に置換:
+  - `getRandom().random()`（attemptLunge 63行）→ `defaultRandom.random()`
+  - `getRandom().shuffle(directions)`（stepRandom 90行）→ `defaultRandom.shuffle(directions)`
+  - `getRandom().randomInt(4, 9)`（generatePatrolPath 114行）→ `defaultRandom.randomInt(4, 9)`
+  - `getRandom().random()`（generatePatrolPath 115行）→ `defaultRandom.random()`
+
+`getRandom()` は常に `defaultRandom` を返していたため、挙動は完全に同一。
+
+### `enemyAiFunctions.ts`（死んだ barrel 再公開を削除）
+
+- 9行目 `export { setRandomProvider, resetRandomProvider } from './aiRandom';` を**削除**
+  （消費者ゼロ・index.ts にも無いため安全）。
+
+### README（任意・軽微）
+
+`src/features/ipne/README.md` の `aiRandom.ts # 乱数プロバイダ DI` の記述を「不変の乱数プロバイダ」へ更新（任意）。
+
+### 依存方向（不変）
+
+`enemyMovement.ts → aiRandom.ts（defaultRandom）`。循環なし。
+
+## 4. 安全網（振る舞い不変の証明）
+
+`getRandom()` が常に `defaultRandom` を返していたため、`defaultRandom` 直接利用への置換は**完全に挙動同一**。
+
+- 既存テストを全工程で緑に保つ: `enemyAI.test` / `enemyAiFunctions.test` / `enemyAttackAnim.test`
+  （enemyMovement の attemptLunge/stepRandom/generatePatrolPath を間接的にカバー）。
+- `npm run typecheck`: 削除した `getRandom`/`setRandomProvider`/`resetRandomProvider` の参照が
+  残っていないこと（残っていれば未定義参照でコンパイルエラー＝検出）を保証。
+- `npm run lint:ci`: 未使用 import の検出。
+
+## 5. 検証手順（refactor-safely）
+
+1. `aiRandom.ts` から可変機構を削除（defaultRandom のみ残す）。
+2. `enemyMovement.ts` を defaultRandom 直接利用へ。
+3. `enemyAiFunctions.ts` の barrel 再公開を削除。
+4. （任意）README 更新。
+5. 検証:
+
+```bash
+npx jest enemyAI enemyAiFunctions enemyAttackAnim
+npm run typecheck
+npm run lint:ci
+```
+
+6. 最終確認: `npx jest ipne` 全パス。
+
+### 完了の定義（Definition of Done）
+
+- [ ] `aiRandom.ts` から `let _random`/`getRandom`/`setRandomProvider`/`resetRandomProvider` が削除され、`defaultRandom`（const）のみ残る
+- [ ] `enemyMovement.ts` が `defaultRandom` を直接利用（4箇所）
+- [ ] `enemyAiFunctions.ts` の `setRandomProvider`/`resetRandomProvider` 再公開が削除されている
+- [ ] 可変モジュール状態（`let _random` ＋ setter）が IPNE から消えている
+- [ ] `tickGameState`・敵AIの挙動は不変（フル DI はしない）
+- [ ] `npx jest ipne` / `npm run typecheck` / `npm run lint:ci` 全パス
+
+## 6. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| 削除した getRandom/setter を見落とした箇所が参照 | typecheck で未定義参照を即検出。事前 grep で参照元が enemyMovement のみと確認済み |
+| defaultRandom 置換で挙動が変わる | getRandom() は常に defaultRandom を返していた＝完全同一。既存テストで担保 |
+| 公開 API の破壊 | index.ts は setter/getRandom を export していない（確認済み）。barrel 削除のみで外部影響なし |
+| defaultRandom の実装変質 | shuffle の Fisher-Yates 等を逐語維持（変更しない） |

--- a/src/features/ipne/README.md
+++ b/src/features/ipne/README.md
@@ -106,7 +106,7 @@ src/features/ipne/
       enemyAi/                #   敵AIポリシー（責務別に分割）
         enemyAiFunctions.ts   #     barrel（後方互換の re-export のみ）
         aiGeometry.ts         #     幾何計算・検知判定（calculateStep, 距離, detect/chase）
-        aiRandom.ts           #     乱数プロバイダ DI
+        aiRandom.ts           #     乱数プロバイダ（不変・Math.random ベース）
         enemyMovement.ts      #     移動エンジン（step/move, 突進, 巡回パス）
         attackState.ts        #     攻撃可否・攻撃/ノックバック状態解決
         behaviors/            #     敵タイプ別 AI（patrol/charge/ranged/flee を1ファイルずつ）

--- a/src/features/ipne/domain/policies/enemyAi/aiRandom.ts
+++ b/src/features/ipne/domain/policies/enemyAi/aiRandom.ts
@@ -1,8 +1,7 @@
 /**
- * 敵AIの乱数プロバイダ管理
+ * 敵AIの乱数プロバイダ
  *
- * テスト時に setRandomProvider で決定的な乱数へ差し替えられる。
- * NOTE: モジュールレベルの可変状態は既知の負債（spec §6）。Phase A では現状維持。
+ * Math.random ベースの不変プロバイダを提供する。
  */
 import { RandomProvider } from '../../ports';
 
@@ -20,18 +19,3 @@ export const defaultRandom: RandomProvider = {
     return result;
   },
 };
-
-let _random: RandomProvider = defaultRandom;
-
-/** 現在の乱数プロバイダーを取得する（モジュール間共有用） */
-export const getRandom = (): RandomProvider => _random;
-
-/** 乱数プロバイダーを設定する（テスト用） */
-export function setRandomProvider(random: RandomProvider): void {
-  _random = random;
-}
-
-/** 乱数プロバイダーをデフォルトにリセットする */
-export function resetRandomProvider(): void {
-  _random = defaultRandom;
-}

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.ts
@@ -5,8 +5,6 @@
  * 公開 API（エクスポート名・シグネチャ）は分割前と完全一致を維持する。
  * 設計: docs/superpowers/specs/2026-06-14-ipne-enemyai-refactoring-design.md
  */
-// 乱数プロバイダ DI
-export { setRandomProvider, resetRandomProvider } from './aiRandom';
 // 幾何計算・検知判定（純粋関数）
 export {
   AI_CONFIG,

--- a/src/features/ipne/domain/policies/enemyAi/enemyMovement.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyMovement.ts
@@ -7,7 +7,7 @@
 import { Enemy, GameMap, Position } from '../../types';
 import { canMove } from '../../services/collisionService';
 import { calculateStep, getManhattanDistance } from './aiGeometry';
-import { getRandom } from './aiRandom';
+import { defaultRandom } from './aiRandom';
 
 /** ターゲットへ1歩近づく（横優先/縦優先を距離差で決定、塞がれたら停止） */
 const stepTowards = (enemy: Enemy, target: Position, map: GameMap): Position => {
@@ -60,7 +60,7 @@ export const attemptLunge = (
 ): Enemy | null => {
   const distance = getManhattanDistance(enemy, target);
   if (distance > maxDistance) return null;
-  if (getRandom().random() > chance) return null;
+  if (defaultRandom.random() > chance) return null;
 
   const { stepX, stepY } = calculateStep(enemy, target);
   const dx = target.x - enemy.x;
@@ -87,7 +87,7 @@ const stepRandom = (enemy: Enemy, map: GameMap): Position => {
     { x: enemy.x, y: enemy.y + 1 },
     { x: enemy.x, y: enemy.y - 1 },
   ];
-  const shuffled = getRandom().shuffle(directions);
+  const shuffled = defaultRandom.shuffle(directions);
   for (const pos of shuffled) {
     if (canMove(map, pos.x, pos.y)) return pos;
   }
@@ -111,8 +111,8 @@ export const moveEnemyRandom = (enemy: Enemy, map: GameMap): Enemy => {
 
 /** 巡回パスを生成する（往路＋復路、長さ4-8マス） */
 export const generatePatrolPath = (origin: Position): Position[] => {
-  const length = getRandom().randomInt(4, 9); // 4-8
-  const horizontal = getRandom().random() > 0.5;
+  const length = defaultRandom.randomInt(4, 9); // 4-8
+  const horizontal = defaultRandom.random() > 0.5;
   const path: Position[] = [];
   for (let i = 0; i < length; i++) {
     path.push({


### PR DESCRIPTION
## 概要

IPNE 敵AIの乱数プロバイダ `aiRandom.ts` が保持していた**モジュールレベルの可変状態**（`let _random` ＋ 未使用の `setRandomProvider`/`resetRandomProvider`/`getRandom`）を除去し、不変の `defaultRandom`（const）の直接利用へ統一する**振る舞い不変リファクタリング**です。IPNE 包括リファクタリング（Phase A〜E 完了）の残フォローアップであり、Phase A spec §6 で記録された「モジュールレベル可変状態の負債」を解消します。

## 背景

調査の結果、この可変状態は**一度も差し替えられていない「死んだ差し替え機構」**でした:

- `setRandomProvider`/`resetRandomProvider` の呼び出しはテスト・本番ともにゼロ（`index.ts` の公開 API にも非公開）
- `getRandom()` は常に `defaultRandom`（Math.random ベース）を返していた

負債の実体は「可変性」であり注入の実需要はゼロのため、フル DI（`random` 引数注入）はせず（YAGNI）、可変性の除去のみを最小変更で行いました。

## 変更内容

- `aiRandom.ts`: `let _random`/`getRandom`/`setRandomProvider`/`resetRandomProvider` を削除し、`defaultRandom`（const）のみ残す（実装は逐語維持）
- `enemyMovement.ts`: `getRandom()` 4箇所（attemptLunge / stepRandom / generatePatrolPath×2）を `defaultRandom` 直接利用へ置換
- `enemyAiFunctions.ts`: 消費者ゼロの barrel 再公開行を削除
- `README.md`: aiRandom の記述を実態（不変・Math.random ベース）に更新

`getRandom()` は常に `defaultRandom` を返していたため、敵AIの挙動・公開 API は完全に不変です。

## テスト方法

- [x] `npx jest ipne`（85 スイート / 1327 テスト 全パス）
- [x] `npm run typecheck`（エラーなし）
- [x] `npm run lint:ci`（警告ゼロ）
- [x] 可変状態の消滅確認（`grep` で `let _random`/setter が IPNE から消滅）

🤖 Generated with [Claude Code](https://claude.com/claude-code)