### PR TITLE
fix: IPNE テストプレイで見つかった3バグを修正

### DIFF
--- a/src/features/ipne/__tests__/progression.test.ts
+++ b/src/features/ipne/__tests__/progression.test.ts
@@ -132,6 +132,49 @@ describe('progression', () => {
     });
   });
 
+  describe('攻撃速度の浮動小数累積誤差（toBe で厳密一致を要求）', () => {
+    const baseStats: PlayerStats = {
+      attackPower: 2,
+      attackRange: 1,
+      moveSpeed: 4,
+      attackSpeed: 1.0,
+      healBonus: 0,
+    };
+
+    const applyAttackSpeed = (stats: PlayerStats, times: number): PlayerStats => {
+      let current = stats;
+      for (let i = 0; i < times; i++) {
+        current = applyLevelUpChoice(current, StatType.ATTACK_SPEED);
+      }
+      return current;
+    };
+
+    test('攻撃速度を3回上げても 0.7 ちょうど（累積誤差なし）', () => {
+      const result = applyAttackSpeed(baseStats, 3);
+      // 修正前は 0.7000000000000001 となり toBe(0.7) で失敗する
+      expect(result.attackSpeed).toBe(0.7);
+    });
+
+    test('攻撃速度を5回上げると下限 0.5 ちょうど', () => {
+      const result = applyAttackSpeed(baseStats, 5);
+      expect(result.attackSpeed).toBe(0.5);
+    });
+
+    test('下限到達後（0.5）は誤差なくこれ以上選べない', () => {
+      const atLimit = applyAttackSpeed(baseStats, 5);
+      expect(atLimit.attackSpeed).toBe(0.5);
+      expect(canChooseStat(atLimit, StatType.ATTACK_SPEED)).toBe(false);
+    });
+
+    test('ステージ報酬の攻撃速度を3回上げても 0.7 ちょうど', () => {
+      let player = aPlayer().withStats({ attackSpeed: 1.0 }).build();
+      for (let i = 0; i < 3; i++) {
+        player = applyStageReward(player, 'attack_speed');
+      }
+      expect(player.stats.attackSpeed).toBe(0.7);
+    });
+  });
+
   describe('canChooseStat', () => {
     test('上限未達の能力は選択可能であること', () => {
       const stats: PlayerStats = {

--- a/src/features/ipne/domain/policies/enemyAi/attackState.ts
+++ b/src/features/ipne/domain/policies/enemyAi/attackState.ts
@@ -10,6 +10,10 @@ export const ENEMY_ATTACK_ANIM_DURATION = GAME_BALANCE.enemyAi.attackAnimDuratio
 
 /** 敵が攻撃可能かどうか */
 export const canEnemyAttack = (enemy: Enemy, player: Position, currentTime: number): boolean => {
+  // 死亡済み・死亡アニメーション中の敵は攻撃できない。
+  // 敵は死亡演出のため最大 DEATH_ANIMATION_DURATION の間ゲーム状態に残るが、
+  // その間に攻撃を成立させない（撃破直後の「最後っ屁攻撃」を防止する不変条件）。
+  if (enemy.hp <= 0 || enemy.isDying) return false;
   if (enemy.attackRange <= 0) return false;
   if (currentTime < enemy.attackCooldownUntil) return false;
   return getManhattanDistance(enemy, player) <= enemy.attackRange;

--- a/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.test.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyAiFunctions.test.ts
@@ -106,6 +106,21 @@ describe('敵AI関数（Policy 統合後）', () => {
       const enemy = createSpecimenEnemy(2, 2, mockIdGen);
       expect(canEnemyAttack(enemy, { x: 2, y: 2 }, 0)).toBe(false);
     });
+
+    it('射程内・クールダウン明けの生存している敵は攻撃できる', () => {
+      const enemy = { ...createRangedEnemy(2, 2, mockIdGen), attackRange: 3, hp: 5, attackCooldownUntil: 0 };
+      expect(canEnemyAttack(enemy, { x: 2, y: 2 }, 1000)).toBe(true);
+    });
+
+    it('HPが0の敵は攻撃できない（最後っ屁攻撃の防止）', () => {
+      const deadEnemy = { ...createRangedEnemy(2, 2, mockIdGen), attackRange: 3, hp: 0, attackCooldownUntil: 0 };
+      expect(canEnemyAttack(deadEnemy, { x: 2, y: 2 }, 1000)).toBe(false);
+    });
+
+    it('死亡アニメーション中（isDying）の敵は攻撃できない', () => {
+      const dyingEnemy = { ...createRangedEnemy(2, 2, mockIdGen), attackRange: 3, hp: 5, isDying: true, attackCooldownUntil: 0 };
+      expect(canEnemyAttack(dyingEnemy, { x: 2, y: 2 }, 1000)).toBe(false);
+    });
   });
 
   describe('markEnemyAttacking', () => {
@@ -161,6 +176,20 @@ describe('敵AI関数（Policy 統合後）', () => {
       expect(result.enemies).toEqual([]);
       expect(result.contactDamage).toBe(0);
       expect(result.attackDamage).toBe(0);
+    });
+
+    it('死亡した敵（isDying）はプレイヤーと同マスでも接触・攻撃ダメージを発生させない', () => {
+      const deadEnemy = {
+        ...createRangedEnemy(2, 2, mockIdGen),
+        attackRange: 3,
+        damage: 5,
+        hp: 0,
+        isDying: true,
+        attackCooldownUntil: 0,
+      };
+      const result = updateEnemiesWithContact([deadEnemy], { x: 2, y: 2 }, testMap, 1000);
+      expect(result.attackDamage).toBe(0);
+      expect(result.contactDamage).toBe(0);
     });
   });
 

--- a/src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts
@@ -104,7 +104,7 @@ export const updateEnemiesWithContact = (
 
     // 接触判定（死亡済み・死亡アニメーション中の敵は接触ダメージを与えない）
     if (candidateKey === playerKey) {
-      if (enemy.hp > 0 && !enemy.isDying && enemy.damage >= contactDamage) {
+      if (candidate.hp > 0 && !candidate.isDying && enemy.damage >= contactDamage) {
         contactDamage = enemy.damage;
         contactEnemy = enemy;
       }

--- a/src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts
+++ b/src/features/ipne/domain/policies/enemyAi/enemyOrchestrator.ts
@@ -102,9 +102,9 @@ export const updateEnemiesWithContact = (
       candidate = markEnemyAttacking(candidate, currentTime);
     }
 
-    // 接触判定
+    // 接触判定（死亡済み・死亡アニメーション中の敵は接触ダメージを与えない）
     if (candidateKey === playerKey) {
-      if (enemy.damage >= contactDamage) {
+      if (enemy.hp > 0 && !enemy.isDying && enemy.damage >= contactDamage) {
         contactDamage = enemy.damage;
         contactEnemy = enemy;
       }

--- a/src/features/ipne/domain/services/progressionService.ts
+++ b/src/features/ipne/domain/services/progressionService.ts
@@ -107,6 +107,15 @@ export const shouldLevelUp = (currentLevel: number, killCount: number): boolean 
 };
 
 /**
+ * 攻撃速度の浮動小数累積誤差を防ぐため小数第1位に丸める
+ *
+ * attackSpeed は -0.1 を繰り返し加算するため、丸めないと 0.7000000000000001 の
+ * ような値が蓄積し、表示や上限判定（canChooseStat）が汚れる。代入のたびに丸めて
+ * 常にクリーンな1桁小数に保つ。
+ */
+const roundAttackSpeed = (value: number): number => Math.round(value * 10) / 10;
+
+/**
  * レベルアップ選択を適用
  */
 export const applyLevelUpChoice = (
@@ -136,7 +145,7 @@ export const applyLevelUpChoice = (
       break;
     case StatType.ATTACK_SPEED:
       newStats.attackSpeed = Math.max(
-        newStats.attackSpeed + choice.increase,
+        roundAttackSpeed(newStats.attackSpeed + choice.increase),
         STAT_LIMITS[StatType.ATTACK_SPEED] ?? 0
       );
       break;
@@ -217,7 +226,7 @@ export const applyStageReward = (player: Player, rewardType: StageRewardType): P
       break;
     case 'attack_speed':
       newPlayer.stats.attackSpeed = Math.max(
-        newPlayer.stats.attackSpeed - 0.1,
+        roundAttackSpeed(newPlayer.stats.attackSpeed - 0.1),
         STAT_LIMITS[StatType.ATTACK_SPEED] ?? 0
       );
       break;

--- a/src/features/ipne/presentation/screens/GameHUD.tsx
+++ b/src/features/ipne/presentation/screens/GameHUD.tsx
@@ -26,6 +26,8 @@ import {
   HelpButton,
   KeyRequiredMessage,
   TopRightControls,
+  TopLeftStatus,
+  TopRightStatus,
 } from '../../../../pages/IpnePage.styles';
 import {
   Player,
@@ -80,68 +82,72 @@ export const GameHUD: React.FC<GameHUDProps> = ({
       <DamageOverlay $visible={renderTime - lastDamageAt < 150} />
       <TimerDisplay>{formatTimeShort(currentElapsed)}</TimerDisplay>
       {currentStage && <StageIndicator>STAGE {currentStage}</StageIndicator>}
-      <HPBarContainer>
-        <HPBarFill $ratio={hpRatio} $color={hpColor} />
-        <HPBarText>
-          HP {player.hp}/{player.maxHp}
-        </HPBarText>
-      </HPBarContainer>
-      <LevelBadge>Lv.{player.level}</LevelBadge>
-      <ExperienceBar>
-        <ExperienceBarFill
-          $ratio={
-            player.level >= maxLevel
-              ? 1
-              : (player.killCount - (KILL_COUNT_TABLE[player.level] || 0)) /
-                Math.max(1, getNextKillsRequired(player.level, player.killCount) + (player.killCount - (KILL_COUNT_TABLE[player.level] || 0)))
-          }
-        />
-      </ExperienceBar>
-      <StatsDisplay>
-        <StatRow>
-          <StatLabel>攻撃力</StatLabel>
-          <StatValue>{player.stats.attackPower}</StatValue>
-        </StatRow>
-        <StatRow>
-          <StatLabel>攻撃距離</StatLabel>
-          <StatValue>{player.stats.attackRange}</StatValue>
-        </StatRow>
-        <StatRow>
-          <StatLabel>移動速度</StatLabel>
-          <StatValue>{player.stats.moveSpeed}</StatValue>
-        </StatRow>
-        <StatRow>
-          <StatLabel>攻撃速度</StatLabel>
-          <StatValue>{player.stats.attackSpeed.toFixed(1)}</StatValue>
-        </StatRow>
-        <StatRow>
-          <StatLabel>撃破数</StatLabel>
-          <StatValue>{player.killCount}</StatValue>
-        </StatRow>
-      </StatsDisplay>
-      <TopRightControls>
-        <PendingPointsBadge
-          $hasPoints={pendingLevelPoints > 0}
-          onClick={onOpenLevelUpModal}
-          aria-label={pendingLevelPoints > 0 ? `未割り振りポイント: ${pendingLevelPoints}` : '未割り振りポイントなし'}
-        >
-          <PendingPointsCount $hasPoints={pendingLevelPoints > 0}>
-            ★ {pendingLevelPoints}
-          </PendingPointsCount>
-          <EnhanceButtonText $hasPoints={pendingLevelPoints > 0}>
-            強化
-          </EnhanceButtonText>
-        </PendingPointsBadge>
-        <KeyIndicator $hasKey={player.hasKey} aria-label={player.hasKey ? '鍵を所持' : '鍵未所持'}>
-          <KeyIcon $hasKey={player.hasKey}>🔑</KeyIcon>
-        </KeyIndicator>
-        <HelpButton onClick={onHelpToggle} aria-label="ヘルプ表示">
-          H
-        </HelpButton>
-        <MapToggleButton onClick={onMapToggle} aria-label="マップ表示切替">
-          🗺️
-        </MapToggleButton>
-      </TopRightControls>
+      <TopLeftStatus>
+        <HPBarContainer>
+          <HPBarFill $ratio={hpRatio} $color={hpColor} />
+          <HPBarText>
+            HP {player.hp}/{player.maxHp}
+          </HPBarText>
+        </HPBarContainer>
+        <ExperienceBar>
+          <ExperienceBarFill
+            $ratio={
+              player.level >= maxLevel
+                ? 1
+                : (player.killCount - (KILL_COUNT_TABLE[player.level] || 0)) /
+                  Math.max(1, getNextKillsRequired(player.level, player.killCount) + (player.killCount - (KILL_COUNT_TABLE[player.level] || 0)))
+            }
+          />
+        </ExperienceBar>
+      </TopLeftStatus>
+      <TopRightStatus>
+        <TopRightControls>
+          <PendingPointsBadge
+            $hasPoints={pendingLevelPoints > 0}
+            onClick={onOpenLevelUpModal}
+            aria-label={pendingLevelPoints > 0 ? `未割り振りポイント: ${pendingLevelPoints}` : '未割り振りポイントなし'}
+          >
+            <PendingPointsCount $hasPoints={pendingLevelPoints > 0}>
+              ★ {pendingLevelPoints}
+            </PendingPointsCount>
+            <EnhanceButtonText $hasPoints={pendingLevelPoints > 0}>
+              強化
+            </EnhanceButtonText>
+          </PendingPointsBadge>
+          <KeyIndicator $hasKey={player.hasKey} aria-label={player.hasKey ? '鍵を所持' : '鍵未所持'}>
+            <KeyIcon $hasKey={player.hasKey}>🔑</KeyIcon>
+          </KeyIndicator>
+          <HelpButton onClick={onHelpToggle} aria-label="ヘルプ表示">
+            H
+          </HelpButton>
+          <MapToggleButton onClick={onMapToggle} aria-label="マップ表示切替">
+            🗺️
+          </MapToggleButton>
+        </TopRightControls>
+        <LevelBadge>Lv.{player.level}</LevelBadge>
+        <StatsDisplay>
+          <StatRow>
+            <StatLabel>攻撃力</StatLabel>
+            <StatValue>{player.stats.attackPower}</StatValue>
+          </StatRow>
+          <StatRow>
+            <StatLabel>攻撃距離</StatLabel>
+            <StatValue>{player.stats.attackRange}</StatValue>
+          </StatRow>
+          <StatRow>
+            <StatLabel>移動速度</StatLabel>
+            <StatValue>{player.stats.moveSpeed}</StatValue>
+          </StatRow>
+          <StatRow>
+            <StatLabel>攻撃速度</StatLabel>
+            <StatValue>{player.stats.attackSpeed.toFixed(1)}</StatValue>
+          </StatRow>
+          <StatRow>
+            <StatLabel>撃破数</StatLabel>
+            <StatValue>{player.killCount}</StatValue>
+          </StatRow>
+        </StatsDisplay>
+      </TopRightStatus>
       {showHelp && <HelpOverlayComponent onClose={onHelpToggle} />}
       {showKeyRequiredMessage && <KeyRequiredMessage>🔑 鍵が必要です</KeyRequiredMessage>}
     </>

--- a/src/features/ipne/presentation/screens/GameHUD.tsx
+++ b/src/features/ipne/presentation/screens/GameHUD.tsx
@@ -25,6 +25,7 @@ import {
   MapToggleButton,
   HelpButton,
   KeyRequiredMessage,
+  TopRightControls,
 } from '../../../../pages/IpnePage.styles';
 import {
   Player,
@@ -118,27 +119,29 @@ export const GameHUD: React.FC<GameHUDProps> = ({
           <StatValue>{player.killCount}</StatValue>
         </StatRow>
       </StatsDisplay>
-      <PendingPointsBadge
-        $hasPoints={pendingLevelPoints > 0}
-        onClick={onOpenLevelUpModal}
-        aria-label={pendingLevelPoints > 0 ? `未割り振りポイント: ${pendingLevelPoints}` : '未割り振りポイントなし'}
-      >
-        <PendingPointsCount $hasPoints={pendingLevelPoints > 0}>
-          ★ {pendingLevelPoints}
-        </PendingPointsCount>
-        <EnhanceButtonText $hasPoints={pendingLevelPoints > 0}>
-          強化
-        </EnhanceButtonText>
-      </PendingPointsBadge>
-      <KeyIndicator $hasKey={player.hasKey} aria-label={player.hasKey ? '鍵を所持' : '鍵未所持'}>
-        <KeyIcon $hasKey={player.hasKey}>🔑</KeyIcon>
-      </KeyIndicator>
-      <MapToggleButton onClick={onMapToggle} aria-label="マップ表示切替">
-        🗺️
-      </MapToggleButton>
-      <HelpButton onClick={onHelpToggle} aria-label="ヘルプ表示">
-        H
-      </HelpButton>
+      <TopRightControls>
+        <PendingPointsBadge
+          $hasPoints={pendingLevelPoints > 0}
+          onClick={onOpenLevelUpModal}
+          aria-label={pendingLevelPoints > 0 ? `未割り振りポイント: ${pendingLevelPoints}` : '未割り振りポイントなし'}
+        >
+          <PendingPointsCount $hasPoints={pendingLevelPoints > 0}>
+            ★ {pendingLevelPoints}
+          </PendingPointsCount>
+          <EnhanceButtonText $hasPoints={pendingLevelPoints > 0}>
+            強化
+          </EnhanceButtonText>
+        </PendingPointsBadge>
+        <KeyIndicator $hasKey={player.hasKey} aria-label={player.hasKey ? '鍵を所持' : '鍵未所持'}>
+          <KeyIcon $hasKey={player.hasKey}>🔑</KeyIcon>
+        </KeyIndicator>
+        <HelpButton onClick={onHelpToggle} aria-label="ヘルプ表示">
+          H
+        </HelpButton>
+        <MapToggleButton onClick={onMapToggle} aria-label="マップ表示切替">
+          🗺️
+        </MapToggleButton>
+      </TopRightControls>
       {showHelp && <HelpOverlayComponent onClose={onHelpToggle} />}
       {showKeyRequiredMessage && <KeyRequiredMessage>🔑 鍵が必要です</KeyRequiredMessage>}
     </>

--- a/src/features/ipne/presentation/screens/GameModals.tsx
+++ b/src/features/ipne/presentation/screens/GameModals.tsx
@@ -124,6 +124,14 @@ export const ClassSelectScreen: React.FC<{
 };
 
 /**
+ * 能力値の表示用フォーマット（小数第1位に丸める）
+ *
+ * attackSpeed は小数のため、表示時のインライン加算（例: 0.8 + (-0.1) = 0.7000000000000001）で
+ * 浮動小数誤差が出る。丸めて常にクリーンな表示にする。整数の能力値はそのまま整数で表示される。
+ */
+const formatStatValue = (value: number): number => Math.round(value * 10) / 10;
+
+/**
  * レベルアップオーバーレイコンポーネント（MVP3、ポイント制対応）
  */
 export const LevelUpOverlayComponent: React.FC<{
@@ -155,7 +163,7 @@ export const LevelUpOverlayComponent: React.FC<{
             <LevelUpChoiceLabel>{choice.description}</LevelUpChoiceLabel>
             <LevelUpChoiceValue $disabled={!choice.canChoose}>
               {choice.canChoose
-                ? `${choice.currentValue} → ${choice.currentValue + choice.increase}`
+                ? `${formatStatValue(choice.currentValue)} → ${formatStatValue(choice.currentValue + choice.increase)}`
                 : '上限'}
             </LevelUpChoiceValue>
           </LevelUpChoice>

--- a/src/pages/IpnePage.styles.ts
+++ b/src/pages/IpnePage.styles.ts
@@ -413,11 +413,24 @@ export const BackToTitleButton = styled.button`
   }
 `;
 
-// マップ切替ボタン
-export const MapToggleButton = styled.button`
+// 右上コントロール群のコンテナ
+// 各ボタンを固定 rem アンカーで個別配置すると内容の伸縮で重なるため、
+// flex + gap でまとめて自動間隔・自動折り返しさせる。
+export const TopRightControls = styled.div`
   position: absolute;
   top: 1rem;
   right: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  max-width: calc(100% - 2rem);
+  z-index: 20;
+`;
+
+// マップ切替ボタン
+export const MapToggleButton = styled.button`
   background: rgba(255, 255, 255, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 0.5rem;
@@ -686,9 +699,6 @@ export const LevelBadge = styled.div`
 // ===== MVP4: ヘルプUI =====
 
 export const HelpButton = styled.button`
-  position: absolute;
-  top: 1rem;
-  right: 5rem;
   background: rgba(255, 255, 255, 0.15);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 0.5rem;
@@ -1171,9 +1181,6 @@ export const TapToStartMessage = styled.div`
 
 // 鍵インジケータ
 export const KeyIndicator = styled.div<{ $hasKey: boolean }>`
-  position: absolute;
-  top: 1rem;
-  right: 8rem;
   display: flex;
   align-items: center;
   gap: 0.25rem;
@@ -1248,11 +1255,8 @@ const bounce = keyframes`
   50% { transform: translateY(-3px); }
 `;
 
-// 未割り振りポイントバッジ（右上に配置、ヘルプボタンの左）
+// 未割り振りポイントバッジ（右上コントロール群の左端に配置）
 export const PendingPointsBadge = styled.button<{ $hasPoints: boolean }>`
-  position: absolute;
-  top: 1rem;
-  right: 11rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/src/pages/IpnePage.styles.ts
+++ b/src/pages/IpnePage.styles.ts
@@ -830,8 +830,10 @@ export const HelpHint = styled.p`
 
 export const TimerDisplay = styled.div`
   position: absolute;
-  top: 2.5rem;
-  left: 50%;
+  /* 左寄せにより HP バー(top:3.75rem)の真上に来るため、下端が HP と重ならないよう少し上げる */
+  top: 2.25rem;
+  /* 完全中央(50%)だと狭い画面で右上カラム(強化バッジ)と接触するため、左へ寄せて安全帯に収める */
+  left: calc(50% - 4.5rem);
   transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.6);
   border: 1px solid rgba(255, 255, 255, 0.2);
@@ -1344,7 +1346,8 @@ export const RemainingPointsText = styled.p`
 export const StageIndicator = styled.div`
   position: absolute;
   top: 0.75rem;
-  left: 50%;
+  /* 完全中央(50%)だと狭い画面で右上カラム(強化バッジ)と接触するため、左へ寄せて安全帯に収める */
+  left: calc(50% - 4.5rem);
   transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.6);
   border: 1px solid rgba(251, 191, 36, 0.4);

--- a/src/pages/IpnePage.styles.ts
+++ b/src/pages/IpnePage.styles.ts
@@ -280,9 +280,7 @@ export const AttackButton = styled.button<{ $ready: boolean }>`
 `;
 
 export const HPBarContainer = styled.div`
-  position: absolute;
-  top: 3rem;
-  left: 1rem;
+  position: relative;
   width: clamp(120px, 20vmin, 200px);
   height: clamp(18px, 3vmin, 24px);
   background: rgba(0, 0, 0, 0.5);
@@ -413,20 +411,42 @@ export const BackToTitleButton = styled.button`
   }
 `;
 
-// 右上コントロール群のコンテナ
-// 各ボタンを固定 rem アンカーで個別配置すると内容の伸縮で重なるため、
-// flex + gap でまとめて自動間隔・自動折り返しさせる。
-export const TopRightControls = styled.div`
+// 左上ステータス群（HP・経験値バー）の縦スタック。
+// グローバルのホームボタン（fixed・左上 約52px四方）と重ならないよう top を下げる。
+export const TopLeftStatus = styled.div`
+  position: absolute;
+  top: 3.75rem;
+  left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 20;
+`;
+
+// 右上ステータス群（ボタン行・レベル・ステータス）の縦スタック。
+// 各要素を固定オフセットで重ね置きすると内容の伸縮や2桁レベルで重なるため、
+// flex 縦並び + gap で自動間隔にして重なりを構造的に防ぐ。
+export const TopRightStatus = styled.div`
   position: absolute;
   top: 1rem;
   right: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  max-width: calc(100% - 2rem);
+  z-index: 20;
+`;
+
+// 右上コントロール群のボタン行。TopRightStatus 内の flex 行として配置。
+// 各ボタンを固定 rem アンカーで個別配置すると内容の伸縮で重なるため、
+// flex + gap でまとめて自動間隔・自動折り返しさせる。
+export const TopRightControls = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 0.5rem;
-  max-width: calc(100% - 2rem);
-  z-index: 20;
 `;
 
 // マップ切替ボタン
@@ -634,9 +654,6 @@ export const LevelUpChoiceValue = styled.span<{ $disabled?: boolean }>`
 // ===== MVP3: ステータス表示 =====
 
 export const StatsDisplay = styled.div`
-  position: absolute;
-  top: clamp(3.5rem, 7vmin, 5rem);
-  right: clamp(0.5rem, 1.5vmin, 1rem);
   display: flex;
   flex-direction: column;
   gap: clamp(0.125rem, 0.5vmin, 0.25rem);
@@ -664,9 +681,7 @@ export const StatValue = styled.span`
 `;
 
 export const ExperienceBar = styled.div`
-  position: absolute;
-  top: 4.75rem;
-  left: 1rem;
+  position: relative;
   width: clamp(120px, 20vmin, 200px);
   height: clamp(5px, 1vmin, 8px);
   background: rgba(0, 0, 0, 0.5);
@@ -684,9 +699,6 @@ export const ExperienceBarFill = styled.div<{ $ratio: number }>`
 `;
 
 export const LevelBadge = styled.div`
-  position: absolute;
-  top: clamp(2.5rem, 5vmin, 3.5rem);
-  right: clamp(0.5rem, 1.5vmin, 1rem);
   background: linear-gradient(to right, #a855f7, #ec4899);
   color: white;
   font-size: clamp(0.6rem, 1.4vmin, 0.75rem);


### PR DESCRIPTION
## 概要

テストプレイで報告された3つの問題を調査・修正しました。**3件とも直近のリファクタリング（Phase A〜E / aiRandom）とは無関係な既存バグ**であることを git 履歴で確認済みです。

## 変更内容

### 1. 攻撃速度アップの表記に大量の小数が出る
- **原因**: `attackSpeed - 0.1` の繰り返し加算による浮動小数累積誤差（`0.7000000000000001`）。HUD は `.toFixed(1)` で防御済みだが、レベルアップ選択モーダルが丸めなしで素の値を表示していた。
- **修正**: `progressionService` の `attackSpeed` 代入を小数第1位に丸める（`roundAttackSpeed`）。これで HUD・モーダル・上限判定すべてがクリーンに。モーダル表示のインライン加算誤差も `formatStatValue` で丸め。

### 2. レベル・マップ等のアイコンが重なる（HUD レイアウト）
固定オフセットの重ね置きをやめ、**左右の HUD を flex 縦スタックに集約**して重なりを構造的に解消。報告された重なり3箇所すべてに対応（3コミット）。
- **右上アイコン群**（マップ/ヘルプ/鍵/強化）: 固定 rem 間隔（`right:1/5/8/11rem`）の絶対配置 → 単一 flex コンテナ `TopRightControls`（`gap` + `flex-wrap`）。
- **レベルバッジ ↔ マップ / HP ↔ ホームボタン（縦の重なり）**: `LevelBadge`・`StatsDisplay`・`HPBarContainer`・`ExperienceBar` の固定オフセットを撤廃し、左上を `TopLeftStatus`、右上を `TopRightStatus` の flex 縦スタックに集約（`gap` で間隔保証）。`TopLeftStatus` は `top:3.75rem` でグローバルのホームボタン（fixed・52px）を回避。
- **STAGE 表示 ↔ 強化バッジの接触**: 中央配置の `StageIndicator`/`TimerDisplay` を `left:calc(50% - 4.5rem)` で安全帯に寄せ、`TimerDisplay` を `top:2.25rem` に上げて HP バーとの近接も解消。

### 3. 敵が死んだ後に必ず最後っ屁攻撃を当てられる
- **原因**: `canEnemyAttack` に生死判定がなく、死亡演出のため最大300ms 状態に残る敵が、その間ティックごとに攻撃を成立させていた。
- **修正**: `canEnemyAttack` に `hp<=0 / isDying` ガードを追加（攻撃経路）。接触ダメージ判定にも同ガードを追加（多層防御）。

## テスト方法

- [x] 失敗テスト先行（TDD）で各 root cause を特性化
  - 攻撃速度を複数回上げても `0.7`/`0.5` ちょうど（`toBe` 厳密一致）
  - 生存敵は攻撃可・死亡/死亡アニメ中の敵は攻撃不可、死亡敵は接触/攻撃ダメージ0
- [x] `npx jest ipne`（85スイート / 1335テスト 全パス）
- [x] `npm run typecheck`（エラーなし）
- [x] `npm run lint:ci`（警告ゼロ）
- [x] **バグ2（HUD レイアウト）を Playwright で 390px 実機相当の座標を実測し、全 HUD 要素ペアの非重なりを確認**（STAGE↔バッジ 41px / Lv↔Map 9px / ホーム↔HP 8px / Timer↔HP 2px の余白）。作者・レビュアー双方でブラウザ目視確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)