### PR TITLE
fix(labyrinth-echo): 初期ステータスを最小1にクランプし run 開始クラッシュを防止 (#141)

### DIFF
--- a/src/features/labyrinth-echo/__tests__/domain/services/unlock-service.test.ts
+++ b/src/features/labyrinth-echo/__tests__/domain/services/unlock-service.test.ts
@@ -117,6 +117,46 @@ describe('UnlockService', () => {
         expect(player.mn).toBe(21); // 33 - 12
       });
     });
+
+    describe('境界値（下限クランプ）', () => {
+      // 再現: abyss(mnMod -20) ＋ 残響圧6(mnMod -6) ＋ lg_elna(mentalBonus -12)
+      // → mn = 33 - 38 = -5 となり、クランプなしでは createPlayer が throw する（Issue #141）
+
+      it('精神力が負になる組み合わせでも throw せず生成できる', () => {
+        // Arrange: BASE_MN(33) を下回る合計修正（mnMod -26 + mentalBonus -12 = -38）
+        const diff = createDomainTestDifficulty({ modifiers: { hpMod: 0, mnMod: -26 } });
+        const fx = createTestFx({ mentalBonus: -12 });
+
+        // Act & Assert
+        expect(() => createNewPlayer(diff, fx)).not.toThrow();
+      });
+
+      it('精神力が負になる場合は mn/maxMn を最小1にクランプする', () => {
+        // Arrange
+        const diff = createDomainTestDifficulty({ modifiers: { hpMod: 0, mnMod: -26 } });
+        const fx = createTestFx({ mentalBonus: -12 });
+
+        // Act
+        const player = createNewPlayer(diff, fx);
+
+        // Assert
+        expect(player.mn).toBe(1);
+        expect(player.maxMn).toBe(1);
+      });
+
+      it('HPが負になる場合は hp/maxHp を最小1にクランプする', () => {
+        // Arrange: BASE_HP(52) を下回る合計修正（hpMod -60）
+        const diff = createDomainTestDifficulty({ modifiers: { hpMod: -60, mnMod: 0 } });
+        const fx = createTestFx();
+
+        // Act
+        const player = createNewPlayer(diff, fx);
+
+        // Assert
+        expect(player.hp).toBe(1);
+        expect(player.maxHp).toBe(1);
+      });
+    });
   });
 
   describe('canPurchaseUnlock', () => {

--- a/src/features/labyrinth-echo/domain/constants/config.ts
+++ b/src/features/labyrinth-echo/domain/constants/config.ts
@@ -11,6 +11,8 @@ export const CFG = Object.freeze({
   BASE_HP: 52,
   BASE_MN: 33,
   BASE_INF: 5,
+  /** 初期ステータス（HP/精神力）の絶対下限。難易度・残響圧・継承の負値積み上げ時のクランプ用 */
+  MIN_START_STAT: 1,
   BOSS_EVENT_ID: "e030",
   MAX_BOSS_RETRIES: 3,
   /** ステータスフラグ: 追加プレフィックス */

--- a/src/features/labyrinth-echo/domain/services/unlock-service.ts
+++ b/src/features/labyrinth-echo/domain/services/unlock-service.ts
@@ -58,11 +58,15 @@ export const computeFx = (unlockIds: readonly string[]): FxState => {
 
 /**
  * プレイヤーの初期ステータスを生成する（Factory パターン）
+ *
+ * 難易度修正（abyss）・残響圧・継承レガシーの負値が積み上がると
+ * BASE 値を下回り 0 以下になりうる（例: abyss + 残響圧6 + lg_elna → mn = -5）。
+ * createPlayer の事後条件 maxHp/maxMn > 0 を満たすため、最小1にクランプする。
  * @post hp > 0 && mn > 0
  */
 export const createNewPlayer = (diff: DifficultyDef, fx: FxState): Player => {
-  const hp = CFG.BASE_HP + fx.hpBonus + diff.modifiers.hpMod;
-  const mn = CFG.BASE_MN + fx.mentalBonus + diff.modifiers.mnMod;
+  const hp = Math.max(CFG.MIN_START_STAT, CFG.BASE_HP + fx.hpBonus + diff.modifiers.hpMod);
+  const mn = Math.max(CFG.MIN_START_STAT, CFG.BASE_MN + fx.mentalBonus + diff.modifiers.mnMod);
   return createPlayer({ hp, maxHp: hp, mn, maxMn: mn, inf: CFG.BASE_INF + fx.infoBonus, statuses: [] });
 };
 

--- a/src/features/labyrinth-echo/simulation/analysis.ts
+++ b/src/features/labyrinth-echo/simulation/analysis.ts
@@ -94,29 +94,17 @@ const buildSurvival = (seeds: number): SurvivalMatrix => {
 };
 
 /**
- * ①-b 継承パワーアップ後の生還率行列（難易度×圧、careful）
+ * 指定 fx の下で「継承なし＋全5レガシー」の最良セル行列（難易度×圧、careful）を構築する。
  *
  * 各セルで「継承なし」と全5レガシーの生還率を測り、最良の選択を best とする
  * （継承なしも選択肢に含めるため delta=best-baseline は常に非負）。
- * bestLegacyId は勝者（none=継承なしが最良）。同率なら継承なしを優先（strict >）。
- */
-/**
- * レガシー込みの生還率。極限セル（例: abyss×圧6 + MN減少レガシー）では maxMn≤0 となり
- * createPlayer の事後条件（mn>0）で throw する＝そのビルドは起動不能。生還率0% として扱う
- * （max 比較で baseline に劣るため best には選ばれない）。本契約違反のみ握り、他例外は再送出。
- */
-const legacySurvivalOrZero = (difficultyId: string, pressure: number, seeds: number, legacy: EchoLegacy, fx: FxState = BASE_FX): number => {
-  try {
-    return survivalRate(difficultyId, pressure, CAREFUL_POLICY, seeds, legacy, fx);
-  } catch (e) {
-    if (e instanceof Error && /must be positive/.test(e.message)) return 0;
-    throw e;
-  }
-};
-
-/**
- * 指定 fx の下で「継承なし＋全5レガシー」の最良セルを構築する共通ロジック。
  * best は baseline（無補助・①と同じ）を起点に max を取るため delta は構築上常に非負。
+ * bestLegacyId は勝者（none=継承なしが最良）。同率なら継承なしを優先（strict >）。
+ *
+ * 極限セル（例: abyss×圧6 + MN減少レガシー）でも、初期ステータスは createNewPlayer が
+ * 最小1にクランプするため起動可能で、精神力1からの実測生還率（ほぼ0%）が算出される。
+ * かつて maxMn≤0 で throw していた契約違反は Issue #141 の根本修正で解消済み。
+ * 例外を握り潰すと本ツールの目的（バグ検出）に反するため、survivalRate を直接呼ぶ。
  * @param fx run に渡す基礎 fx（①-b は BASE_FX、①-c は FULL_FX）
  * @param noLegacyRate 「このfxで継承なし」の生還率（①-b は baseline と同じ、①-c はフル無継承）
  */
@@ -130,7 +118,7 @@ const buildBestLegacyMatrix = (seeds: number, fx: FxState, noLegacyRate: (id: st
       const none = noLegacyRate(id, p);
       if (none > best) { best = none; bestLegacyId = 'none'; }
       for (const l of LEGACIES) {
-        const rate = legacySurvivalOrZero(id, p, seeds, l, fx);
+        const rate = survivalRate(id, p, CAREFUL_POLICY, seeds, l, fx);
         if (rate > best) { best = rate; bestLegacyId = l.id; }
       }
       cells.push({ difficultyId: id, pressure: p, baseline, best, bestLegacyId, delta: best - baseline });


### PR DESCRIPTION
## 概要

迷宮の残響で **abyss（修羅）＋残響圧6＋特定レガシー（lg_twins/lg_elna）** という到達可能な組み合わせを選ぶと、初期精神力が 0 以下となり `createPlayer` の事後条件 `maxMn > 0` で例外が発生、run が開始できなかった不具合を修正します（Issue #141）。

## 原因

`createNewPlayer`（`domain/services/unlock-service.ts`）が hp/mn をクランプせず、難易度修正（abyss `mnMod -20`）＋残響圧6（`mnMod -6`）＋継承（lg_elna `mentalBonus -12`）の負値が積み上がり `mn = 33 - 38 = -5` となっていた。

## 変更内容

- `createNewPlayer` で hp/mn を `CFG.MIN_START_STAT(=1)` で下限クランプ（方針1: 最小侵襲・確実）
- マジックナンバー回避のため `MIN_START_STAT` 定数を `config.ts` に追加
- 境界値テスト3件を追加（精神/HP が負になる場合のクランプ・throw しないこと）

UI（`LabyrinthEchoGame.tsx`）とシミュレーター（`run-simulator.ts`）は共に `createNewPlayer` を経由するため、両方が同時に保護されます。

## 挙動への影響

極端ビルドは精神力1スタートとなり高難度のままですが、run 自体は開始可能になります（仕様内）。

## テスト方法

- [x] `npx jest .../unlock-service.test.ts` → 20 passed（新規3件含む）
- [x] 実値再現（abyss＋圧6＋lg_elna/lg_twins）で throw せず mn=1 を確認
- [x] 迷宮の残響 feature 全テスト 822 passed
- [x] `tsc --noEmit` / `eslint` 対象ファイル エラーなし

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)