### PR TITLE
fix(air-hockey): 障害物リスポーンテストのフレーキーを解消

### DIFF
--- a/src/features/air-hockey/__tests__/integration/obstacle.test.ts
+++ b/src/features/air-hockey/__tests__/integration/obstacle.test.ts
@@ -81,9 +81,14 @@ describe('障害物ライフサイクル統合テスト', () => {
       destroyedAt: 0, // フレーム0で破壊
     });
 
-    // Act: リスポーン時間（5000ms = 約312フレーム @16ms）以上実行
-    // 16ms/フレームなので 5000/16 ≈ 313 フレーム
-    runner.runFrames(320);
+    // パックを中央の障害物から遠ざけて静止させる
+    // （復活直後にパックが再衝突して hp が減る非決定的なフレークを防ぐ）
+    runner.setPuckPosition(0, 40, 800);
+    runner.setPuckVelocity(0, 0, 0);
+
+    // Act: リスポーン時間（5000ms = 16ms/フレームで 313 フレーム）を
+    // 1 フレームだけ超えて実行し、復活後の余剰フレームを最小化する
+    runner.runFrames(314);
 
     // Assert: 障害物が復活している
     const newState = runner.getState();


### PR DESCRIPTION
## 概要
`obstacle.test.ts`「破壊された障害物がリスポーン時間後に復活する」が CI で稀に失敗する（PR #153 のランで観測: `expect(hp).toBe(3)` が 2 で失敗、`destroyed=false` はパス）。

原因はテスト内のレース条件: 障害物（フィールド中央）のリスポーン 5000ms ≒ 313 フレームに対し 320 フレーム実行するため、復活後の残り約7フレームで AI が動かすパックが障害物に再衝突すると hp が 3→2 に減る。

## 変更内容
- パックを中央の障害物から遠ざけて静止させる（`setPuckPosition(0, 40, 800)` + 速度ゼロ）
- 実行フレームを 320 → 314 に短縮し、復活後の余剰フレームを1フレームに最小化
- テストの検証意図（リスポーン時間経過で hp=maxHp で復活する）は不変

## テスト方法
- [x] `obstacle.test.ts` を5回連続実行し全パス（3 passed × 5）
- [ ] CI 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)