### PR TITLE
feat: Picture Puzzle フェーズ2 収蔵コレクション

### DIFF
--- a/docs/superpowers/plans/2026-07-08-picture-puzzle-gallery-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-picture-puzzle-gallery-phase2.md
@@ -1,0 +1,1374 @@
+# Picture Puzzle フェーズ2「収蔵コレクション」Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 既存のクリア記録を美術館メタファーの「収蔵目録」独立ビューへ読み替え、展示室ごとの収蔵率と名誉学芸員（段階ゴール）を可視化する。
+
+**Architecture:** 新規永続データを足さず、`puzzle_records`・`themes`・`puzzle_total_clears` を読み取り、ドメイン純粋関数 `collection-service` で「作品単位」に集約する。UI は `PuzzlePageContainer` 配下に独立ビュー `CollectionView` を追加し、gallery テーマを自動適用する。
+
+**Tech Stack:** React 19 + TypeScript + styled-components + Jotai。テストは Jest 30 + @testing-library/react。
+
+## Global Constraints
+
+- 応答・コメント・ドキュメントは日本語。コード（変数・関数名）は英語可。
+- `any` 型禁止（`unknown` + 型ガード）。`null` より `undefined` を優先（外部境界を除く）。
+- 名前付きエクスポートを優先。関数コンポーネントのみ。Props は型定義必須。
+- **安全境界（厳守）**: 変更は picture-puzzle 専用コードに閉じる。以下は触らない: `src/styles/GlobalStyle.ts` / `src/styles/tokens/*` / `src/App.tsx` / `src/pages/GameListPage.tsx` / `src/features/*`。
+- 新規 localStorage キーを追加しない（読み取り専用の派生計算のみ）。
+- 結合キー: `PuzzleRecord.imageId` == `themes[].images[].id`。収蔵判定は `clearCount > 0`。
+- ランクの優劣順序: `★★★` > `★★☆` > `★☆☆` > `クリア`。
+- TDD（Red→Green→Refactor）。ドメイン 90%+、新規コード 80%+。コミットは Conventional Commits。
+- 全展示室=6室、全作品=15点。名誉学芸員は段階ゴール（第1目標=全15点収蔵／最上位=全15点★★★収蔵）。
+
+---
+
+### Task 1: ドメイン型定義（collection/types.ts）
+
+**Files:**
+- Create: `src/domain/collection/types.ts`
+
+**Interfaces:**
+- Produces:
+  - `ArtworkStatus` — 作品1点の集約結果
+  - `RoomCollection` — 展示室1室の収蔵状況
+  - `CuratorGoal` — 名誉学芸員の進捗
+  - `CollectionSummary` — ビューが受け取る集約全体
+
+- [ ] **Step 1: 型定義ファイルを作成する**
+
+```typescript
+// src/domain/collection/types.ts
+import { PuzzleRank } from '../../types/puzzle';
+
+/** 作品1点の収蔵状況（同一 imageId の複数難易度レコードを集約した結果） */
+export interface ArtworkStatus {
+  readonly imageId: string;
+  /** themes から引いた表示名（alt を流用） */
+  readonly title: string;
+  /** サムネイル用ファイル名 */
+  readonly filename: string;
+  /** 1回以上クリア済みか */
+  readonly isCollected: boolean;
+  /** 集約後の最高鑑定評価（未収蔵は undefined） */
+  readonly bestRank?: PuzzleRank;
+  /** 集約後のベストスコア最大値 */
+  readonly bestScore: number;
+  /** 集約後のベストタイム最小値（未収蔵は undefined） */
+  readonly bestTime?: number;
+  /** 集約後の最少手数（未取得は undefined） */
+  readonly bestMoves?: number;
+  /** 全難易度合算のクリア回数 */
+  readonly clearCount: number;
+  /** 最終クリア日時（ISO文字列・未収蔵は undefined） */
+  readonly lastClearDate?: string;
+}
+
+/** 展示室1室の収蔵状況 */
+export interface RoomCollection {
+  readonly themeId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly isUnlocked: boolean;
+  /** 未開館時の解放条件文言（開館済みは undefined） */
+  readonly unlockHint?: string;
+  readonly collectedCount: number;
+  readonly totalCount: number;
+  readonly artworks: readonly ArtworkStatus[];
+}
+
+/** 名誉学芸員（段階ゴール）の進捗 */
+export interface CuratorGoal {
+  /** 収蔵済み作品数 */
+  readonly collected: number;
+  /** ★★★収蔵の作品数 */
+  readonly appraised3star: number;
+  /** 全作品数（=15） */
+  readonly total: number;
+  /** 全作品を★★★収蔵したか */
+  readonly isHonorary: boolean;
+}
+
+/** 収蔵目録ビューが受け取る集約全体 */
+export interface CollectionSummary {
+  readonly rooms: readonly RoomCollection[];
+  readonly goal: CuratorGoal;
+}
+```
+
+- [ ] **Step 2: 型チェックが通ることを確認する**
+
+Run: `npm run typecheck`
+Expected: PASS（エラーなし）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/domain/collection/types.ts
+git commit -m "feat: 収蔵コレクションのドメイン型を定義"
+```
+
+---
+
+### Task 2: 作品単位の集約（aggregateByArtwork）
+
+**Files:**
+- Create: `src/domain/collection/collection-service.ts`
+- Test: `src/domain/collection/collection-service.test.ts`
+
+**Interfaces:**
+- Consumes: `PuzzleRecord`（`src/types/puzzle.ts`）, `PuzzleImage`, `ArtworkStatus`（Task 1）
+- Produces:
+  - `compareRank(a: PuzzleRank, b: PuzzleRank): number` — 優劣比較（a が上位なら正）
+  - `aggregateByArtwork(image: PuzzleImage, records: readonly PuzzleRecord[]): ArtworkStatus`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```typescript
+// src/domain/collection/collection-service.test.ts
+import { aggregateByArtwork, compareRank } from './collection-service';
+import { PuzzleImage, PuzzleRecord } from '../../types/puzzle';
+
+const image: PuzzleImage = {
+  id: 'moonlight_dancer',
+  filename: 'moonlight_dancer.webp',
+  alt: '月明かりのダンサー',
+  themeId: 'illustration-gallery',
+  hasVideo: true,
+};
+
+const rec = (over: Partial<PuzzleRecord>): PuzzleRecord => ({
+  imageId: 'moonlight_dancer',
+  division: 4,
+  bestScore: 1000,
+  bestRank: 'クリア',
+  bestTime: 100,
+  bestMoves: 50,
+  clearCount: 1,
+  lastClearDate: '2026-07-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('compareRank', () => {
+  it('★★★ は クリア より上位', () => {
+    expect(compareRank('★★★', 'クリア')).toBeGreaterThan(0);
+  });
+  it('同ランクは 0', () => {
+    expect(compareRank('★☆☆', '★☆☆')).toBe(0);
+  });
+});
+
+describe('aggregateByArtwork', () => {
+  it('レコードなしは未収蔵として畳む', () => {
+    const result = aggregateByArtwork(image, []);
+    expect(result.isCollected).toBe(false);
+    expect(result.clearCount).toBe(0);
+    expect(result.bestRank).toBeUndefined();
+    expect(result.title).toBe('月明かりのダンサー');
+    expect(result.filename).toBe('moonlight_dancer.webp');
+  });
+
+  it('複数難易度のレコードを最良値へ集約する', () => {
+    const records = [
+      rec({ division: 3, bestScore: 2000, bestRank: '★☆☆', bestTime: 120, bestMoves: 60, clearCount: 2, lastClearDate: '2026-07-01T00:00:00.000Z' }),
+      rec({ division: 5, bestScore: 5000, bestRank: '★★★', bestTime: 80, bestMoves: 40, clearCount: 3, lastClearDate: '2026-07-05T00:00:00.000Z' }),
+    ];
+    const result = aggregateByArtwork(image, records);
+    expect(result.isCollected).toBe(true);
+    expect(result.bestScore).toBe(5000);
+    expect(result.bestRank).toBe('★★★');
+    expect(result.bestTime).toBe(80);
+    expect(result.bestMoves).toBe(40);
+    expect(result.clearCount).toBe(5);
+    expect(result.lastClearDate).toBe('2026-07-05T00:00:00.000Z');
+  });
+
+  it('bestMoves が全て null なら undefined', () => {
+    const result = aggregateByArtwork(image, [rec({ bestMoves: null })]);
+    expect(result.bestMoves).toBeUndefined();
+  });
+
+  it('別 imageId のレコードは無視する', () => {
+    const other = rec({ imageId: 'other_image', clearCount: 9 });
+    const result = aggregateByArtwork(image, [other]);
+    expect(result.isCollected).toBe(false);
+    expect(result.clearCount).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- collection-service`
+Expected: FAIL（`aggregateByArtwork`/`compareRank` が未定義）
+
+- [ ] **Step 3: 最小実装を書く**
+
+```typescript
+// src/domain/collection/collection-service.ts
+import { PuzzleImage, PuzzleRank, PuzzleRecord } from '../../types/puzzle';
+import { ArtworkStatus } from './types';
+
+/** ランクの優劣順序（大きいほど上位） */
+const RANK_ORDER: Record<PuzzleRank, number> = {
+  'クリア': 0,
+  '★☆☆': 1,
+  '★★☆': 2,
+  '★★★': 3,
+};
+
+/** ランクを比較する。a が上位なら正、同位で 0、下位で負 */
+export const compareRank = (a: PuzzleRank, b: PuzzleRank): number =>
+  RANK_ORDER[a] - RANK_ORDER[b];
+
+/**
+ * 1作品（imageId）について、全難易度のレコードを最良値へ集約する。
+ * 収蔵判定は clearCount > 0。表示名は image.alt を流用する。
+ */
+export const aggregateByArtwork = (
+  image: PuzzleImage,
+  records: readonly PuzzleRecord[]
+): ArtworkStatus => {
+  const mine = records.filter(r => r.imageId === image.id && r.clearCount > 0);
+  const base = {
+    imageId: image.id,
+    title: image.alt,
+    filename: image.filename,
+  };
+
+  if (mine.length === 0) {
+    return { ...base, isCollected: false, bestScore: 0, clearCount: 0 };
+  }
+
+  const bestScore = Math.max(...mine.map(r => r.bestScore));
+  const bestRank = mine
+    .map(r => r.bestRank)
+    .reduce((best, cur) => (compareRank(cur, best) > 0 ? cur : best));
+  const bestTime = Math.min(...mine.map(r => r.bestTime));
+  const moves = mine.map(r => r.bestMoves).filter((m): m is number => m !== null);
+  const bestMoves = moves.length > 0 ? Math.min(...moves) : undefined;
+  const clearCount = mine.reduce((sum, r) => sum + r.clearCount, 0);
+  const lastClearDate = mine
+    .map(r => r.lastClearDate)
+    .reduce((latest, cur) => (cur > latest ? cur : latest));
+
+  return {
+    ...base,
+    isCollected: true,
+    bestRank,
+    bestScore,
+    bestTime,
+    bestMoves,
+    clearCount,
+    lastClearDate,
+  };
+};
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+Run: `npm test -- collection-service`
+Expected: PASS（6件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/domain/collection/collection-service.ts src/domain/collection/collection-service.test.ts
+git commit -m "feat: 作品単位の収蔵集約 aggregateByArtwork を実装"
+```
+
+---
+
+### Task 3: 展示室ごとの収蔵状況（buildRoomCollections）
+
+**Files:**
+- Modify: `src/domain/collection/collection-service.ts`
+- Test: `src/domain/collection/collection-service.test.ts`（追記）
+
+**Interfaces:**
+- Consumes: `Theme`, `PuzzleRecord`, `ThemeId`（`src/types/puzzle.ts`）, `isThemeUnlocked` + `UnlockContext`（`src/domain/theme/theme-unlock-service.ts`）, `aggregateByArtwork`（Task 2）
+- Produces:
+  - `buildRoomCollections(themes: readonly Theme[], records: readonly PuzzleRecord[], totalClears: number): RoomCollection[]`
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+```typescript
+// src/domain/collection/collection-service.test.ts に追記
+import { buildRoomCollections } from './collection-service';
+import { Theme } from '../../types/puzzle';
+
+const twoRoomThemes: Theme[] = [
+  {
+    id: 'illustration-gallery',
+    name: 'イラストギャラリー',
+    description: 'desc-a',
+    unlockCondition: { type: 'always' },
+    images: [
+      { id: 'img_a1', filename: 'a1.webp', alt: 'A1', themeId: 'illustration-gallery', hasVideo: false },
+      { id: 'img_a2', filename: 'a2.webp', alt: 'A2', themeId: 'illustration-gallery', hasVideo: false },
+    ],
+  },
+  {
+    id: 'sea-and-sky',
+    name: '海と空',
+    description: 'desc-b',
+    unlockCondition: { type: 'clearCount', count: 5 },
+    images: [
+      { id: 'img_b1', filename: 'b1.webp', alt: 'B1', themeId: 'sea-and-sky', hasVideo: false },
+    ],
+  },
+];
+
+const clearedRecord = (imageId: string): PuzzleRecord => ({
+  imageId,
+  division: 4,
+  bestScore: 3000,
+  bestRank: '★★☆',
+  bestTime: 90,
+  bestMoves: 30,
+  clearCount: 1,
+  lastClearDate: '2026-07-06T00:00:00.000Z',
+});
+
+describe('buildRoomCollections', () => {
+  it('開館室は収蔵率を、未開館室は解放条件文言を返す', () => {
+    const rooms = buildRoomCollections(twoRoomThemes, [clearedRecord('img_a1')], 1);
+    const roomA = rooms.find(r => r.themeId === 'illustration-gallery')!;
+    const roomB = rooms.find(r => r.themeId === 'sea-and-sky')!;
+
+    expect(roomA.isUnlocked).toBe(true);
+    expect(roomA.unlockHint).toBeUndefined();
+    expect(roomA.collectedCount).toBe(1);
+    expect(roomA.totalCount).toBe(2);
+    expect(roomA.artworks[0].isCollected).toBe(true);
+    expect(roomA.artworks[1].isCollected).toBe(false);
+
+    expect(roomB.isUnlocked).toBe(false);
+    expect(roomB.unlockHint).toContain('5');
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- collection-service`
+Expected: FAIL（`buildRoomCollections` が未定義）
+
+- [ ] **Step 3: 最小実装を追記する**
+
+```typescript
+// src/domain/collection/collection-service.ts に追記
+import { Theme, ThemeId } from '../../types/puzzle';
+import { isThemeUnlocked, UnlockContext } from '../theme/theme-unlock-service';
+import { RoomCollection } from './types';
+
+/** 未開館室の解放条件文言を生成する */
+const buildUnlockHint = (theme: Theme, totalClears: number): string => {
+  const cond = theme.unlockCondition;
+  if (cond.type === 'clearCount') {
+    return `あと ${Math.max(0, cond.count - totalClears)} 点で開館（${cond.count}回クリア）`;
+  }
+  if (cond.type === 'themesClear') {
+    return '全展示室で1点以上収蔵すると開館';
+  }
+  return '';
+};
+
+/**
+ * 展示室ごとの収蔵状況を構築する。
+ * アンロック判定は既存 theme-unlock-service を再利用する。
+ */
+export const buildRoomCollections = (
+  themes: readonly Theme[],
+  records: readonly PuzzleRecord[],
+  totalClears: number
+): RoomCollection[] => {
+  const themeImageIds = new Map<ThemeId, string[]>();
+  for (const theme of themes) {
+    themeImageIds.set(theme.id, theme.images.map(img => img.id));
+  }
+  const context: UnlockContext = { totalClears, records, themeImageIds };
+
+  return themes.map(theme => {
+    const isUnlocked = isThemeUnlocked(theme.unlockCondition, context);
+    const artworks = theme.images.map(img => aggregateByArtwork(img, records));
+    const collectedCount = artworks.filter(a => a.isCollected).length;
+    return {
+      themeId: theme.id,
+      name: theme.name,
+      description: theme.description,
+      isUnlocked,
+      unlockHint: isUnlocked ? undefined : buildUnlockHint(theme, totalClears),
+      collectedCount,
+      totalCount: theme.images.length,
+      artworks,
+    };
+  });
+};
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+Run: `npm test -- collection-service`
+Expected: PASS（既存 + 1件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/domain/collection/collection-service.ts src/domain/collection/collection-service.test.ts
+git commit -m "feat: 展示室ごとの収蔵状況 buildRoomCollections を実装"
+```
+
+---
+
+### Task 4: 名誉学芸員ゴール判定と集約全体（evaluateCuratorGoal / buildCollectionSummary）
+
+**Files:**
+- Modify: `src/domain/collection/collection-service.ts`
+- Test: `src/domain/collection/collection-service.test.ts`（追記）
+
+**Interfaces:**
+- Consumes: `buildRoomCollections`（Task 3）, `CuratorGoal`, `CollectionSummary`（Task 1）
+- Produces:
+  - `evaluateCuratorGoal(rooms: readonly RoomCollection[]): CuratorGoal`
+  - `buildCollectionSummary(themes, records, totalClears): CollectionSummary`
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+```typescript
+// src/domain/collection/collection-service.test.ts に追記
+import { evaluateCuratorGoal, buildCollectionSummary } from './collection-service';
+
+describe('evaluateCuratorGoal / buildCollectionSummary', () => {
+  it('全作品★★★で名誉学芸員を達成する', () => {
+    const summary = buildCollectionSummary(
+      twoRoomThemes,
+      [
+        { ...clearedRecord('img_a1'), bestRank: '★★★' },
+        { ...clearedRecord('img_a2'), bestRank: '★★★' },
+        { ...clearedRecord('img_b1'), bestRank: '★★★' },
+      ],
+      5
+    );
+    expect(summary.goal.total).toBe(3);
+    expect(summary.goal.collected).toBe(3);
+    expect(summary.goal.appraised3star).toBe(3);
+    expect(summary.goal.isHonorary).toBe(true);
+    expect(summary.rooms).toHaveLength(2);
+  });
+
+  it('一部のみ収蔵なら名誉学芸員は未達', () => {
+    const summary = buildCollectionSummary(twoRoomThemes, [clearedRecord('img_a1')], 1);
+    expect(summary.goal.collected).toBe(1);
+    expect(summary.goal.appraised3star).toBe(0);
+    expect(summary.goal.isHonorary).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- collection-service`
+Expected: FAIL（`evaluateCuratorGoal`/`buildCollectionSummary` が未定義）
+
+- [ ] **Step 3: 最小実装を追記する**
+
+```typescript
+// src/domain/collection/collection-service.ts に追記
+import { CuratorGoal, CollectionSummary } from './types';
+
+/** 全展示室の収蔵状況から名誉学芸員の進捗を評価する */
+export const evaluateCuratorGoal = (
+  rooms: readonly RoomCollection[]
+): CuratorGoal => {
+  const artworks = rooms.flatMap(room => room.artworks);
+  const total = artworks.length;
+  const collected = artworks.filter(a => a.isCollected).length;
+  const appraised3star = artworks.filter(a => a.bestRank === '★★★').length;
+  return {
+    collected,
+    appraised3star,
+    total,
+    isHonorary: total > 0 && appraised3star === total,
+  };
+};
+
+/** 収蔵目録ビュー向けの集約全体を構築する */
+export const buildCollectionSummary = (
+  themes: readonly Theme[],
+  records: readonly PuzzleRecord[],
+  totalClears: number
+): CollectionSummary => {
+  const rooms = buildRoomCollections(themes, records, totalClears);
+  return { rooms, goal: evaluateCuratorGoal(rooms) };
+};
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+Run: `npm test -- collection-service`
+Expected: PASS（全件）
+
+- [ ] **Step 5: カバレッジを確認する**
+
+Run: `npm test -- collection-service --coverage --collectCoverageFrom='src/domain/collection/collection-service.ts'`
+Expected: collection-service.ts の statements 90%+
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/domain/collection/collection-service.ts src/domain/collection/collection-service.test.ts
+git commit -m "feat: 名誉学芸員ゴール判定と集約全体を実装"
+```
+
+---
+
+### Task 5: 作品フレーム コンポーネント（ArtworkFrame）
+
+**Files:**
+- Create: `src/components/molecules/ArtworkFrame.tsx`
+- Create: `src/components/molecules/ArtworkFrame.styles.ts`
+- Test: `src/components/molecules/ArtworkFrame.test.tsx`
+
+**Interfaces:**
+- Consumes: `ArtworkStatus`（Task 1）, `ArtFrame`（`src/components/molecules/ArtFrame`）, `galleryTokens`（`src/pages/gallery-theme`）
+- Produces: `ArtworkFrame`（default export）— props `{ artwork: ArtworkStatus }`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```tsx
+// src/components/molecules/ArtworkFrame.test.tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ArtworkFrame from './ArtworkFrame';
+import { ArtworkStatus } from '../../domain/collection/types';
+
+const collected: ArtworkStatus = {
+  imageId: 'moonlight_dancer',
+  title: '月明かりのダンサー',
+  filename: 'moonlight_dancer.webp',
+  isCollected: true,
+  bestRank: '★★★',
+  bestScore: 5000,
+  bestTime: 80,
+  bestMoves: 40,
+  clearCount: 3,
+  lastClearDate: '2026-07-05T00:00:00.000Z',
+};
+
+const notCollected: ArtworkStatus = {
+  imageId: 'unseen',
+  title: '未収蔵の作品',
+  filename: 'unseen.webp',
+  isCollected: false,
+  bestScore: 0,
+  clearCount: 0,
+};
+
+describe('ArtworkFrame', () => {
+  it('収蔵済みは画像と鑑定評価を表示する', () => {
+    render(<ArtworkFrame artwork={collected} />);
+    const img = screen.getByAltText('月明かりのダンサー') as HTMLImageElement;
+    expect(img.src).toContain('/images/default/moonlight_dancer.webp');
+    expect(screen.getByText('★★★')).toBeInTheDocument();
+  });
+
+  it('未収蔵は空フレーム（画像なし）を表示する', () => {
+    render(<ArtworkFrame artwork={notCollected} />);
+    expect(screen.queryByAltText('未収蔵の作品')).not.toBeInTheDocument();
+    expect(screen.getByText('未収蔵')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- ArtworkFrame`
+Expected: FAIL（モジュール未解決）
+
+- [ ] **Step 3: スタイルを実装する**
+
+```typescript
+// src/components/molecules/ArtworkFrame.styles.ts
+import styled from 'styled-components';
+import { galleryTokens } from '../../pages/gallery-theme';
+
+export const FrameFigure = styled.figure`
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const Thumb = styled.img`
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+/** 未収蔵の空フレーム内側 */
+export const EmptySlot = styled.div`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${galleryTokens.sub};
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  background: repeating-linear-gradient(
+    45deg,
+    ${galleryTokens.mat},
+    ${galleryTokens.mat} 8px,
+    ${galleryTokens.cream} 8px,
+    ${galleryTokens.cream} 16px
+  );
+`;
+
+export const Caption = styled.figcaption`
+  font-size: 0.72rem;
+  color: ${galleryTokens.sub};
+  text-align: center;
+`;
+
+export const Rank = styled.span`
+  color: ${galleryTokens.gold};
+  letter-spacing: 0.1em;
+`;
+```
+
+- [ ] **Step 4: コンポーネントを実装する**
+
+```tsx
+// src/components/molecules/ArtworkFrame.tsx
+import React from 'react';
+import { ArtFrame } from './ArtFrame';
+import { ArtworkStatus } from '../../domain/collection/types';
+import { FrameFigure, Thumb, EmptySlot, Caption, Rank } from './ArtworkFrame.styles';
+
+export interface ArtworkFrameProps {
+  readonly artwork: ArtworkStatus;
+}
+
+/** 収蔵目録の作品1点。収蔵済みは額装画像＋鑑定評価、未収蔵は空フレーム */
+const ArtworkFrame: React.FC<ArtworkFrameProps> = ({ artwork }) => (
+  <FrameFigure>
+    <ArtFrame>
+      {artwork.isCollected ? (
+        <Thumb src={`/images/default/${artwork.filename}`} alt={artwork.title} />
+      ) : (
+        <EmptySlot>未収蔵</EmptySlot>
+      )}
+    </ArtFrame>
+    <Caption>
+      {artwork.isCollected && artwork.bestRank ? (
+        <Rank>{artwork.bestRank}</Rank>
+      ) : (
+        artwork.title
+      )}
+    </Caption>
+  </FrameFigure>
+);
+
+export default ArtworkFrame;
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+Run: `npm test -- ArtworkFrame`
+Expected: PASS（2件）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/components/molecules/ArtworkFrame.tsx src/components/molecules/ArtworkFrame.styles.ts src/components/molecules/ArtworkFrame.test.tsx
+git commit -m "feat: 収蔵作品フレーム ArtworkFrame を実装"
+```
+
+---
+
+### Task 6: 名誉学芸員バナー（CuratorGoalBanner）
+
+**Files:**
+- Create: `src/components/molecules/CuratorGoalBanner.tsx`
+- Create: `src/components/molecules/CuratorGoalBanner.styles.ts`
+- Test: `src/components/molecules/CuratorGoalBanner.test.tsx`
+
+**Interfaces:**
+- Consumes: `CuratorGoal`（Task 1）, `galleryTokens`
+- Produces: `CuratorGoalBanner`（default export）— props `{ goal: CuratorGoal }`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```tsx
+// src/components/molecules/CuratorGoalBanner.test.tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CuratorGoalBanner from './CuratorGoalBanner';
+import { CuratorGoal } from '../../domain/collection/types';
+
+describe('CuratorGoalBanner', () => {
+  it('収蔵コンプと★★★コンプの2段進捗を表示する', () => {
+    const goal: CuratorGoal = { collected: 12, appraised3star: 4, total: 15, isHonorary: false };
+    render(<CuratorGoalBanner goal={goal} />);
+    expect(screen.getByText('12 / 15')).toBeInTheDocument();
+    expect(screen.getByText('4 / 15')).toBeInTheDocument();
+    expect(screen.queryByText(/名誉学芸員に認定/)).not.toBeInTheDocument();
+  });
+
+  it('名誉学芸員達成時は称号を表示する', () => {
+    const goal: CuratorGoal = { collected: 15, appraised3star: 15, total: 15, isHonorary: true };
+    render(<CuratorGoalBanner goal={goal} />);
+    expect(screen.getByText(/名誉学芸員に認定/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- CuratorGoalBanner`
+Expected: FAIL（モジュール未解決）
+
+- [ ] **Step 3: スタイルを実装する**
+
+```typescript
+// src/components/molecules/CuratorGoalBanner.styles.ts
+import styled from 'styled-components';
+import { galleryTokens } from '../../pages/gallery-theme';
+
+export const BannerContainer = styled.section`
+  background: ${galleryTokens.mat};
+  border: 1px solid ${galleryTokens.frameBorder};
+  border-radius: 4px;
+  padding: 16px 20px;
+  margin: 0 auto 24px;
+  max-width: 560px;
+`;
+
+export const BannerTitle = styled.h2`
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+  font-size: 1.1rem;
+  color: ${galleryTokens.ink};
+  margin: 0 0 12px;
+  text-align: center;
+`;
+
+export const GoalRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 0;
+`;
+
+export const GoalLabel = styled.span`
+  flex: 0 0 8.5em;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  color: ${galleryTokens.sub};
+`;
+
+export const Track = styled.div`
+  flex: 1;
+  height: 8px;
+  background: ${galleryTokens.cream};
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+export const Fill = styled.div<{ $percent: number; $gold?: boolean }>`
+  width: ${({ $percent }) => $percent}%;
+  height: 100%;
+  background: ${({ $gold }) => ($gold ? galleryTokens.gold : galleryTokens.sage)};
+  transition: width 300ms ease;
+`;
+
+export const GoalCount = styled.span`
+  flex: 0 0 3.5em;
+  text-align: right;
+  font-size: 0.74rem;
+  color: ${galleryTokens.ink};
+`;
+
+export const Honor = styled.p`
+  margin: 12px 0 0;
+  text-align: center;
+  color: ${galleryTokens.gold};
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+`;
+```
+
+- [ ] **Step 4: コンポーネントを実装する**
+
+```tsx
+// src/components/molecules/CuratorGoalBanner.tsx
+import React from 'react';
+import { CuratorGoal } from '../../domain/collection/types';
+import {
+  BannerContainer,
+  BannerTitle,
+  GoalRow,
+  GoalLabel,
+  Track,
+  Fill,
+  GoalCount,
+  Honor,
+} from './CuratorGoalBanner.styles';
+
+export interface CuratorGoalBannerProps {
+  readonly goal: CuratorGoal;
+}
+
+const toPercent = (value: number, total: number): number =>
+  total > 0 ? (value / total) * 100 : 0;
+
+/** 名誉学芸員への2段プログレス（収蔵コンプ／★★★コンプ）を表示する */
+const CuratorGoalBanner: React.FC<CuratorGoalBannerProps> = ({ goal }) => (
+  <BannerContainer>
+    <BannerTitle>名誉学芸員への道</BannerTitle>
+    <GoalRow>
+      <GoalLabel>収蔵コンプ</GoalLabel>
+      <Track>
+        <Fill $percent={toPercent(goal.collected, goal.total)} />
+      </Track>
+      <GoalCount>{goal.collected} / {goal.total}</GoalCount>
+    </GoalRow>
+    <GoalRow>
+      <GoalLabel>鑑定コンプ ★★★</GoalLabel>
+      <Track>
+        <Fill $percent={toPercent(goal.appraised3star, goal.total)} $gold />
+      </Track>
+      <GoalCount>{goal.appraised3star} / {goal.total}</GoalCount>
+    </GoalRow>
+    {goal.isHonorary && <Honor>あなたは名誉学芸員に認定されました</Honor>}
+  </BannerContainer>
+);
+
+export default CuratorGoalBanner;
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+Run: `npm test -- CuratorGoalBanner`
+Expected: PASS（2件）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/components/molecules/CuratorGoalBanner.tsx src/components/molecules/CuratorGoalBanner.styles.ts src/components/molecules/CuratorGoalBanner.test.tsx
+git commit -m "feat: 名誉学芸員バナー CuratorGoalBanner を実装"
+```
+
+---
+
+### Task 7: 収蔵目録ビュー（CollectionView）
+
+**Files:**
+- Create: `src/components/molecules/CollectionView.tsx`
+- Create: `src/components/molecules/CollectionView.styles.ts`
+- Test: `src/components/molecules/CollectionView.test.tsx`
+
+**Interfaces:**
+- Consumes: `buildCollectionSummary`（Task 4）, `ArtworkFrame`（Task 5）, `CuratorGoalBanner`（Task 6）, `Theme`/`PuzzleRecord`（types）, `galleryTokens`
+- Produces: `CollectionView`（default export）— props `{ themes, records, totalClears, onBack }`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```tsx
+// src/components/molecules/CollectionView.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CollectionView from './CollectionView';
+import { Theme, PuzzleRecord } from '../../types/puzzle';
+
+const themes: Theme[] = [
+  {
+    id: 'illustration-gallery',
+    name: 'イラストギャラリー',
+    description: 'desc-a',
+    unlockCondition: { type: 'always' },
+    images: [
+      { id: 'img_a1', filename: 'a1.webp', alt: 'A1', themeId: 'illustration-gallery', hasVideo: false },
+      { id: 'img_a2', filename: 'a2.webp', alt: 'A2', themeId: 'illustration-gallery', hasVideo: false },
+    ],
+  },
+  {
+    id: 'sea-and-sky',
+    name: '海と空',
+    description: 'desc-b',
+    unlockCondition: { type: 'clearCount', count: 5 },
+    images: [
+      { id: 'img_b1', filename: 'b1.webp', alt: 'B1', themeId: 'sea-and-sky', hasVideo: false },
+    ],
+  },
+];
+
+const records: PuzzleRecord[] = [
+  { imageId: 'img_a1', division: 4, bestScore: 3000, bestRank: '★★☆', bestTime: 90, bestMoves: 30, clearCount: 1, lastClearDate: '2026-07-06T00:00:00.000Z' },
+];
+
+describe('CollectionView', () => {
+  it('展示室名・収蔵率・未開館文言を表示する', () => {
+    render(<CollectionView themes={themes} records={records} totalClears={1} onBack={() => {}} />);
+    expect(screen.getByText('イラストギャラリー')).toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    expect(screen.getByText('海と空')).toBeInTheDocument();
+    expect(screen.getByText(/あと 4 点で開館/)).toBeInTheDocument();
+  });
+
+  it('戻るボタンで onBack を呼ぶ', () => {
+    const onBack = jest.fn();
+    render(<CollectionView themes={themes} records={records} totalClears={1} onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: '戻る' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- CollectionView`
+Expected: FAIL（モジュール未解決）
+
+- [ ] **Step 3: スタイルを実装する**
+
+```typescript
+// src/components/molecules/CollectionView.styles.ts
+import styled from 'styled-components';
+import { galleryTokens } from '../../pages/gallery-theme';
+
+export const ViewContainer = styled.div`
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+`;
+
+export const ViewHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+`;
+
+export const ViewTitle = styled.h1`
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.1em;
+  color: ${galleryTokens.ink};
+  margin: 0;
+`;
+
+export const BackButton = styled.button`
+  background: transparent;
+  border: 1px solid ${galleryTokens.frameBorder};
+  border-radius: 4px;
+  padding: 6px 14px;
+  color: ${galleryTokens.ink};
+  cursor: pointer;
+  font-size: 0.8rem;
+
+  &:hover {
+    background: ${galleryTokens.mat};
+  }
+`;
+
+export const Room = styled.section`
+  margin-bottom: 32px;
+`;
+
+export const RoomHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid ${galleryTokens.frameBorder};
+  padding-bottom: 6px;
+  margin-bottom: 12px;
+`;
+
+export const RoomName = styled.h2`
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+  font-size: 1.1rem;
+  color: ${galleryTokens.ink};
+  margin: 0;
+`;
+
+export const RoomRate = styled.span`
+  font-size: 0.78rem;
+  color: ${galleryTokens.sub};
+  letter-spacing: 0.06em;
+`;
+
+export const Wall = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 16px;
+`;
+
+export const LockedRoom = styled.p`
+  color: ${galleryTokens.sub};
+  font-size: 0.82rem;
+  padding: 12px 0;
+`;
+```
+
+- [ ] **Step 4: コンポーネントを実装する**
+
+```tsx
+// src/components/molecules/CollectionView.tsx
+import React, { useMemo } from 'react';
+import { Theme, PuzzleRecord } from '../../types/puzzle';
+import { buildCollectionSummary } from '../../domain/collection/collection-service';
+import ArtworkFrame from './ArtworkFrame';
+import CuratorGoalBanner from './CuratorGoalBanner';
+import {
+  ViewContainer,
+  ViewHeader,
+  ViewTitle,
+  BackButton,
+  Room,
+  RoomHeader,
+  RoomName,
+  RoomRate,
+  Wall,
+  LockedRoom,
+} from './CollectionView.styles';
+
+export interface CollectionViewProps {
+  readonly themes: Theme[];
+  readonly records: PuzzleRecord[];
+  readonly totalClears: number;
+  readonly onBack: () => void;
+}
+
+/** 収蔵目録の独立ビュー。展示室ごとに作品の壁を並べる */
+const CollectionView: React.FC<CollectionViewProps> = ({
+  themes,
+  records,
+  totalClears,
+  onBack,
+}) => {
+  const summary = useMemo(
+    () => buildCollectionSummary(themes, records, totalClears),
+    [themes, records, totalClears]
+  );
+
+  return (
+    <ViewContainer>
+      <ViewHeader>
+        <ViewTitle>収蔵目録</ViewTitle>
+        <BackButton onClick={onBack}>戻る</BackButton>
+      </ViewHeader>
+
+      <CuratorGoalBanner goal={summary.goal} />
+
+      {summary.rooms.map(room => (
+        <Room key={room.themeId}>
+          <RoomHeader>
+            <RoomName>{room.name}</RoomName>
+            {room.isUnlocked && (
+              <RoomRate>{room.collectedCount} / {room.totalCount}</RoomRate>
+            )}
+          </RoomHeader>
+          {room.isUnlocked ? (
+            <Wall>
+              {room.artworks.map(artwork => (
+                <ArtworkFrame key={artwork.imageId} artwork={artwork} />
+              ))}
+            </Wall>
+          ) : (
+            <LockedRoom>{room.unlockHint}</LockedRoom>
+          )}
+        </Room>
+      ))}
+    </ViewContainer>
+  );
+};
+
+export default CollectionView;
+```
+
+- [ ] **Step 5: テストが通ることを確認する**
+
+Run: `npm test -- CollectionView`
+Expected: PASS（2件）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/components/molecules/CollectionView.tsx src/components/molecules/CollectionView.styles.ts src/components/molecules/CollectionView.test.tsx
+git commit -m "feat: 収蔵目録の独立ビュー CollectionView を実装"
+```
+
+---
+
+### Task 8: タイトル画面に収蔵目録への導線を追加
+
+**Files:**
+- Modify: `src/components/TitleScreen.tsx`
+- Test: `src/components/TitleScreen.test.tsx`（追記）
+
+**Interfaces:**
+- Consumes: 既存 `TitleScreenProps`
+- Produces: `TitleScreenProps` に `onOpenCollection: () => void` を追加
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+```tsx
+// src/components/TitleScreen.test.tsx に追記
+// 既存の import（render, screen, fireEvent, TitleScreen）を利用する
+it('「収蔵目録を見る」で onOpenCollection を呼ぶ', () => {
+  const onOpenCollection = jest.fn();
+  render(
+    <TitleScreen
+      onStart={() => {}}
+      onDebugActivate={() => {}}
+      onOpenCollection={onOpenCollection}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: '収蔵目録を見る' }));
+  expect(onOpenCollection).toHaveBeenCalledTimes(1);
+});
+```
+
+> 注: 既存 `TitleScreen.test.tsx` の各 render 呼び出しにも `onOpenCollection={() => {}}` を追加して型エラーを防ぐこと。
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- TitleScreen`
+Expected: FAIL（「収蔵目録を見る」ボタンが存在しない）
+
+- [ ] **Step 3: TitleScreen を修正する**
+
+`TitleScreenProps` と本体を以下のように変更する:
+
+```tsx
+// 追加: 既存 import 群の下に、目録導線ボタン用のスタイル
+const SecondaryButton = styled.button`
+  display: block;
+  margin: 14px auto 0;
+  background: transparent;
+  border: none;
+  color: ${galleryTokens.sub};
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  text-decoration: underline;
+  animation: ${fadeIn} 0.8s ease-out 0.9s both;
+
+  &:hover {
+    color: ${galleryTokens.gold};
+  }
+`;
+
+type TitleScreenProps = {
+  onStart: () => void;
+  onDebugActivate: () => void;
+  onOpenCollection: () => void;
+};
+
+const TitleScreen: React.FC<TitleScreenProps> = ({
+  onStart,
+  onDebugActivate,
+  onOpenCollection,
+}) => {
+  // ...既存の useRef / useEffect はそのまま...
+
+  return (
+    <SetupSection>
+      <Hero>
+        <HeroArt />
+      </Hero>
+      <Title>ピクチャーパズル</Title>
+      <Kicker>Your Private Gallery</Kicker>
+      <EnterButton onClick={onStart}>入館する</EnterButton>
+      <SecondaryButton onClick={onOpenCollection}>収蔵目録を見る</SecondaryButton>
+    </SetupSection>
+  );
+};
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+Run: `npm test -- TitleScreen`
+Expected: PASS（既存 + 1件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/components/TitleScreen.tsx src/components/TitleScreen.test.tsx
+git commit -m "feat: タイトル画面に収蔵目録への導線を追加"
+```
+
+---
+
+### Task 9: PuzzlePage に収蔵目録ビューを接続
+
+**Files:**
+- Modify: `src/pages/PuzzlePage.tsx`
+- Test: `src/pages/PuzzlePage.test.tsx`（追記）
+
+**Interfaces:**
+- Consumes: `CollectionView`（Task 7）, 拡張後の `TitleScreen`（Task 8）, `themes`（`src/data/themes.ts`）, 既存 `puzzleRecords`/`totalClears` state
+- Produces: なし（結線タスク）
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+```tsx
+// src/pages/PuzzlePage.test.tsx に追記
+// 既存の render ヘルパ（PuzzlePage をモックストレージ付きで描画）を流用する
+import { fireEvent, screen } from '@testing-library/react';
+
+it('タイトルから収蔵目録を開き、戻れる', () => {
+  render(<PuzzlePage recordStorage={mockRecordStorage} totalClearsStorage={mockTotalClearsStorage} />);
+  fireEvent.click(screen.getByRole('button', { name: '収蔵目録を見る' }));
+  expect(screen.getByText('収蔵目録')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: '戻る' }));
+  expect(screen.getByRole('button', { name: '入館する' })).toBeInTheDocument();
+});
+```
+
+> 注: 既存テストのモックストレージ生成（`mockRecordStorage` 等）を再利用する。無ければ `{ getAll: () => [], get: () => undefined, save: () => {}, recordScore: () => {} }` 相当のスタブを用意する。
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+Run: `npm test -- PuzzlePage`
+Expected: FAIL（「収蔵目録を見る」導線が未接続）
+
+- [ ] **Step 3: PuzzlePage を修正する**
+
+```tsx
+// import 追加
+import CollectionView from '../components/molecules/CollectionView';
+import { themes } from '../data/themes';
+
+// state 追加（showTitle の近く）
+const [showCollection, setShowCollection] = useState(false);
+
+// TitleScreen 呼び出しに onOpenCollection を追加
+<TitleScreen
+  onStart={() => setShowTitle(false)}
+  onDebugActivate={() => setDebugMode(true)}
+  onOpenCollection={() => setShowCollection(true)}
+/>
+
+// return 直下の分岐を、収蔵目録を最優先で描画するよう変更する
+return (
+  <PuzzlePageContainer>
+    {showCollection ? (
+      <CollectionView
+        themes={themes}
+        records={puzzleRecords}
+        totalClears={totalClears}
+        onBack={() => setShowCollection(false)}
+      />
+    ) : showTitle ? (
+      <TitleScreen
+        onStart={() => setShowTitle(false)}
+        onDebugActivate={() => setDebugMode(true)}
+        onOpenCollection={() => setShowCollection(true)}
+      />
+    ) : !gameStarted ? (
+      /* ...既存 SetupSectionComponent... */
+    ) : (
+      /* ...既存 GameSectionComponent... */
+    )}
+    {/* 遊び方・ClearHistoryList のブロックは showCollection 中は隠す */}
+    {!showTitle && !showCollection && (
+      <>
+        {/* ...既存 Instructions + ClearHistoryList... */}
+      </>
+    )}
+  </PuzzlePageContainer>
+);
+```
+
+> 注: 収蔵目録は `puzzleRecords`/`totalClears` を参照する。これらは `gameStarted` 変化時にのみ読み込まれるため、タイトル表示中の最新値で十分（プレイ後はセットアップ経由で更新済み）。
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+Run: `npm test -- PuzzlePage`
+Expected: PASS（既存 + 1件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/pages/PuzzlePage.tsx src/pages/PuzzlePage.test.tsx
+git commit -m "feat: PuzzlePage に収蔵目録ビューを接続"
+```
+
+---
+
+### Task 10: 全体検証と回帰チェック
+
+**Files:**
+- なし（検証のみ）
+
+- [ ] **Step 1: CI パイプラインを実行する**
+
+Run: `npm run ci`
+Expected: lint:ci → typecheck → test → build がすべて PASS
+
+- [ ] **Step 2: 開発サーバーで手動確認する**
+
+Run: `npm start`
+確認項目:
+- タイトル →「収蔵目録を見る」→ 展示室ごとに作品フレームが並ぶ
+- 収蔵済み=画像+★、未収蔵=空フレーム、未開館室=「あと○点で開館」
+- 名誉学芸員の2段プログレスが表示される
+- 「戻る」でタイトルに戻る
+- gallery トーン（オフホワイト背景・明朝見出し・ゴールドアクセント）が適用されている
+
+- [ ] **Step 3: 他ゲーム非波及の回帰チェック（親設計書 §4 手順）**
+
+`npm start` で picture-puzzle 以外のゲーム1本以上（例: air-hockey）を開き、背景・配色・タイポが従来どおりであることを確認する。
+
+- [ ] **Step 4: プッシュして PR を作成する**
+
+```bash
+git push -u origin feature/picture-puzzle-gallery-phase2
+gh pr create --base main --title "feat: Picture Puzzle フェーズ2 収蔵コレクション" --body "$(cat <<'EOF'
+## 概要
+既存のクリア記録を美術館メタファーの「収蔵目録」独立ビューへ読み替え、展示室ごとの収蔵率と名誉学芸員（段階ゴール）を可視化する。新規永続データは追加しない。
+
+## 変更内容
+- ドメイン層 collection-service（作品単位集約・収蔵率・名誉学芸員判定）
+- CollectionView / ArtworkFrame / CuratorGoalBanner を追加
+- タイトル画面に「収蔵目録を見る」導線、PuzzlePage に第4ビューを接続
+
+## テスト方法
+- [ ] npm run ci が全パス
+- [ ] タイトル→収蔵目録→戻るの導線
+- [ ] 収蔵済み/未収蔵/未開館室の3状態表示
+- [ ] 他12ゲームの見た目に影響しないこと
+EOF
+)"
+```
+
+- [ ] **Step 5: CI を確認する**
+
+Run: `gh pr checks <PR番号>`
+Expected: 全チェック（Lint/Test/TypeCheck/Build/E2E）が PASS
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 収蔵目録ビュー（独立フルスクリーン）→ Task 7 + Task 9 ✅
+- 展示室ごと収蔵率 → Task 3（データ）+ Task 7（表示）✅
+- 名誉学芸員 段階ゴール → Task 4（判定）+ Task 6（表示）✅
+- 作品単位集約（粒度ミスマッチ橋渡し）→ Task 2 ✅
+- 3状態フレーム（収蔵済み/未収蔵/未開館）→ Task 5 + Task 7 ✅
+- 新規永続データなし → 全タスク読み取り専用（新規 store なし）✅
+- ClearHistoryList 統合 → 設計では目録内統合だが、本プランでは既存の
+  セットアップ下部表示を維持しつつ独立目録を新設する構成とした。ClearHistoryList の
+  目録内埋め込みは受け入れ基準「既存の履歴・ベストスコアが目録として正しく表示」を
+  ArtworkFrame の実績表示（★・スコア）で満たすため、二重表示を避け現状維持とする。
+- 他ゲーム非波及 → Task 10 Step 3 ✅
+
+**Placeholder scan:** プレースホルダなし。全コードブロックは実行可能な完全実装。
+
+**Type consistency:** `ArtworkStatus`/`RoomCollection`/`CuratorGoal`/`CollectionSummary`（Task 1）を
+Task 2-7 で一貫使用。`buildCollectionSummary`/`aggregateByArtwork`/`buildRoomCollections`/
+`evaluateCuratorGoal`/`compareRank` のシグネチャは Interfaces ブロックと実装で一致。
+`onOpenCollection`（Task 8）と PuzzlePage 接続（Task 9）の名称一致を確認済み。

--- a/docs/superpowers/specs/2026-07-08-picture-puzzle-gallery-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-08-picture-puzzle-gallery-phase2-design.md
@@ -1,0 +1,132 @@
+# Picture Puzzle ギャラリー化 フェーズ2「収蔵コレクション」設計書
+
+> 親設計書: `2026-07-07-picture-puzzle-gallery-brushup-design.md`（全4フェーズの俯瞰）
+> 本書はフェーズ2の実装レベル設計。フェーズ1（PR #158、main マージ済）の続き。
+
+## 1. 目的
+
+パズルを解くたびに絵を自分の美術館に「収蔵」していく達成感を可視化する。
+既存の「クリア履歴／ベストスコア」を美術館メタファーの**収蔵目録**へ再設計する。
+
+**★方針: 新規永続データを足さない。** 既存の `PuzzleRecord`（`puzzle_records`）・
+累計クリア（`puzzle_total_clears`）・`themes`（6室15点）の読み替えのみで実現する。
+
+## 2. スコープと安全境界（親設計書 §4 を厳守）
+
+picture-puzzle 専用コードのみ変更し、他12ゲームへ波及させない。
+
+- 触ってよい: `src/pages/PuzzlePage.tsx` / `src/components/*`(puzzle 専用) /
+  `src/components/molecules/*` / `src/domain/*`(新規 collection のみ) / `src/store/atoms.ts`
+- 触らない: `src/styles/GlobalStyle.ts` / `src/styles/tokens/*` / `src/App.tsx` /
+  `src/pages/GameListPage.tsx` / `src/features/*`
+- 新規ビューは `PuzzlePageContainer` 配下に置き、`gallery-theme.ts` のトーンを自動適用する。
+
+## 3. データ基盤（調査で確定した事実）
+
+- **結合キー**: `PuzzleRecord.imageId` == `themes[].images[].id`（filename から拡張子除去で一致）。
+- **収蔵判定**: `clearCount > 0` の imageId = 収蔵済み。
+- **粒度のミスマッチ**: レコードは imageId × division 粒度。1作品を複数難易度でクリアすると
+  複数レコードになるため、「作品」単位に集約する読み替えが必要（本フェーズの主要な新規ロジック）。
+- **展示室構成**: 6室・計15点。
+  | themeId | 名前 | 画像数 | アンロック条件 |
+  |---|---|---|---|
+  | illustration-gallery | イラストギャラリー | 2 | always |
+  | world-scenery | 世界の風景 | 2 | always |
+  | nostalgia | ノスタルジー | 2 | always |
+  | sea-and-sky | 海と空 | 3 | clearCount ≥ 5 |
+  | four-seasons | 四季 | 3 | clearCount ≥ 10 |
+  | mystery | ミステリー | 3 | 他5テーマ全クリア |
+- **制約**: 初収蔵日は未保持（`lastClearDate`＝最終クリア日のみ）。目録の日付表示は
+  lastClearDate で代用し、「初収蔵日」は表示しない（新規保存を避けるため）。
+
+## 4. 設計判断（本フェーズで確定）
+
+1. **収蔵目録ビューの配置＝独立フルスクリーンビュー**（推奨案）。
+   `PuzzlePage.tsx` に第4のビュー状態 `showCollection` を追加し、タイトル画面「入館する」の
+   隣に「収蔵目録を見る」導線を置く。美術館の展示室を巡る没入体験にする。既存
+   `ClearHistoryList`（ベストスコア／履歴）は目録内へ統合する。
+2. **名誉学芸員ゴール＝段階ゴール**（推奨案）。
+   - 第1目標: 全15点**収蔵**（各1回クリア）
+   - 最上位: 全15点**★★★鑑定収蔵**
+   - 目録上部に2段プログレスで併記し、近い目標と遠い目標を両立させ継続動機を保つ。
+
+## 5. アーキテクチャ
+
+### ドメイン層（新規・純粋関数）
+
+`src/domain/collection/collection-service.ts`（UI 非依存・テスト容易）:
+
+```
+aggregateByArtwork(records: PuzzleRecord[]): ArtworkStatus[]
+  同一 imageId を集約: clearCount 合算 / bestScore=max / bestRank=最高 /
+  bestTime=min / bestMoves=min / lastClearDate=最新
+
+buildRoomCollections(themes, records, totalClears): RoomCollection[]
+  展示室ごとに { themeId, name, isUnlocked, unlockHint, collected/total, artworks[] } を構築
+  アンロック判定は既存 theme-unlock-service を再利用
+
+evaluateCuratorGoal(themes, records): CuratorGoal
+  { collected: n/15, appraised3star: m/15, isHonorary: boolean }
+```
+
+型は `src/types/` または `src/domain/collection/types.ts` に定義（`ArtworkStatus`,
+`RoomCollection`, `CuratorGoal`）。既存 `PuzzleRank` を再利用する。
+
+### プレゼンテーション層（新規コンポーネント・gallery テーマ配下）
+
+```
+CollectionView.tsx（中核ビュー）
+├─ CuratorGoalBanner.tsx  … 名誉学芸員への2段プログレス（収蔵コンプ / ★★★コンプ）
+├─ RoomWall.tsx（展示室ごと）
+│   ├─ RoomHeader         … 展示室名 + 収蔵率バー（ThemeSelector の計算を流用）
+│   └─ ArtworkFrame.tsx[] … 3状態を描画
+│        収蔵済み: ArtFrame で額装した画像 + 鑑定評価（★）+ ベスト実績
+│        未収蔵  : 空フレーム（プレースホルダ）
+│        未開館室: 「あと○点で開館」表示（室単位）
+└─ 既存 ClearHistoryList の内容（ベストスコア/履歴）を折り畳みで統合
+```
+
+- 額装は既存 `ArtFrame`（フェーズ1）を再利用する。
+- スタイルは各 `.styles.ts` に分離し、色は `galleryTokens` を参照する。
+
+### 画面遷移 / データフロー
+
+`PuzzlePage.tsx` に `showCollection` 状態を追加（`showTitle`/`gameStarted` と同様の分岐）:
+
+```
+タイトル ──「収蔵目録を見る」──▶ CollectionView ──「戻る」──▶ タイトル
+```
+
+データは既存の読込フロー（gameStarted / ビュー変化時に atoms から取得）を流用し、
+`recordStorage.getAll()` + `themes` + `totalClearsStorage.get()` を collection-service に渡す。
+新規 localStorage キー・新規 use-case は追加しない（読み取り専用の派生計算のため）。
+
+## 6. エラー処理・エッジケース
+
+- レコード0件: 全フレーム空 +「最初の一枚を収蔵しましょう」訴求。
+- 未開館展示室: 室ヘッダにアンロック条件文言（theme-unlock-service の条件を読み替え）。
+  室内の作品フレームは伏せる or シルエット表示。
+- 集約時の null/空配列（bestMoves=null 等）を安全に畳む。
+- 同一作品を複数難易度でクリア: 集約して1フレーム。ベスト実績は最良値を表示。
+
+## 7. テスト方針（TDD・親設計書 §6 準拠）
+
+- `collection-service.test.ts`: 集約・収蔵率・ゴール判定（ドメイン 90%+）。
+  代表ケース: 0件 / 一部収蔵 / 全収蔵 / 全★★★ / 複数難易度集約 / 未開館室。
+- `CollectionView.test.tsx` ほか: 3状態フレーム描画・空状態・導線・戻る操作。
+- 回帰: 他ゲーム1本以上をブラウザで開き背景・配色・タイポが従来どおりか確認（親 §4 手順）。
+
+## 8. 受け入れ基準
+
+- [ ] 既存の履歴・ベストスコアが目録として正しく表示される。
+- [ ] 展示室ごとの収蔵率・全体収蔵率が正しく算出される。
+- [ ] ★★★再収蔵で鑑定評価が更新される。
+- [ ] 名誉学芸員の2段プログレス（収蔵コンプ／★★★コンプ）が正しく表示される。
+- [ ] 既存 localStorage データを壊さない（新規キー追加なし）。
+- [ ] 他12ゲームの見た目に影響しない（gallery テーマ局所適用の維持）。
+
+## 9. アウトオブスコープ（YAGNI）
+
+- 初収蔵日・達成日時の記録（新規永続データが必要なため見送り）。
+- 難易度ごとの収蔵バッジの細分表示（作品単位に集約して簡潔に保つ）。
+- 収蔵目録の共有・エクスポート（フェーズ管理外）。

--- a/src/components/TitleScreen.test.tsx
+++ b/src/components/TitleScreen.test.tsx
@@ -4,21 +4,31 @@ import TitleScreen from './TitleScreen';
 
 describe('TitleScreen', () => {
   it('タイトルと入館するボタンが表示される', () => {
-    render(<TitleScreen onStart={jest.fn()} onDebugActivate={jest.fn()} />);
+    render(
+      <TitleScreen onStart={jest.fn()} onDebugActivate={jest.fn()} onOpenCollection={jest.fn()} />
+    );
     expect(screen.getByText('ピクチャーパズル')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '入館する' })).toBeInTheDocument();
   });
 
   it('入館するボタンをクリックするとonStartが呼ばれる', () => {
     const onStart = jest.fn();
-    render(<TitleScreen onStart={onStart} onDebugActivate={jest.fn()} />);
+    render(
+      <TitleScreen onStart={onStart} onDebugActivate={jest.fn()} onOpenCollection={jest.fn()} />
+    );
     fireEvent.click(screen.getByRole('button', { name: '入館する' }));
     expect(onStart).toHaveBeenCalledTimes(1);
   });
 
   it('"jin"と入力するとonDebugActivateが呼ばれる', () => {
     const onDebugActivate = jest.fn();
-    render(<TitleScreen onStart={jest.fn()} onDebugActivate={onDebugActivate} />);
+    render(
+      <TitleScreen
+        onStart={jest.fn()}
+        onDebugActivate={onDebugActivate}
+        onOpenCollection={jest.fn()}
+      />
+    );
 
     fireEvent.keyDown(window, { key: 'j' });
     fireEvent.keyDown(window, { key: 'i' });
@@ -29,12 +39,31 @@ describe('TitleScreen', () => {
 
   it('無関係なキー入力ではonDebugActivateが呼ばれない', () => {
     const onDebugActivate = jest.fn();
-    render(<TitleScreen onStart={jest.fn()} onDebugActivate={onDebugActivate} />);
+    render(
+      <TitleScreen
+        onStart={jest.fn()}
+        onDebugActivate={onDebugActivate}
+        onOpenCollection={jest.fn()}
+      />
+    );
 
     fireEvent.keyDown(window, { key: 'a' });
     fireEvent.keyDown(window, { key: 'b' });
     fireEvent.keyDown(window, { key: 'c' });
 
     expect(onDebugActivate).not.toHaveBeenCalled();
+  });
+
+  it('「収蔵目録を見る」で onOpenCollection を呼ぶ', () => {
+    const onOpenCollection = jest.fn();
+    render(
+      <TitleScreen
+        onStart={() => {}}
+        onDebugActivate={() => {}}
+        onOpenCollection={onOpenCollection}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '収蔵目録を見る' }));
+    expect(onOpenCollection).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/TitleScreen.tsx
+++ b/src/components/TitleScreen.tsx
@@ -43,12 +43,35 @@ const EnterButton = styled(StartButton)`
   animation: ${fadeIn} 0.8s ease-out 0.6s both;
 `;
 
+/** 収蔵目録（コレクション画面）への導線ボタン */
+const SecondaryButton = styled.button`
+  display: block;
+  margin: 14px auto 0;
+  background: transparent;
+  border: none;
+  color: ${galleryTokens.sub};
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  text-decoration: underline;
+  animation: ${fadeIn} 0.8s ease-out 0.9s both;
+
+  &:hover {
+    color: ${galleryTokens.gold};
+  }
+`;
+
 type TitleScreenProps = {
   onStart: () => void;
   onDebugActivate: () => void;
+  onOpenCollection: () => void;
 };
 
-const TitleScreen: React.FC<TitleScreenProps> = ({ onStart, onDebugActivate }) => {
+const TitleScreen: React.FC<TitleScreenProps> = ({
+  onStart,
+  onDebugActivate,
+  onOpenCollection,
+}) => {
   const bufferRef = useRef('');
 
   useEffect(() => {
@@ -70,6 +93,7 @@ const TitleScreen: React.FC<TitleScreenProps> = ({ onStart, onDebugActivate }) =
       <Title>ピクチャーパズル</Title>
       <Kicker>Your Private Gallery</Kicker>
       <EnterButton onClick={onStart}>入館する</EnterButton>
+      <SecondaryButton onClick={onOpenCollection}>収蔵目録を見る</SecondaryButton>
     </SetupSection>
   );
 };

--- a/src/components/molecules/ArtworkFrame.styles.ts
+++ b/src/components/molecules/ArtworkFrame.styles.ts
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import { galleryTokens } from '../../pages/gallery-theme';
+
+export const FrameFigure = styled.figure`
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const Thumb = styled.img`
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+/** 未収蔵の空フレーム内側 */
+export const EmptySlot = styled.div`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${galleryTokens.sub};
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  background: repeating-linear-gradient(
+    45deg,
+    ${galleryTokens.mat},
+    ${galleryTokens.mat} 8px,
+    ${galleryTokens.cream} 8px,
+    ${galleryTokens.cream} 16px
+  );
+`;
+
+export const Caption = styled.figcaption`
+  font-size: 0.72rem;
+  color: ${galleryTokens.sub};
+  text-align: center;
+`;
+
+export const Rank = styled.span`
+  color: ${galleryTokens.gold};
+  letter-spacing: 0.1em;
+`;

--- a/src/components/molecules/ArtworkFrame.styles.ts
+++ b/src/components/molecules/ArtworkFrame.styles.ts
@@ -45,3 +45,12 @@ export const Rank = styled.span`
   color: ${galleryTokens.gold};
   letter-spacing: 0.1em;
 `;
+
+/** 収蔵済み作品の実績（スコア・タイム・手数）を表示する行 */
+export const Detail = styled.span`
+  display: block;
+  font-size: 0.66rem;
+  color: ${galleryTokens.sub};
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+`;

--- a/src/components/molecules/ArtworkFrame.test.tsx
+++ b/src/components/molecules/ArtworkFrame.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ArtworkFrame from './ArtworkFrame';
 import { ArtworkStatus } from '../../domain/collection/types';
+import { formatElapsedTime } from '../../shared/utils/format';
 
 const collected: ArtworkStatus = {
   imageId: 'moonlight_dancer',
@@ -37,5 +38,12 @@ describe('ArtworkFrame', () => {
     render(<ArtworkFrame artwork={notCollected} />);
     expect(screen.queryByAltText('未収蔵の作品')).not.toBeInTheDocument();
     expect(screen.getByText('未収蔵')).toBeInTheDocument();
+  });
+
+  it('収蔵済みはベストスコア・タイム・手数を表示する', () => {
+    render(<ArtworkFrame artwork={collected} />);
+    expect(screen.getByText(new RegExp(collected.bestScore.toLocaleString()))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(formatElapsedTime(collected.bestTime!)))).toBeInTheDocument();
+    expect(screen.getByText(/40手/)).toBeInTheDocument();
   });
 });

--- a/src/components/molecules/ArtworkFrame.test.tsx
+++ b/src/components/molecules/ArtworkFrame.test.tsx
@@ -42,8 +42,7 @@ describe('ArtworkFrame', () => {
 
   it('収蔵済みはベストスコア・タイム・手数を表示する', () => {
     render(<ArtworkFrame artwork={collected} />);
-    expect(screen.getByText(new RegExp(collected.bestScore.toLocaleString()))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(formatElapsedTime(collected.bestTime!)))).toBeInTheDocument();
-    expect(screen.getByText(/40手/)).toBeInTheDocument();
+    const expected = `${collected.bestScore.toLocaleString()}pts ・ ${formatElapsedTime(collected.bestTime!)} ・ ${collected.bestMoves}手`;
+    expect(screen.getByText(expected)).toBeInTheDocument();
   });
 });

--- a/src/components/molecules/ArtworkFrame.test.tsx
+++ b/src/components/molecules/ArtworkFrame.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ArtworkFrame from './ArtworkFrame';
+import { ArtworkStatus } from '../../domain/collection/types';
+
+const collected: ArtworkStatus = {
+  imageId: 'moonlight_dancer',
+  title: '月明かりのダンサー',
+  filename: 'moonlight_dancer.webp',
+  isCollected: true,
+  bestRank: '★★★',
+  bestScore: 5000,
+  bestTime: 80,
+  bestMoves: 40,
+  clearCount: 3,
+  lastClearDate: '2026-07-05T00:00:00.000Z',
+};
+
+const notCollected: ArtworkStatus = {
+  imageId: 'unseen',
+  title: '未収蔵の作品',
+  filename: 'unseen.webp',
+  isCollected: false,
+  bestScore: 0,
+  clearCount: 0,
+};
+
+describe('ArtworkFrame', () => {
+  it('収蔵済みは画像と鑑定評価を表示する', () => {
+    render(<ArtworkFrame artwork={collected} />);
+    const img = screen.getByAltText('月明かりのダンサー') as HTMLImageElement;
+    expect(img.src).toContain('/images/default/moonlight_dancer.webp');
+    expect(screen.getByText('★★★')).toBeInTheDocument();
+  });
+
+  it('未収蔵は空フレーム（画像なし）を表示する', () => {
+    render(<ArtworkFrame artwork={notCollected} />);
+    expect(screen.queryByAltText('未収蔵の作品')).not.toBeInTheDocument();
+    expect(screen.getByText('未収蔵')).toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/ArtworkFrame.tsx
+++ b/src/components/molecules/ArtworkFrame.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { ArtFrame } from './ArtFrame';
 import { ArtworkStatus } from '../../domain/collection/types';
-import { FrameFigure, Thumb, EmptySlot, Caption, Rank } from './ArtworkFrame.styles';
+import { FrameFigure, Thumb, EmptySlot, Caption, Rank, Detail } from './ArtworkFrame.styles';
+import { formatElapsedTime } from '../../shared/utils/format';
 
 export interface ArtworkFrameProps {
   readonly artwork: ArtworkStatus;
@@ -18,8 +19,15 @@ const ArtworkFrame: React.FC<ArtworkFrameProps> = ({ artwork }) => (
       )}
     </ArtFrame>
     <Caption>
-      {artwork.isCollected && artwork.bestRank ? (
-        <Rank>{artwork.bestRank}</Rank>
+      {artwork.isCollected ? (
+        <>
+          {artwork.bestRank && <Rank>{artwork.bestRank}</Rank>}
+          <Detail>
+            {`${artwork.bestScore.toLocaleString()}pts`}
+            {artwork.bestTime !== undefined && ` ・ ${formatElapsedTime(artwork.bestTime)}`}
+            {artwork.bestMoves !== undefined && ` ・ ${artwork.bestMoves}手`}
+          </Detail>
+        </>
       ) : (
         artwork.title
       )}

--- a/src/components/molecules/ArtworkFrame.tsx
+++ b/src/components/molecules/ArtworkFrame.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ArtFrame } from './ArtFrame';
+import { ArtworkStatus } from '../../domain/collection/types';
+import { FrameFigure, Thumb, EmptySlot, Caption, Rank } from './ArtworkFrame.styles';
+
+export interface ArtworkFrameProps {
+  readonly artwork: ArtworkStatus;
+}
+
+/** 収蔵目録の作品1点。収蔵済みは額装画像＋鑑定評価、未収蔵は空フレーム */
+const ArtworkFrame: React.FC<ArtworkFrameProps> = ({ artwork }) => (
+  <FrameFigure>
+    <ArtFrame>
+      {artwork.isCollected ? (
+        <Thumb src={`/images/default/${artwork.filename}`} alt={artwork.title} />
+      ) : (
+        <EmptySlot>未収蔵</EmptySlot>
+      )}
+    </ArtFrame>
+    <Caption>
+      {artwork.isCollected && artwork.bestRank ? (
+        <Rank>{artwork.bestRank}</Rank>
+      ) : (
+        artwork.title
+      )}
+    </Caption>
+  </FrameFigure>
+);
+
+export default ArtworkFrame;

--- a/src/components/molecules/CollectionView.styles.ts
+++ b/src/components/molecules/CollectionView.styles.ts
@@ -1,0 +1,75 @@
+import styled from 'styled-components';
+import { galleryTokens } from '../../pages/gallery-theme';
+
+export const ViewContainer = styled.div`
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+`;
+
+export const ViewHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+`;
+
+export const ViewTitle = styled.h1`
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.1em;
+  color: ${galleryTokens.ink};
+  margin: 0;
+`;
+
+export const BackButton = styled.button`
+  background: transparent;
+  border: 1px solid ${galleryTokens.frameBorder};
+  border-radius: 4px;
+  padding: 6px 14px;
+  color: ${galleryTokens.ink};
+  cursor: pointer;
+  font-size: 0.8rem;
+
+  &:hover {
+    background: ${galleryTokens.mat};
+  }
+`;
+
+export const Room = styled.section`
+  margin-bottom: 32px;
+`;
+
+export const RoomHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid ${galleryTokens.frameBorder};
+  padding-bottom: 6px;
+  margin-bottom: 12px;
+`;
+
+export const RoomName = styled.h2`
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+  font-size: 1.1rem;
+  color: ${galleryTokens.ink};
+  margin: 0;
+`;
+
+export const RoomRate = styled.span`
+  font-size: 0.78rem;
+  color: ${galleryTokens.sub};
+  letter-spacing: 0.06em;
+`;
+
+export const Wall = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 16px;
+`;
+
+export const LockedRoom = styled.p`
+  color: ${galleryTokens.sub};
+  font-size: 0.82rem;
+  padding: 12px 0;
+`;

--- a/src/components/molecules/CollectionView.test.tsx
+++ b/src/components/molecules/CollectionView.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CollectionView from './CollectionView';
+import { Theme, PuzzleRecord } from '../../types/puzzle';
+
+const themes: Theme[] = [
+  {
+    id: 'illustration-gallery',
+    name: 'イラストギャラリー',
+    description: 'desc-a',
+    unlockCondition: { type: 'always' },
+    images: [
+      { id: 'img_a1', filename: 'a1.webp', alt: 'A1', themeId: 'illustration-gallery', hasVideo: false },
+      { id: 'img_a2', filename: 'a2.webp', alt: 'A2', themeId: 'illustration-gallery', hasVideo: false },
+    ],
+  },
+  {
+    id: 'sea-and-sky',
+    name: '海と空',
+    description: 'desc-b',
+    unlockCondition: { type: 'clearCount', count: 5 },
+    images: [
+      { id: 'img_b1', filename: 'b1.webp', alt: 'B1', themeId: 'sea-and-sky', hasVideo: false },
+    ],
+  },
+];
+
+const records: PuzzleRecord[] = [
+  { imageId: 'img_a1', division: 4, bestScore: 3000, bestRank: '★★☆', bestTime: 90, bestMoves: 30, clearCount: 1, lastClearDate: '2026-07-06T00:00:00.000Z' },
+];
+
+describe('CollectionView', () => {
+  it('展示室名・収蔵率・未開館文言を表示する', () => {
+    render(<CollectionView themes={themes} records={records} totalClears={1} onBack={() => {}} />);
+    expect(screen.getByText('イラストギャラリー')).toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    expect(screen.getByText('海と空')).toBeInTheDocument();
+    expect(screen.getByText(/あと 4 点で開館/)).toBeInTheDocument();
+  });
+
+  it('戻るボタンで onBack を呼ぶ', () => {
+    const onBack = jest.fn();
+    render(<CollectionView themes={themes} records={records} totalClears={1} onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: '戻る' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/molecules/CollectionView.tsx
+++ b/src/components/molecules/CollectionView.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo } from 'react';
+import { Theme, PuzzleRecord } from '../../types/puzzle';
+import { buildCollectionSummary } from '../../domain/collection/collection-service';
+import ArtworkFrame from './ArtworkFrame';
+import CuratorGoalBanner from './CuratorGoalBanner';
+import {
+  ViewContainer,
+  ViewHeader,
+  ViewTitle,
+  BackButton,
+  Room,
+  RoomHeader,
+  RoomName,
+  RoomRate,
+  Wall,
+  LockedRoom,
+} from './CollectionView.styles';
+
+export interface CollectionViewProps {
+  readonly themes: Theme[];
+  readonly records: PuzzleRecord[];
+  readonly totalClears: number;
+  readonly onBack: () => void;
+}
+
+/** 収蔵目録の独立ビュー。展示室ごとに作品の壁を並べる */
+const CollectionView: React.FC<CollectionViewProps> = ({
+  themes,
+  records,
+  totalClears,
+  onBack,
+}) => {
+  const summary = useMemo(
+    () => buildCollectionSummary(themes, records, totalClears),
+    [themes, records, totalClears]
+  );
+
+  return (
+    <ViewContainer>
+      <ViewHeader>
+        <ViewTitle>収蔵目録</ViewTitle>
+        <BackButton onClick={onBack}>戻る</BackButton>
+      </ViewHeader>
+
+      <CuratorGoalBanner goal={summary.goal} />
+
+      {summary.rooms.map(room => (
+        <Room key={room.themeId}>
+          <RoomHeader>
+            <RoomName>{room.name}</RoomName>
+            {room.isUnlocked && (
+              <RoomRate>{room.collectedCount} / {room.totalCount}</RoomRate>
+            )}
+          </RoomHeader>
+          {room.isUnlocked ? (
+            <Wall>
+              {room.artworks.map(artwork => (
+                <ArtworkFrame key={artwork.imageId} artwork={artwork} />
+              ))}
+            </Wall>
+          ) : (
+            <LockedRoom>{room.unlockHint}</LockedRoom>
+          )}
+        </Room>
+      ))}
+    </ViewContainer>
+  );
+};
+
+export default CollectionView;

--- a/src/components/molecules/CuratorGoalBanner.styles.ts
+++ b/src/components/molecules/CuratorGoalBanner.styles.ts
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+import { galleryTokens } from '../../pages/gallery-theme';
+
+export const BannerContainer = styled.section`
+  background: ${galleryTokens.mat};
+  border: 1px solid ${galleryTokens.frameBorder};
+  border-radius: 4px;
+  padding: 16px 20px;
+  margin: 0 auto 24px;
+  max-width: 560px;
+`;
+
+export const BannerTitle = styled.h2`
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+  font-size: 1.1rem;
+  color: ${galleryTokens.ink};
+  margin: 0 0 12px;
+  text-align: center;
+`;
+
+export const GoalRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 0;
+`;
+
+export const GoalLabel = styled.span`
+  flex: 0 0 8.5em;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  color: ${galleryTokens.sub};
+`;
+
+export const Track = styled.div`
+  flex: 1;
+  height: 8px;
+  background: ${galleryTokens.cream};
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+export const Fill = styled.div<{ $percent: number; $gold?: boolean }>`
+  width: ${({ $percent }) => $percent}%;
+  height: 100%;
+  background: ${({ $gold }) => ($gold ? galleryTokens.gold : galleryTokens.sage)};
+  transition: width 300ms ease;
+`;
+
+export const GoalCount = styled.span`
+  flex: 0 0 3.5em;
+  text-align: right;
+  font-size: 0.74rem;
+  color: ${galleryTokens.ink};
+`;
+
+export const Honor = styled.p`
+  margin: 12px 0 0;
+  text-align: center;
+  color: ${galleryTokens.gold};
+  font-family: Georgia, 'Times New Roman', 'Yu Mincho', serif;
+`;

--- a/src/components/molecules/CuratorGoalBanner.test.tsx
+++ b/src/components/molecules/CuratorGoalBanner.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CuratorGoalBanner from './CuratorGoalBanner';
+import { CuratorGoal } from '../../domain/collection/types';
+
+describe('CuratorGoalBanner', () => {
+  it('収蔵コンプと★★★コンプの2段進捗を表示する', () => {
+    const goal: CuratorGoal = { collected: 12, appraised3star: 4, total: 15, isHonorary: false };
+    render(<CuratorGoalBanner goal={goal} />);
+    expect(screen.getByText('12 / 15')).toBeInTheDocument();
+    expect(screen.getByText('4 / 15')).toBeInTheDocument();
+    expect(screen.queryByText(/名誉学芸員に認定/)).not.toBeInTheDocument();
+  });
+
+  it('名誉学芸員達成時は称号を表示する', () => {
+    const goal: CuratorGoal = { collected: 15, appraised3star: 15, total: 15, isHonorary: true };
+    render(<CuratorGoalBanner goal={goal} />);
+    expect(screen.getByText(/名誉学芸員に認定/)).toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/CuratorGoalBanner.tsx
+++ b/src/components/molecules/CuratorGoalBanner.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { CuratorGoal } from '../../domain/collection/types';
+import {
+  BannerContainer,
+  BannerTitle,
+  GoalRow,
+  GoalLabel,
+  Track,
+  Fill,
+  GoalCount,
+  Honor,
+} from './CuratorGoalBanner.styles';
+
+export interface CuratorGoalBannerProps {
+  readonly goal: CuratorGoal;
+}
+
+const toPercent = (value: number, total: number): number =>
+  total > 0 ? (value / total) * 100 : 0;
+
+/** 名誉学芸員への2段プログレス（収蔵コンプ／★★★コンプ）を表示する */
+const CuratorGoalBanner: React.FC<CuratorGoalBannerProps> = ({ goal }) => (
+  <BannerContainer>
+    <BannerTitle>名誉学芸員への道</BannerTitle>
+    <GoalRow>
+      <GoalLabel>収蔵コンプ</GoalLabel>
+      <Track>
+        <Fill $percent={toPercent(goal.collected, goal.total)} />
+      </Track>
+      <GoalCount>{goal.collected} / {goal.total}</GoalCount>
+    </GoalRow>
+    <GoalRow>
+      <GoalLabel>鑑定コンプ ★★★</GoalLabel>
+      <Track>
+        <Fill $percent={toPercent(goal.appraised3star, goal.total)} $gold />
+      </Track>
+      <GoalCount>{goal.appraised3star} / {goal.total}</GoalCount>
+    </GoalRow>
+    {goal.isHonorary && <Honor>あなたは名誉学芸員に認定されました</Honor>}
+  </BannerContainer>
+);
+
+export default CuratorGoalBanner;

--- a/src/domain/collection/collection-service.test.ts
+++ b/src/domain/collection/collection-service.test.ts
@@ -1,0 +1,69 @@
+import { aggregateByArtwork, compareRank } from './collection-service';
+import { PuzzleImage, PuzzleRecord } from '../../types/puzzle';
+
+const image: PuzzleImage = {
+  id: 'moonlight_dancer',
+  filename: 'moonlight_dancer.webp',
+  alt: '月明かりのダンサー',
+  themeId: 'illustration-gallery',
+  hasVideo: true,
+};
+
+const rec = (over: Partial<PuzzleRecord>): PuzzleRecord => ({
+  imageId: 'moonlight_dancer',
+  division: 4,
+  bestScore: 1000,
+  bestRank: 'クリア',
+  bestTime: 100,
+  bestMoves: 50,
+  clearCount: 1,
+  lastClearDate: '2026-07-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('compareRank', () => {
+  it('★★★ は クリア より上位', () => {
+    expect(compareRank('★★★', 'クリア')).toBeGreaterThan(0);
+  });
+  it('同ランクは 0', () => {
+    expect(compareRank('★☆☆', '★☆☆')).toBe(0);
+  });
+});
+
+describe('aggregateByArtwork', () => {
+  it('レコードなしは未収蔵として畳む', () => {
+    const result = aggregateByArtwork(image, []);
+    expect(result.isCollected).toBe(false);
+    expect(result.clearCount).toBe(0);
+    expect(result.bestRank).toBeUndefined();
+    expect(result.title).toBe('月明かりのダンサー');
+    expect(result.filename).toBe('moonlight_dancer.webp');
+  });
+
+  it('複数難易度のレコードを最良値へ集約する', () => {
+    const records = [
+      rec({ division: 3, bestScore: 2000, bestRank: '★☆☆', bestTime: 120, bestMoves: 60, clearCount: 2, lastClearDate: '2026-07-01T00:00:00.000Z' }),
+      rec({ division: 5, bestScore: 5000, bestRank: '★★★', bestTime: 80, bestMoves: 40, clearCount: 3, lastClearDate: '2026-07-05T00:00:00.000Z' }),
+    ];
+    const result = aggregateByArtwork(image, records);
+    expect(result.isCollected).toBe(true);
+    expect(result.bestScore).toBe(5000);
+    expect(result.bestRank).toBe('★★★');
+    expect(result.bestTime).toBe(80);
+    expect(result.bestMoves).toBe(40);
+    expect(result.clearCount).toBe(5);
+    expect(result.lastClearDate).toBe('2026-07-05T00:00:00.000Z');
+  });
+
+  it('bestMoves が全て null なら undefined', () => {
+    const result = aggregateByArtwork(image, [rec({ bestMoves: null })]);
+    expect(result.bestMoves).toBeUndefined();
+  });
+
+  it('別 imageId のレコードは無視する', () => {
+    const other = rec({ imageId: 'other_image', clearCount: 9 });
+    const result = aggregateByArtwork(image, [other]);
+    expect(result.isCollected).toBe(false);
+    expect(result.clearCount).toBe(0);
+  });
+});

--- a/src/domain/collection/collection-service.test.ts
+++ b/src/domain/collection/collection-service.test.ts
@@ -1,5 +1,5 @@
-import { aggregateByArtwork, compareRank } from './collection-service';
-import { PuzzleImage, PuzzleRecord } from '../../types/puzzle';
+import { aggregateByArtwork, compareRank, buildRoomCollections } from './collection-service';
+import { PuzzleImage, PuzzleRecord, Theme } from '../../types/puzzle';
 
 const image: PuzzleImage = {
   id: 'moonlight_dancer',
@@ -65,5 +65,56 @@ describe('aggregateByArtwork', () => {
     const result = aggregateByArtwork(image, [other]);
     expect(result.isCollected).toBe(false);
     expect(result.clearCount).toBe(0);
+  });
+});
+
+const twoRoomThemes: Theme[] = [
+  {
+    id: 'illustration-gallery',
+    name: 'イラストギャラリー',
+    description: 'desc-a',
+    unlockCondition: { type: 'always' },
+    images: [
+      { id: 'img_a1', filename: 'a1.webp', alt: 'A1', themeId: 'illustration-gallery', hasVideo: false },
+      { id: 'img_a2', filename: 'a2.webp', alt: 'A2', themeId: 'illustration-gallery', hasVideo: false },
+    ],
+  },
+  {
+    id: 'sea-and-sky',
+    name: '海と空',
+    description: 'desc-b',
+    unlockCondition: { type: 'clearCount', count: 5 },
+    images: [
+      { id: 'img_b1', filename: 'b1.webp', alt: 'B1', themeId: 'sea-and-sky', hasVideo: false },
+    ],
+  },
+];
+
+const clearedRecord = (imageId: string): PuzzleRecord => ({
+  imageId,
+  division: 4,
+  bestScore: 3000,
+  bestRank: '★★☆',
+  bestTime: 90,
+  bestMoves: 30,
+  clearCount: 1,
+  lastClearDate: '2026-07-06T00:00:00.000Z',
+});
+
+describe('buildRoomCollections', () => {
+  it('開館室は収蔵率を、未開館室は解放条件文言を返す', () => {
+    const rooms = buildRoomCollections(twoRoomThemes, [clearedRecord('img_a1')], 1);
+    const roomA = rooms.find(r => r.themeId === 'illustration-gallery')!;
+    const roomB = rooms.find(r => r.themeId === 'sea-and-sky')!;
+
+    expect(roomA.isUnlocked).toBe(true);
+    expect(roomA.unlockHint).toBeUndefined();
+    expect(roomA.collectedCount).toBe(1);
+    expect(roomA.totalCount).toBe(2);
+    expect(roomA.artworks[0].isCollected).toBe(true);
+    expect(roomA.artworks[1].isCollected).toBe(false);
+
+    expect(roomB.isUnlocked).toBe(false);
+    expect(roomB.unlockHint).toContain('5');
   });
 });

--- a/src/domain/collection/collection-service.test.ts
+++ b/src/domain/collection/collection-service.test.ts
@@ -1,4 +1,4 @@
-import { aggregateByArtwork, compareRank, buildRoomCollections } from './collection-service';
+import { aggregateByArtwork, compareRank, buildRoomCollections, buildCollectionSummary } from './collection-service';
 import { PuzzleImage, PuzzleRecord, Theme } from '../../types/puzzle';
 
 const image: PuzzleImage = {
@@ -116,5 +116,31 @@ describe('buildRoomCollections', () => {
 
     expect(roomB.isUnlocked).toBe(false);
     expect(roomB.unlockHint).toContain('5');
+  });
+});
+
+describe('evaluateCuratorGoal / buildCollectionSummary', () => {
+  it('全作品★★★で名誉学芸員を達成する', () => {
+    const summary = buildCollectionSummary(
+      twoRoomThemes,
+      [
+        { ...clearedRecord('img_a1'), bestRank: '★★★' },
+        { ...clearedRecord('img_a2'), bestRank: '★★★' },
+        { ...clearedRecord('img_b1'), bestRank: '★★★' },
+      ],
+      5
+    );
+    expect(summary.goal.total).toBe(3);
+    expect(summary.goal.collected).toBe(3);
+    expect(summary.goal.appraised3star).toBe(3);
+    expect(summary.goal.isHonorary).toBe(true);
+    expect(summary.rooms).toHaveLength(2);
+  });
+
+  it('一部のみ収蔵なら名誉学芸員は未達', () => {
+    const summary = buildCollectionSummary(twoRoomThemes, [clearedRecord('img_a1')], 1);
+    expect(summary.goal.collected).toBe(1);
+    expect(summary.goal.appraised3star).toBe(0);
+    expect(summary.goal.isHonorary).toBe(false);
   });
 });

--- a/src/domain/collection/collection-service.ts
+++ b/src/domain/collection/collection-service.ts
@@ -1,5 +1,6 @@
-import { PuzzleImage, PuzzleRank, PuzzleRecord } from '../../types/puzzle';
-import { ArtworkStatus } from './types';
+import { PuzzleImage, PuzzleRank, PuzzleRecord, Theme, ThemeId } from '../../types/puzzle';
+import { ArtworkStatus, RoomCollection } from './types';
+import { isThemeUnlocked, UnlockContext } from '../theme/theme-unlock-service';
 
 /** ランクの優劣順序（大きいほど上位） */
 const RANK_ORDER: Record<PuzzleRank, number> = {
@@ -54,4 +55,48 @@ export const aggregateByArtwork = (
     clearCount,
     lastClearDate,
   };
+};
+
+/** 未開館室の解放条件文言を生成する */
+const buildUnlockHint = (theme: Theme, totalClears: number): string => {
+  const cond = theme.unlockCondition;
+  if (cond.type === 'clearCount') {
+    return `あと ${Math.max(0, cond.count - totalClears)} 点で開館（${cond.count}回クリア）`;
+  }
+  if (cond.type === 'themesClear') {
+    return '全展示室で1点以上収蔵すると開館';
+  }
+  return '';
+};
+
+/**
+ * 展示室ごとの収蔵状況を構築する。
+ * アンロック判定は既存 theme-unlock-service を再利用する。
+ */
+export const buildRoomCollections = (
+  themes: readonly Theme[],
+  records: readonly PuzzleRecord[],
+  totalClears: number
+): RoomCollection[] => {
+  const themeImageIds = new Map<ThemeId, string[]>();
+  for (const theme of themes) {
+    themeImageIds.set(theme.id, theme.images.map(img => img.id));
+  }
+  const context: UnlockContext = { totalClears, records, themeImageIds };
+
+  return themes.map(theme => {
+    const isUnlocked = isThemeUnlocked(theme.unlockCondition, context);
+    const artworks = theme.images.map(img => aggregateByArtwork(img, records));
+    const collectedCount = artworks.filter(a => a.isCollected).length;
+    return {
+      themeId: theme.id,
+      name: theme.name,
+      description: theme.description,
+      isUnlocked,
+      unlockHint: isUnlocked ? undefined : buildUnlockHint(theme, totalClears),
+      collectedCount,
+      totalCount: theme.images.length,
+      artworks,
+    };
+  });
 };

--- a/src/domain/collection/collection-service.ts
+++ b/src/domain/collection/collection-service.ts
@@ -1,0 +1,57 @@
+import { PuzzleImage, PuzzleRank, PuzzleRecord } from '../../types/puzzle';
+import { ArtworkStatus } from './types';
+
+/** ランクの優劣順序（大きいほど上位） */
+const RANK_ORDER: Record<PuzzleRank, number> = {
+  'クリア': 0,
+  '★☆☆': 1,
+  '★★☆': 2,
+  '★★★': 3,
+};
+
+/** ランクを比較する。a が上位なら正、同位で 0、下位で負 */
+export const compareRank = (a: PuzzleRank, b: PuzzleRank): number =>
+  RANK_ORDER[a] - RANK_ORDER[b];
+
+/**
+ * 1作品（imageId）について、全難易度のレコードを最良値へ集約する。
+ * 収蔵判定は clearCount > 0。表示名は image.alt を流用する。
+ */
+export const aggregateByArtwork = (
+  image: PuzzleImage,
+  records: readonly PuzzleRecord[]
+): ArtworkStatus => {
+  const mine = records.filter(r => r.imageId === image.id && r.clearCount > 0);
+  const base = {
+    imageId: image.id,
+    title: image.alt,
+    filename: image.filename,
+  };
+
+  if (mine.length === 0) {
+    return { ...base, isCollected: false, bestScore: 0, clearCount: 0 };
+  }
+
+  const bestScore = Math.max(...mine.map(r => r.bestScore));
+  const bestRank = mine
+    .map(r => r.bestRank)
+    .reduce((best, cur) => (compareRank(cur, best) > 0 ? cur : best));
+  const bestTime = Math.min(...mine.map(r => r.bestTime));
+  const moves = mine.map(r => r.bestMoves).filter((m): m is number => m !== null);
+  const bestMoves = moves.length > 0 ? Math.min(...moves) : undefined;
+  const clearCount = mine.reduce((sum, r) => sum + r.clearCount, 0);
+  const lastClearDate = mine
+    .map(r => r.lastClearDate)
+    .reduce((latest, cur) => (cur > latest ? cur : latest));
+
+  return {
+    ...base,
+    isCollected: true,
+    bestRank,
+    bestScore,
+    bestTime,
+    bestMoves,
+    clearCount,
+    lastClearDate,
+  };
+};

--- a/src/domain/collection/collection-service.ts
+++ b/src/domain/collection/collection-service.ts
@@ -1,5 +1,5 @@
 import { PuzzleImage, PuzzleRank, PuzzleRecord, Theme, ThemeId } from '../../types/puzzle';
-import { ArtworkStatus, RoomCollection } from './types';
+import { ArtworkStatus, RoomCollection, CuratorGoal, CollectionSummary } from './types';
 import { isThemeUnlocked, UnlockContext } from '../theme/theme-unlock-service';
 
 /** ランクの優劣順序（大きいほど上位） */
@@ -99,4 +99,30 @@ export const buildRoomCollections = (
       artworks,
     };
   });
+};
+
+/** 全展示室の収蔵状況から名誉学芸員の進捗を評価する */
+export const evaluateCuratorGoal = (
+  rooms: readonly RoomCollection[]
+): CuratorGoal => {
+  const artworks = rooms.flatMap(room => room.artworks);
+  const total = artworks.length;
+  const collected = artworks.filter(a => a.isCollected).length;
+  const appraised3star = artworks.filter(a => a.bestRank === '★★★').length;
+  return {
+    collected,
+    appraised3star,
+    total,
+    isHonorary: total > 0 && appraised3star === total,
+  };
+};
+
+/** 収蔵目録ビュー向けの集約全体を構築する */
+export const buildCollectionSummary = (
+  themes: readonly Theme[],
+  records: readonly PuzzleRecord[],
+  totalClears: number
+): CollectionSummary => {
+  const rooms = buildRoomCollections(themes, records, totalClears);
+  return { rooms, goal: evaluateCuratorGoal(rooms) };
 };

--- a/src/domain/collection/types.ts
+++ b/src/domain/collection/types.ts
@@ -1,0 +1,55 @@
+import { PuzzleRank } from '../../types/puzzle';
+
+/** 作品1点の収蔵状況（同一 imageId の複数難易度レコードを集約した結果） */
+export interface ArtworkStatus {
+  readonly imageId: string;
+  /** themes から引いた表示名（alt を流用） */
+  readonly title: string;
+  /** サムネイル用ファイル名 */
+  readonly filename: string;
+  /** 1回以上クリア済みか */
+  readonly isCollected: boolean;
+  /** 集約後の最高鑑定評価（未収蔵は undefined） */
+  readonly bestRank?: PuzzleRank;
+  /** 集約後のベストスコア最大値 */
+  readonly bestScore: number;
+  /** 集約後のベストタイム最小値（未収蔵は undefined） */
+  readonly bestTime?: number;
+  /** 集約後の最少手数（未取得は undefined） */
+  readonly bestMoves?: number;
+  /** 全難易度合算のクリア回数 */
+  readonly clearCount: number;
+  /** 最終クリア日時（ISO文字列・未収蔵は undefined） */
+  readonly lastClearDate?: string;
+}
+
+/** 展示室1室の収蔵状況 */
+export interface RoomCollection {
+  readonly themeId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly isUnlocked: boolean;
+  /** 未開館時の解放条件文言（開館済みは undefined） */
+  readonly unlockHint?: string;
+  readonly collectedCount: number;
+  readonly totalCount: number;
+  readonly artworks: readonly ArtworkStatus[];
+}
+
+/** 名誉学芸員（段階ゴール）の進捗 */
+export interface CuratorGoal {
+  /** 収蔵済み作品数 */
+  readonly collected: number;
+  /** ★★★収蔵の作品数 */
+  readonly appraised3star: number;
+  /** 全作品数（=15） */
+  readonly total: number;
+  /** 全作品を★★★収蔵したか */
+  readonly isHonorary: boolean;
+}
+
+/** 収蔵目録ビューが受け取る集約全体 */
+export interface CollectionSummary {
+  readonly rooms: readonly RoomCollection[];
+  readonly goal: CuratorGoal;
+}

--- a/src/pages/PuzzlePage.test.tsx
+++ b/src/pages/PuzzlePage.test.tsx
@@ -11,9 +11,16 @@ jest.mock('../infrastructure/storage/total-clears-store');
 jest.mock('../components/TitleScreen', () => {
   return {
     __esModule: true,
-    default: ({ onStart }: { onStart: () => void }) => (
+    default: ({
+      onStart,
+      onOpenCollection,
+    }: {
+      onStart: () => void;
+      onOpenCollection: () => void;
+    }) => (
       <div data-testid="title-screen">
         <button onClick={onStart}>入館する</button>
+        <button onClick={onOpenCollection}>収蔵目録を見る</button>
       </div>
     ),
   };
@@ -47,6 +54,20 @@ jest.mock('../components/molecules/ClearHistoryList', () => {
 /** Jotai Provider でラップしてレンダリングする */
 const renderWithProvider = (ui: React.ReactElement) =>
   render(React.createElement(Provider, null, ui));
+
+/** テスト用の記録ストレージスタブ（収蔵目録の描画に必要な最小実装） */
+const mockRecordStorage = {
+  getAll: () => [],
+  get: () => undefined,
+  save: () => {},
+  recordScore: () => ({ isBestScore: false }),
+};
+
+/** テスト用の累計クリア数ストレージスタブ */
+const mockTotalClearsStorage = {
+  get: () => 0,
+  increment: () => 0,
+};
 
 describe('PuzzlePage', () => {
   beforeEach(() => {
@@ -104,5 +125,17 @@ describe('PuzzlePage', () => {
     expect(historyItems.length).toBe(2);
     expect(historyItems[0].textContent).toContain('test_image_1');
     expect(historyItems[1].textContent).toContain('test_image_2');
+  });
+
+  it('タイトルから収蔵目録を開き、戻れる', () => {
+    renderWithProvider(
+      <PuzzlePage recordStorage={mockRecordStorage} totalClearsStorage={mockTotalClearsStorage} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '収蔵目録を見る' }));
+    expect(screen.getByText('収蔵目録')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '戻る' }));
+    expect(screen.getByRole('button', { name: '入館する' })).toBeInTheDocument();
   });
 });

--- a/src/pages/PuzzlePage.tsx
+++ b/src/pages/PuzzlePage.tsx
@@ -13,6 +13,8 @@ import { useGameFlow } from '../presentation/hooks/useGameFlow';
 import { LocalPuzzleRecordStorage } from '../infrastructure/storage/puzzle-records-store';
 import { LocalTotalClearsStorage } from '../infrastructure/storage/total-clears-store';
 import TitleScreen from '../components/TitleScreen';
+import CollectionView from '../components/molecules/CollectionView';
+import { themes } from '../data/themes';
 import { PuzzleRecordStorage, TotalClearsStorage } from '../application/ports/storage-port';
 
 /** デフォルトのストレージインスタンス（コンポーネント外で生成してリレンダリングを防ぐ） */
@@ -36,6 +38,8 @@ const PuzzlePage: React.FC<PuzzlePageProps> = ({
   // タイトル画面の状態
   const [showTitle, setShowTitle] = useState(true);
   const [debugMode, setDebugMode] = useState(false);
+  // 収蔵目録（コレクション画面）の表示状態
+  const [showCollection, setShowCollection] = useState(false);
 
   // クリア履歴の状態
   const [clearHistory, setClearHistory] = useState<ClearHistory[]>([]);
@@ -84,10 +88,18 @@ const PuzzlePage: React.FC<PuzzlePageProps> = ({
 
   return (
     <PuzzlePageContainer>
-      {showTitle ? (
+      {showCollection ? (
+        <CollectionView
+          themes={themes}
+          records={puzzleRecords}
+          totalClears={totalClears}
+          onBack={() => setShowCollection(false)}
+        />
+      ) : showTitle ? (
         <TitleScreen
           onStart={() => setShowTitle(false)}
           onDebugActivate={() => setDebugMode(true)}
+          onOpenCollection={() => setShowCollection(true)}
         />
       ) : !gameStarted ? (
         <SetupSectionComponent
@@ -124,7 +136,7 @@ const PuzzlePage: React.FC<PuzzlePageProps> = ({
           debugMode={debugMode}
         />
       )}
-      {!showTitle && (
+      {!showTitle && !showCollection && (
         <>
           <Instructions>
             <InstructionsTitle>遊び方</InstructionsTitle>


### PR DESCRIPTION
## 概要
既存のクリア記録を美術館メタファーの「収蔵目録」独立ビューへ読み替え、展示室ごとの収蔵率と名誉学芸員（段階ゴール）を可視化する。**新規永続データは追加しない**（既存 `puzzle_records`/`puzzle_total_clears`/`themes` の読み替えのみ）。フェーズ1（PR #158）の続き。

設計書: `docs/superpowers/specs/2026-07-08-picture-puzzle-gallery-phase2-design.md`
実装計画: `docs/superpowers/plans/2026-07-08-picture-puzzle-gallery-phase2.md`

## 変更内容
- **ドメイン層** `src/domain/collection/`: 作品単位集約 `aggregateByArtwork`・展示室収蔵状況 `buildRoomCollections`・名誉学芸員判定 `evaluateCuratorGoal`・集約全体 `buildCollectionSummary`（純粋関数・カバレッジ93.75%）
- **UI** `CollectionView`（収蔵目録の独立ビュー）/ `ArtworkFrame`（収蔵済み=額装画像+★+ベストスコア/タイム/手数、未収蔵=空フレーム、未開館室=「あと○点で開館」）/ `CuratorGoalBanner`（収蔵コンプ・★★★コンプの2段プログレス）
- **結線**: タイトル画面に「収蔵目録を見る」導線、`PuzzlePage` に第4ビューを接続

## 設計判断
- 収蔵目録＝独立フルスクリーンビュー（既存 ClearHistoryList はセットアップ下部に維持）
- 名誉学芸員＝段階ゴール（第1目標=全15点収蔵／最上位=全15点★★★収蔵）

## 安全境界
picture-puzzle 局所に限定。共有コード（`GlobalStyle.ts`/`tokens/`/`App.tsx`/`GameListPage.tsx`/`features/*`）は不可侵。gallery テーマは `PuzzlePageContainer` 配下で局所適用。

## テスト方法
- [x] `npm run lint:ci`（警告0）・`npm run typecheck`・関連テスト全PASS・`npm run build` 成功
- [ ] タイトル→収蔵目録→戻るの導線
- [ ] 収蔵済み/未収蔵/未開館室の3状態表示・2段プログレス
- [ ] 他12ゲームの見た目に影響しないこと（E2E）

🤖 Generated with [Claude Code](https://claude.com/claude-code)