### PR TITLE
chore(labyrinth-echo-sim): シミュレーション基盤のマイナー追補（tech debt / Issue #143）

### DIFF
--- a/src/features/labyrinth-echo/__tests__/simulation/analysis.test.ts
+++ b/src/features/labyrinth-echo/__tests__/simulation/analysis.test.ts
@@ -32,12 +32,24 @@ describe('aggregateAll', () => {
     }
   });
 
-  it('レガシー分析: effects は5件、baseline を含む', () => {
+  it('レガシー分析: effects は5件、baseline(P0/P3) は 0..1、取得タイムラインは非空', () => {
     expect(result.legacies.effects.length).toBe(5);
-    expect(typeof result.legacies.baselineP0).toBe('number');
+    // baselineP0/P3 は 0..1 の生還率（型だけでなく値域も検証）
+    for (const baseline of [result.legacies.baselineP0, result.legacies.baselineP3]) {
+      expect(baseline).toBeGreaterThanOrEqual(0);
+      expect(baseline).toBeLessThanOrEqual(1);
+    }
+    // easy×lorehunter の代表キャリアではレガシーが解禁されるため非空（空だと③の意味が失われる）
+    expect(result.legacies.unlockTimeline.length).toBeGreaterThan(0);
+    for (const u of result.legacies.unlockTimeline) {
+      expect(u.legacyId.length).toBeGreaterThan(0);
+      expect(u.runIndex).toBeGreaterThanOrEqual(1);
+    }
   });
 
-  it('エンディング分布: 各行の counts 合計が total に一致', () => {
+  it('エンディング分布: endingIds は非空、各行の counts 合計が total に一致', () => {
+    // 脱出が一定数発生するため到達ENDが1種以上ある（空だと④の集計が成立しない）
+    expect(result.endings.endingIds.length).toBeGreaterThan(0);
     for (const row of result.endings.rows) {
       const sum = Object.values(row.counts).reduce((a, b) => a + b, 0);
       expect(sum).toBe(row.total);

--- a/src/features/labyrinth-echo/__tests__/simulation/invariants.test.ts
+++ b/src/features/labyrinth-echo/__tests__/simulation/invariants.test.ts
@@ -76,12 +76,15 @@ describe('checkCareer 故意の不正を検出', () => {
     expect(checkCareer(bad).some(v => v.rule === 'fragment_monotonic')).toBe(true);
   });
 
-  it('escapes > runs なら error', () => {
+  it('escapes > runs は run_count に統合され error として検出される（escapes_le_runs 廃止: Issue #143）', () => {
     const bad: CareerResult = {
       unlocked: false, runsToUnlock: 2, escapesToUnlock: 3, deathsToUnlock: 0,
       finalDepth: 3, finalFragments: 5, timeline: [baseStep()], legacyUnlocks: [],
     };
-    expect(checkCareer(bad).some(v => v.rule === 'escapes_le_runs')).toBe(true);
+    // escapes(3)+deaths(0) != runs(2) のため run_count が発火する（escapes>runs を含意）
+    expect(checkCareer(bad).some(v => v.rule === 'run_count')).toBe(true);
+    // 廃止したルールはもう存在しない
+    expect(checkCareer(bad).some(v => v.rule === 'escapes_le_runs')).toBe(false);
   });
 });
 
@@ -103,7 +106,8 @@ describe('checkRun', () => {
     expect(checkRun(r).some(v => v.rule === 'fragment_valid')).toBe(true);
   });
   it('未知の cause で error', () => {
-    const r: RunResult = { survived: false, floorReached: 3, endingId: null, cause: 'unknown_cause', events: 1, fragmentsRead: [] };
+    // cause は RunCause 型だが、検出器の動作確認のため意図的に範囲外の値を注入する
+    const r: RunResult = { survived: false, floorReached: 3, endingId: null, cause: 'unknown_cause' as RunResult['cause'], events: 1, fragmentsRead: [] };
     expect(checkRun(r).some(v => v.rule === 'cause_valid')).toBe(true);
   });
 });

--- a/src/features/labyrinth-echo/__tests__/simulation/run-simulator.test.ts
+++ b/src/features/labyrinth-echo/__tests__/simulation/run-simulator.test.ts
@@ -107,7 +107,12 @@ describe('simulateRun fragmentsRead', () => {
       },
     };
     const validIds = new Set(ECHO_FRAGMENTS.map(f => f.id));
-    const r = simulateRun({ difficulty: normal, fx, rng: new SeededRandomSource(3), policy: lorePolicy, events: EVENTS, meta });
-    for (const id of r.fragmentsRead) expect(validIds.has(id)).toBe(true);
+    // echo はレアなため複数シードを跨いで断片を集める（単一シードだと未出現で空配列＝検証が素通りしうる）
+    const collected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap(s =>
+      simulateRun({ difficulty: normal, fx, rng: new SeededRandomSource(s), policy: lorePolicy, events: EVENTS, meta }).fragmentsRead,
+    );
+    // 前提: 少なくとも1件は読めている（0件だと以降の検証が無意味になるためガード）
+    expect(collected.length).toBeGreaterThan(0);
+    for (const id of collected) expect(validIds.has(id)).toBe(true);
   });
 });

--- a/src/features/labyrinth-echo/simulation/invariants.ts
+++ b/src/features/labyrinth-echo/simulation/invariants.ts
@@ -11,6 +11,7 @@ import { ECHO_FRAGMENTS } from '../domain/constants/echo-fragment-defs';
 import { ENDINGS } from '../domain/constants/ending-defs';
 import { TRUE_ENDINGS } from '../domain/constants/true-ending-defs';
 import { CFG } from '../domain/constants/config';
+import { RUN_CAUSE } from './run-cause';
 
 /** 不変条件違反レコード */
 export interface Violation {
@@ -22,7 +23,7 @@ export interface Violation {
 const FRAGMENT_IDS = new Set(ECHO_FRAGMENTS.map(f => f.id));
 const FRAGMENT_TOTAL = ECHO_FRAGMENTS.length; // 19
 const ENDING_IDS = new Set<string>([...ENDINGS.map(e => e.id), ...TRUE_ENDINGS.map(e => e.id)]);
-const KNOWN_CAUSES = new Set(['escape', '体力消耗', '精神崩壊']);
+const KNOWN_CAUSES = new Set<string>(Object.values(RUN_CAUSE));
 
 /** キャリア結果の不変条件を検査する */
 export const checkCareer = (career: CareerResult): Violation[] => {
@@ -45,11 +46,11 @@ export const checkCareer = (career: CareerResult): Violation[] => {
       v.push({ severity: 'error', rule: 'fragment_monotonic', detail: `run ${timeline[i].runIndex}: 断片 ${timeline[i].fragmentCount} < 前周 ${timeline[i - 1].fragmentCount}` });
     }
   }
+  // escapes + deaths = runs を検査する。deaths >= 0 のため、これは escapes <= runs も含意する
+  // （escapes > runs なら escapes + deaths > runs となり必ず本ルールが発火する）。
+  // かつて別に持っていた escapes_le_runs ルールは独立した信号を増やさないため統合・削除した（Issue #143）。
   if (career.escapesToUnlock + career.deathsToUnlock !== career.runsToUnlock) {
     v.push({ severity: 'error', rule: 'run_count', detail: `escapes(${career.escapesToUnlock}) + deaths(${career.deathsToUnlock}) != runs(${career.runsToUnlock})` });
-  }
-  if (career.escapesToUnlock > career.runsToUnlock) {
-    v.push({ severity: 'error', rule: 'escapes_le_runs', detail: `escapes(${career.escapesToUnlock}) > runs(${career.runsToUnlock})` });
   }
   if (career.unlocked && (career.finalDepth !== ECHO_DEPTH_MAX || career.finalFragments !== FRAGMENT_TOTAL)) {
     v.push({ severity: 'error', rule: 'true_route_condition', detail: `解禁時 depth=${career.finalDepth}(要${ECHO_DEPTH_MAX}) 断片=${career.finalFragments}(要${FRAGMENT_TOTAL})` });

--- a/src/features/labyrinth-echo/simulation/report/render-html.ts
+++ b/src/features/labyrinth-echo/simulation/report/render-html.ts
@@ -27,9 +27,13 @@ const esc = (s: string): string =>
 
 const pct = (x: number): string => (x * 100).toFixed(1) + '%';
 
-/** 横棒（div幅%）。0..1 を受け取る */
+/**
+ * 横棒（div幅%）。0..1 を受け取る。
+ * color は現状すべて hex リテラルだが、style 属性へ注入するため esc() で安全側に倒す
+ * （将来データ由来の色を渡しても属性ブレイクアウトを防ぐ）。
+ */
 const bar = (ratio: number, color: string): string =>
-  `<div class="bar"><div class="bar-fill" style="width:${Math.round(ratio * 100)}%;background:${color}"></div></div>`;
+  `<div class="bar"><div class="bar-fill" style="width:${Math.round(ratio * 100)}%;background:${esc(color)}"></div></div>`;
 
 const renderSurvival = (m: SurvivalMatrix): string => {
   const head = `<tr><th>難易度＼圧</th>${m.pressures.map(p => `<th>圧${p}</th>`).join('')}</tr>`;

--- a/src/features/labyrinth-echo/simulation/run-cause.ts
+++ b/src/features/labyrinth-echo/simulation/run-cause.ts
@@ -1,0 +1,21 @@
+/**
+ * 迷宮の残響 - ラン終了原因（cause）の共有定数
+ *
+ * run-simulator が結果に書き込む cause と、invariants が検証する既知 cause 集合は
+ * 同一の文字列でなければならない。両者でリテラルを二重定義すると、生成側を変えた際に
+ * 検証側が古いままになり「未知の cause」を誤検出する（ドリフト）。
+ * 単一ソースとしてここに集約する。
+ */
+
+/** ラン終了原因（脱出・体力消耗・精神崩壊） */
+export const RUN_CAUSE = Object.freeze({
+  /** 脱出成功（survived=true） */
+  ESCAPE: 'escape',
+  /** HP が尽きて死亡 */
+  HP_DEPLETED: '体力消耗',
+  /** MN が尽きて精神崩壊 */
+  MN_DEPLETED: '精神崩壊',
+});
+
+/** RUN_CAUSE の値のユニオン型 */
+export type RunCause = (typeof RUN_CAUSE)[keyof typeof RUN_CAUSE];

--- a/src/features/labyrinth-echo/simulation/run-simulator.ts
+++ b/src/features/labyrinth-echo/simulation/run-simulator.ts
@@ -17,6 +17,8 @@ import { createMetaState } from '../domain/models/meta-state';
 import { applyPressureToDifficulty } from '../domain/services/pressure-service';
 import { mergeLegacyIntoFx } from '../domain/services/legacy-service';
 import { CFG } from '../domain/constants/config';
+import { RUN_CAUSE } from './run-cause';
+import type { RunCause } from './run-cause';
 import type { Player } from '../domain/models/player';
 import type { DifficultyDef } from '../domain/models/difficulty';
 import type { FxState } from '../domain/models/unlock';
@@ -30,8 +32,8 @@ export interface RunResult {
   readonly survived: boolean;
   readonly floorReached: number;
   readonly endingId: string | null;
-  /** "escape" | "体力消耗" | "精神崩壊" */
-  readonly cause: string;
+  /** ラン終了原因（RUN_CAUSE のいずれか） */
+  readonly cause: RunCause;
   /** 消化したイベント数 */
   readonly events: number;
   /** 探索中に「読み解いた」断片 id 群（キャリアシミュレーション用） */
@@ -107,7 +109,7 @@ export const simulateRun = (params: {
 
   let event = pickEvent({ events: [...events], floor, usedIds, meta, fx, rng, pressure });
 
-  const fail = (cause: string): RunResult =>
+  const fail = (cause: RunCause): RunResult =>
     ({ survived: false, floorReached: floor, endingId: null, cause, events: eventsConsumed, fragmentsRead });
 
   while (event) {
@@ -127,10 +129,10 @@ export const simulateRun = (params: {
       // なので、消化数長の合成ログを渡して log ベース END（歴戦の探索者）も sim で評価可能にする。
       const syntheticLog: LogEntry[] = Array.from({ length: eventsConsumed }, () => SYNTHETIC_LOG_ENTRY);
       const endingId = determineEnding(player, syntheticLog, difficulty).id;
-      return { survived: true, floorReached: floor, endingId, cause: 'escape', events: eventsConsumed, fragmentsRead };
+      return { survived: true, floorReached: floor, endingId, cause: RUN_CAUSE.ESCAPE, events: eventsConsumed, fragmentsRead };
     }
     if (player.hp <= 0 || player.mn <= 0) {
-      return fail(player.hp <= 0 ? '体力消耗' : '精神崩壊');
+      return fail(player.hp <= 0 ? RUN_CAUSE.HP_DEPLETED : RUN_CAUSE.MN_DEPLETED);
     }
 
     // チェイン優先（step を進めるが floor は進めない: useProceed と同じ）
@@ -160,7 +162,7 @@ export const simulateRun = (params: {
     usedIds = [...usedIds, event.id];
     if (nextFloor > CFG.MAX_FLOOR) {
       const r = resolveBossStep(usedIds, floor, events, fx, rng, pressure, meta);
-      if ('gameover' in r) return fail('精神崩壊');
+      if ('gameover' in r) return fail(RUN_CAUSE.MN_DEPLETED);
       step = nextStep; event = r.event;
       continue;
     }
@@ -168,5 +170,5 @@ export const simulateRun = (params: {
     event = pickEvent({ events: [...events], floor, usedIds, meta, fx, rng, pressure });
   }
   // プール枯渇 = 探索続行不能
-  return fail('精神崩壊');
+  return fail(RUN_CAUSE.MN_DEPLETED);
 };


### PR DESCRIPTION
## 概要

PR #140（迷宮の残響 シミュレーション・レポート基盤）のレビューで挙がった軽微な tech debt 4 項目（Issue #143）を解消します。いずれも現状の正確性には影響しない非ブロッキング項目で、保守性と将来の堅牢性を改善します。

Closes #143

## 変更内容

| 項目 | 対応 |
|------|------|
| ① `escapes_le_runs` の冗長性 | **削除**。`escapes>runs` は `run_count`（`escapes+deaths≠runs`）が `deaths≥0` より数学的に含意するため独立信号を増やさない。統合理由をコメントで明記 |
| ② `KNOWN_CAUSES` のハードコード | 共有定数 `RUN_CAUSE` を `run-cause.ts` に抽出。`run-simulator`（生成）と `invariants`（検証）の cause 二重定義を単一ソース化しドリフトを防止。併せて `RunResult.cause` を `string`→`RunCause` ユニオン型に昇格 |
| ③ `bar()` の `color` 未エスケープ | `esc(color)` でラップし style 属性のブレイクアウトを防御（既存の `esc` 統一パターンに整合） |
| ④ 一部テストの浅さ | `run-simulator.test.ts` の seed=3 vacuous pass を**複数シード集約＋非空ガード**に修正。`analysis.test.ts` の `unlockTimeline`/`baselineP0,P3`/`endingIds` に非空・値域アサートを追加 |

### 補足
- 残る `'体力消耗'`/`'精神崩壊'` リテラルはプロダクション側 `DeathCause` 型・presentation テストであり、Issue が対象とした sim 内の重複とは別レイヤーのため据え置き（sim をドメイン層へ結合させない）。

## テスト方法

- [x] `npx tsc --noEmit`：エラーなし
- [x] `npx eslint --max-warnings 0`（変更全ファイル）：clean
- [x] `npx jest src/features/labyrinth-echo/__tests__/simulation/`：全7スイート **67 テスト pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)